### PR TITLE
Redo status_pages.csv with top 50 resorts by lift count

### DIFF
--- a/data/status_pages.csv
+++ b/data/status_pages.csv
@@ -1,439 +1,51 @@
-resort_id,resort_name,website_url,status_page_url
-cece2d5f54131184f301a127d3f1e0f747031367,3 Zinnen Dolomites (Dobbiaco - San Candido - Braies - Sesto - Alta Pusteria),https://www.dreizinnen.com/,https://www.dreizinnen.com/en/lift-status
-0ed72c1a44d748a815d1efcd54caacf169610f05,4 Vallées – Verbier/La Tzoumaz/Nendaz/Veysonnaz/Thyon,http://www.4vallees.ch/,https://verbier4vallees.ch/en/useful-information/live-information-winter
-fdbe9df85d02479357a5a789328b43cb5b6aef1c,Adelboden - Lenk,https://www.adelboden-lenk.ch/de/Erlebnis/Skiregion/Adelboden-Lenk,https://www.adelboden-lenk.ch/de/Erlebnis/Skiregion/Adelboden-Lenk/en/lift-status
-083130d6713ac93c9eed6c074b958271f2995e4d,Afton Alps,https://www.aftonalps.com/,https://www.aftonalps.com/en/lift-status
-d264be37a4fd40a4de858be7fee0a5c077cb1068,Aletsch Arena,https://www.aletscharena.ch/,https://www.aletscharena.ch/en/live-info
-ef817c42b82422721b05028c6d58ce10f8a2190c,Alpe Cimbra,http://www.lavaroneski.it/ https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html,http://www.lavaroneski.it/ https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html/en/lift-status
-721dd142d0af653027c7569e1bd0799586bdefa1,Alpe d'Huez Grand Domaine,https://www.alpedhuez.com/,https://www.seealpedhuez.com/lifts/status
-8e8a2328ddca41517300284a9ddd2839299de448,Alpine Valley Resort,https://www.alpinevalleyresort.com/,https://www.alpinevalleyresort.com/en/lift-status
-41ca531357e0d2a532b8ab94e3e9fe74ddbe88c4,Alta Badia,https://www.altabadia.org/,https://www.altabadia.org/en/open-lifts-snow-report-dolomites
-2bb6a71b243972bb44faef0f818e1d6a4979cacc,Ancelle,https://www.ancelleski.fr,https://www.ancelleski.fr/en/lift-status
-23c484a02dad8207dee185a68f77c03e314a395d,Anzère,https://www.anzere.ch,https://www.anzere.ch/en/lift-status
-f188964e40a2c3d00d8638f937cc91842fc0b532,Aprica,https://www.apricaonline.com/index.php,https://www.apricaonline.com/index.php/en/lift-status
-96be13b1dd69f96a46471628f93fb9efdcb8fa4b,Arabba,http://www.arabba.it,http://www.arabba.it/en/lift-status
-b11f8a9b8390463caf77e7adc3db6c226cfe088b,Aramòn Panticosa,https://www.formigal-panticosa.com/,https://www.formigal-panticosa.com/en/lift-status
-ffc04590f75f3e275d90108cc0984829ee429dda,Area Sciistica Abetone,https://multipassabetone.it/,https://multipassabetone.it/en/lift-status
-4ae9b0cba5454d6f0921bf413c33a267f1d63cca,Arosa Lenzerheide,http://arosalenzerheide.ch,https://arosalenzerheide.swiss/en/Ski-Area/Lift-Company/Operating-hours-winter
-b397f0f5eee9f8ab94490ebf1df40b8ebe640c9a,Artesina,https://www.frabosaski.it/,https://www.frabosaski.it/en/lift-status
-d19b617dc3a4c9a07b0f8b3360f7f5a20d384a48,Arêches Beaufort,https://www.areches-beaufort.com,https://www.areches-beaufort.com/en/lift-status
-7d5123086c5d8855b491bf4905f3b6c5e336c846,Aspen Snowmass,https://www.aspensnowmass.com/,https://www.aspensnowmass.com/en/lift-status
-7e2b2e2ae39a8764945229ed9d6314ee6d0aae47,Astun,https://www.astun.com/,https://www.astun.com/en/lift-status
-7cac2b19d023f887e458c354be9caf833b6aed6d,Avoriaz,https://www.avoriaz.com/en/discover/discover/ski-area-and-maps/,https://www.seeavoriaz.com/lifts/status
-4d065e674fc26a1c1142f9449bee9528e741468b,Axamer Lizum - Muttereralm,https://www.axamer-lizum.at/ https://www.muttereralm.at/,https://www.axamer-lizum.at/ https://www.muttereralm.at/en/lift-status
-ae6ee1b64d24f32a1a020aa4448d29b83dd1e43f,Banff Sunshine Village,https://www.skibanff.com,https://www.skibanff.com/en/lift-status
-bdd08a03378f40f323db3efc27d51bafea12c040,Bansko,http://www.banskoski.com,http://www.banskoski.com/en/lift-status
-dfc5c773c999f3cf6df73a599e3d647a0da2c9e7,Bardonecchia,https://www.bardonecchiaski.com,https://www.bardonecchiaski.com/en/lift-status
-78bac1237b378a398d712ba2cc962ddf9d1c6479,Bear Mountain,https://www.bigbearmountainresort.com/,https://www.bigbearmountainresort.com/en/lift-status
-7218febe9d8f23877d54283872e3ff7860b6cbcc,Beaver Creek,https://www.beavercreek.com/,https://www.beavercreek.com/en/lift-status
-8e34404723365a14254b4ba907fba70f0fe368e4,"Beidahu Ski Resort, 北大湖滑雪度假区",http://www.beidahuski.com/,http://www.beidahuski.com/en/lift-status
-e9c0a197353bef2c6ed47d85c268582cae8ad8ea,Belalp,https://www.belalp.ch/,https://www.belalp.ch/en/lift-status
-8477e343b0af5c6d75f1a3d08329339d3417cc6b,Belleayre Mountain Ski Center,https://www.belleayre.com/,https://www.belleayre.com/en/lift-status
-1ffe57b7257e8e6f0d45c04ce32786c6b04438f4,Belvedere - Col Rodella - Passo Pordoi,https://www.dolomitisuperski.com/ https://www.fassa.it/ https://www.valdifassalift.it/,https://dolomitisuperski.com/en/live-info/lifts
-6520fde4643dba824360f5f75edb51e8048eaa88,Berwang - Bichlbach (Zugspitz Arena),https://www.berwang.tirol/,https://www.berwang.tirol/en/lift-status
-00fb2c5ba89284e0b4e3708d04d549905f260cf3,Big Sky Resort,https://bigskyresort.com,https://bigskyresort.com/the-mountain/conditions
-4e9295e870b927f90f542cd716b60fe0c2b04cb8,Big White Ski Resort,https://www.bigwhite.com/,https://www.bigwhite.com/en/lift-status
-b80dd18fc32df44f83dad7576cdbb0316286ef66,Blue Mountain Resort,https://www.skibluemt.com/,https://www.skibluemt.com/en/lift-status
-fecbf1bbf84bdaf7d4efa2b040d9990e0a7c9490,Blue Mountain Ski Resort,https://www.bluemountain.ca,https://www.bluemountain.ca/en/lift-status
-02afb35f5d4315ae5ff1abcef85259463632463c,Bláfjöll,https://skidasvaedi.is/,https://skidasvaedi.is/en/lift-status
-ce6e3ec4d3f2bbc76901192ad2e21caacf0329a5,Bogus Basin,https://bogusbasin.org/,https://bogusbasin.org/en/lift-status
-76d441ab94356152a7e13a3a67001259a0d3d3c5,Bonneval-sur-Arc,https://www.bonneval-sur-arc.com/,https://www.bonneval-sur-arc.com/en/lift-status
-d4daebca40119e46e0a6f0a873bf3fcbb4585fff,Bormio Ski,https://www.bormioski.eu/,https://www.bormioski.eu/en/lift-status
-c32e64673614d65c65f0123491f1976f62e9a55c,Borovets,https://www.borovets-bg.com/,https://www.borovets-bg.com/en/lift-status
-b006b322d1e68bc5d77d0758fb19d16d76e04a37,Brandnertal – Brand/​Bürserberg,https://www.vorarlberg-alpenregion.at/en/brandnertal/holiday-in-winter-in-brandertal.html,https://www.vorarlberg-alpenregion.at/en/brandnertal/holiday-in-winter-in-brandertal.html/en/lift-status
-dc38c005346ecf95ae82d52334753ff6b594784b,Branäs,https://www.branas.se/?nr=1,https://www.branas.se/weather-and-slopes/
-4f29aa0694d65e2fdda688ea60209f7ad9f18729,Brauneck,https://www.brauneck-bergbahn.de/,https://www.brauneck-bergbahn.de/en/lift-status
-e18255e7d2167bde2ed8fb9099d3b4e3dfd3f1a3,Braunwald,https://www.braunwald.ch/,https://www.braunwald.ch/en/lift-status
-c329b1fe669c197d615896dfd4e38d4bb039e30c,Breckenridge,https://www.breckenridge.com/,https://www.breckenridge.com/the-mountain/mountain-conditions/terrain-and-lift-status.aspx
-d65fe4b57a5fba26b0631bd1c39af529e7d3390c,Brentonico,https://www.brentonicoski.com,https://www.brentonicoski.com/en/lift-status
-2826e74d5f33a0bd943b7353dcda7e1419c36ace,"Brigels-Waltensburg-Andiast, Brigels-Waltenburg-Andiast, Breil-Vuorz-Andiast",https://www.brigels-bergbahnen.ch,https://www.brigels-bergbahnen.ch/en/lift-status
-7a889ccffcd71d1bfce9d50b10fa5c34fbd873e7,Bromont Montagne d'Expérience,https://www.bromontmontagne.com/,https://www.bromontmontagne.com/en/lift-status
-8432e3c536835ef8a690f63b62060a7993bfd964,Brévent/Flégère (Chamonix),https://en.chamonix.com/activities/winter/skiing-in-chamonix-mont-blanc-valley/list-of-ski-areas/domaine-skiable-brevent-flegere,https://www.seechamonix.com/lifts/status
-5b1ffa98c849d075c0581f57b5a4bab21b94e468,Buck Hill,https://buckhill.com/,https://buckhill.com/en/lift-status
-a92bdf9c9959ecbfd436556e0c71a630759be88e,Buffaure - Ciampac,https://www.fassa.com/ https://www.fassa.it/,https://www.fassa.com/ https://www.fassa.it/en/lift-status
-ad2faceffa44fe6c1a3149d02c89759a7145af52,Bödele,https://www.boedele.info/,https://www.boedele.info/en/lift-status
-21a648855e9be69e7a077523014c81c2c8859484,Cairngorm (Aviemore),https://www.cairngormmountain.co.uk/,https://www.cairngormmountain.co.uk/en/lift-status
-a69e726ad816e743f1abff11e3813659637a008f,Camelback Resort,https://www.camelbackresort.com/ski-tube/poconos-ski-snowboarding-resort/,https://www.camelbackresort.com/ski-tube/poconos-ski-snowboarding-resort/en/lift-status
-7f3dde2cf70f25d4f6dab9271332f2942bbf5543,Campiglio Dolomiti di Brenta,https://www.funiviecampiglio.it/,https://www.funiviecampiglio.it/en/lift-status
-34c3dc543a71495ffe5c7267a898311a3b49014e,Canaro,https://www.grandvalira.com/,https://www.grandvalira.com/en/lift-status
-304d72fa57c50cd759b4ebeff3e48dbee4789b17,Candanchu,https://www.candanchu.com/,https://www.candanchu.com/en/lift-status
-7ed532f09ad353d121841f56c60990bde6d70741,Carezza,https://carezza.it/,https://carezza.it/en/lift-status
-01b54e4e5ba0cc28ab50515e9fb34754ba3d44d1,Caviahue,https://www.caviahue.com/invierno,https://www.caviahue.com/invierno/en/lift-status
-1b306639a276ae1103bb8f7f682db30d717d65be,Cerler,https://www.cerler.com/,https://www.cerler.com/en/lift-status
-d04af1a4f5b41f91be8f0ef321d9a4e1b98f6ccc,Cerro Bayo,https://www.cerrobayo.com.ar/,https://www.cerrobayo.com.ar/en/lift-status
-c98a7d946853fffdaa82714e15903353c697bb66,Cerro Catedral,https://www.catedralaltapatagonia.com/,https://www.catedralaltapatagonia.com/en/lift-status
-22c54e1e92de27ad2b47090f9b33564d0cbe8edc,Chabanon,https://www.chabanon-selonnet.com/ https://www.seynelesalpes.fr/,https://www.chabanon-selonnet.com/ https://www.seynelesalpes.fr/en/lift-status
-5aab8555b0a533bbab416e958475b98050eda5bb,Champéry – Les Crosets – Champoussin – Morgins,https://www.regiondentsdumidi.ch,https://www.regiondentsdumidi.ch/en/lift-status
-705c23e66271d234c4f99f8ea662dfbed74e18c7,Chamrousse,https://www.chamrousse.com/,https://www.chamrousse.com/en/lift-status
-14114018bd9e7dfbbcfe5fa8d117e222081a3fbc,Chapelco Ski Resort,http://www.laspendientes.com/ https://www.cerrochapelco.com.ar/,http://www.laspendientes.com/ https://www.cerrochapelco.com.ar/en/lift-status
-9e118f4eb36fb34e987c7a3ddd7f2d976b6a7443,China Peak Mountain Resort,https://www.skichinapeak.com/,https://www.skichinapeak.com/en/lift-status
-a28270143c38a4fdd9830c42c08cbd4625efdf2c,Chopok Jasná,https://www.jasna.sk/,https://www.jasna.sk/en/lift-status
-2b04168ef9b209ad4cd6b13f80f42eb7e9a652d5,Chäserrug-Alt St. Johann,https://www.chaeserrugg.ch/,https://www.chaeserrugg.ch/en/lift-status
-f5023cc992ce7e785b7226435512549698ee597b,Cimetta,https://www.cardada.ch/,https://www.cardada.ch/en/lift-status
-7464f379f1806addd8f3976a39005c4628587fac,Copper Mountain,https://www.coppercolorado.com/,https://www.coppercolorado.com/en/lift-status
-9838fb2aa78f10391ff5a3bf3e85105c0f8b73e6,Cortina Tofane,https://www.impianticortina.it/,https://www.impianticortina.it/en/lift-status
-13756027a3c85c2f3e1b8742865baa4f2469a277,Corvatsch-Furtschellas,https://www.corvatsch-diavolezza.ch/ https://www.engadin.ch/de/langlauf,https://www.corvatsch-diavolezza.ch/ https://www.engadin.ch/de/langlauf/en/lift-status
-f9beaf4e37ef88b422b9ee4aa2ae9224f10afd02,Corviglia,https://www.mountains.ch/,https://www.stmoritz.com/en/live/cable-cars-slopes
-349f901b7ae1ab9e324e59654d401933e7ff48ba,Courmayeur,https://www.courmayeur-montblanc.com/,https://www.courmayeur-montblanc.com/en/lift-status
-7764d597cda909bb1bc7fd66a07bbfa6bb8ab695,Crans-Montana,https://www.crans-montana.ch/,https://www.crans-montana.ch/en/lift-status
-8ab7176879f602eb83ffe4a235a84e0f84e839e4,Crested Butte Mountain Resort,https://www.skicb.com/,https://www.skicb.com/en/lift-status
-4f8cc7c822ff08fe15a457cfd10dacbe603a16cf,Damüls,https://www.damuels-mellau.at/,https://www.damuels-mellau.at/en/lift-status
-b88b846a0807188fc4d5794280840a6b92bb1b29,Deer Valley Resort,https://www.deervalley.com/,https://www.deervalley.com/explore-the-mountain/mountain-report
-162525ff9a2a65810a602b74f338303d1bb9ea38,Dodge Ridge Ski Area,https://www.dodgeridge.com/site/,https://www.dodgeridge.com/site/en/lift-status
-c4fe645047e06c17f033f3092f88a83b9f7012e2,Domaine Autrans - Méaudre,https://autrans-meaudre.com/,https://autrans-meaudre.com/en/lift-status
-9fe896a648d66b5c9d92d7d85fb2aff59ca5e5d7,Domaine Skiable Chamrousse,https://www.chamrousse.com/,https://www.chamrousse.com/en/lift-status
-d33fdae30ec8d64328941afdb3e23384f564839a,Domaine skiable Valberg,https://www.valberg.com,https://www.valberg.com/en/lift-status
-f3673494c5e9c944c88bc2482e1b42785db85488,Donovaly,https://www.parksnow.sk/zima/,https://www.parksnow.sk/zima/en/lift-status
-8e5dbdde0808be45e5e47253e905635c9f867c3b,Dévoluy,https://www.ledevoluy.com/,https://www.ledevoluy.com/en/lift-status
-35632469fb7cccf46b30c15b9f1758f7dff918ac,El Colorado,https://centrofarellones.cl/ https://www.elcolorado.cl/,https://centrofarellones.cl/ https://www.elcolorado.cl/en/lift-status
-6f191d7d668cc5585e972733711d6b72ca99b5db,Elsigenalp,https://elsigen-metsch.ch/,https://elsigen-metsch.ch/en/lift-status
-7de1bcf43b60126cd7ec928effe87c5257cfca30,Espace Cambre d'Aze,https://www.cambre-d-aze.com/,https://www.cambre-d-aze.com/en/lift-status
-0345d73f7a4bf0f49815ccb16306a3ec6371544b,Espace Diamant,https://www.espacediamant.com/,https://peakvisor.com/ski/france/france/espace-diamant/live
-baca23b1d6c08055f995fe20b50e3f6910b2ea2b,Espace Liberté,https://en.chatel.com/chatel-and-portes-du-soleil-ski-areas.html,https://www.seechamonix.com/lifts/status
-e7c4c03bd7f9a3d907ff566775cfba1823bcf2ae,Espace Lumière,https://www.praloup.com/,https://www.praloup.com/en/live-info
-125d02338620dc079d5d635595a099370161bf83,Estació d'Esquí Baqueira-Beret,http://www.baqueira.cat,https://www.baqueira.es/estado-pistas
-54f0403b857b338494661a2382df9502e407e954,Estació d'esquí Port del Comte,https://www.portdelcomte.net/,https://www.portdelcomte.net/en/lift-status
-dc3f198b305b2f8ec1db8b15a47548900646d93d,Estación de Esquí y Montaña de Sierra Nevada,https://sierranevada.es,https://sierranevada.es/en/lift-status
-a6792c241300dee70b989ffcf6a12b8225bbd7d9,Estación de esquí de Valdesquí,https://www.valdesqui.es/,https://www.valdesqui.es/en/lift-status
-2ea01c73118f9c02add82629743aade1a80abcce,Falls Creek,https://www.skifalls.com.au/,https://www.skifalls.com.au/en/lift-status
-ac6e8db707345e560695c24c1d0ec5bc069a797f,Feldberg,https://www.liftverbund-feldberg.de/,https://www.liftverbund-feldberg.de/en/lift-status
-14b4ddb66d56cfb67e579c250c5931cb86a1f989,Flachau,https://www.snow-space.com/,https://www.snow-space.com/en/lift-status
-f9d49079770850663f3c200a1956a203489c57ac,Flumserberg,https://www.flumserberg.ch/,https://www.flumserberg.ch/en/lift-status
-2f30e6cc24791f93fe1c0eabc3ddc75f5eae8584,"Folgaria, Area sciistica Folgaria",https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html,https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html/en/lift-status
-aaea5a8af2e4bbcafe21bedf8accd50ee1700dae,Folgarida-Marilleva,https://www.visittrentino.info/en/trentino/ski-areas/alpine-skiing/folgarida-marilleva-skiarea-campiglio-dolomiti-di-brenta-val-di-sole-val-rendena_md_2211,https://www.visittrentino.info/en/trentino/ski-areas/alpine-skiing/folgarida-marilleva-skiarea-campiglio-dolomiti-di-brenta-val-di-sole-val-rendena_md_2211/en/lift-status
-1d00a3f356e6ee869926e23d9a9457cdc5f9eebf,Font d'Urle Chaud Clapier,https://www.lesstationsdeladrome.fr/,https://www.lesstationsdeladrome.fr/en/lift-status
-4a30e21219abb7c297eea39860578ad22572d0eb,"Font-Romeu Pyrénées 2000, Font-Romeu",https://font-romeu.fr/,https://font-romeu.fr/en/lift-status
-0f46917975b8dab5e541edf6469105c3c091ec22,Formigal,https://www.formigal-panticosa.com/,https://www.formigal-panticosa.com/en/lift-status
-9d0b2c5e0fcac9deba9c727a834cac4b43a5d2c9,Forêt Blanche : Vars/Risoul,https://www.vars.com/hiver/,https://www.vars.com/en/live-info
-4d69a850bfa3eeaf928e5d154bb6768fcfbe240e,Gausta skisenter,https://www.gausta.com/en-US/gausta-skisenter/,https://www.gausta.com/en-US/gausta-skisenter/en/lift-status
-db230da8ae03e645cb56642e15e00767f43f5252,"Gitschberg Jochtal, Rio Pusteria",https://www.gitschberg-jochtal.com,https://www.gitschberg-jochtal.com/en/lift-status
-41629c07606b21cd89ede704bb1fe2a939ae9aea,Glacier 3000,https://www.glacier3000.ch/,https://www.glacier3000.ch/en/lift-status
-c16a9ecc277a8ad0b7e90224430ffe1767c3a755,Glenshee Ski Center,https://www.ski-glenshee.co.uk/,https://www.ski-glenshee.co.uk/en/lift-status
-9e8a091097aeb5af7c87b5f53922e3db043a9849,"Gletscher-Skigebiet Zugspitze, Ski resort Zugspitze",https://zugspitze.de/de/winter/skigebiet/zugspitze,https://zugspitze.de/de/winter/skigebiet/zugspitze/en/lift-status
-504eff3fdb5510cb38a4f75324fa846fba9728f3,Gourette,https://www.gourette.com/,https://www.gourette.com/en/lift-status
-4d9c0191491227da58bc418ee8633c62485f29c8,Grand Tourmalet,https://www.n-py.com/fr/grand-tourmalet,https://www.n-py.com/fr/grand-tourmalet/en/lift-status
-de4f884c40976fe9d18c23d0bab174c1d6b79218,GrandValira,https://www.grandvalira.com/,https://www.snow-online.com/snow-report/ski-resort/grandvalira.html
-1d111e0379650f6a9186eaa3d21dadf973340c88,Grindelwald - Wengen (Kleine Scheidegg - Männlichen),https://www.jungfrau.ch/de-ch/jungfrau-ski-region/grindelwald-wengen/,https://www.jungfrau.ch/de-ch/jungfrau-ski-region/grindelwald-wengen/en/lift-status
-1871bd97633b45248e93e03d11f44d94caae83fc,Grindelwald First,https://www.jungfrau.ch/de-ch/grindelwaldfirst/,https://www.jungfrau.ch/de-ch/grindelwaldfirst/en/lift-status
-4684082ba7a884e51f003f63750ecc7c47f68b42,Großarltal-Dorfgastein,https://www.grossarltal.info/,https://www.grossarltal.info/en/lift-status
-6cabfdba2cce9ad12136c554e82e32540f996477,Großeck-Speiereck,https://www.grosseck-speiereck.at/,https://www.grosseck-speiereck.at/en/lift-status
-9ea685d2404d5268c6cb02acbda87feb44cb0db4,Grächen,https://www.graechen.ch/,https://www.graechen.ch/en/lift-status
-c8f66e784133d6becb1aba654e27b446daa7af7b,Guzet-Neige,https://www.guzet.ski/,https://www.guzet.ski/en/lift-status
-7ccf68e28c0dfb0a0d21e0ad24260a5775c63263,Gérardmer,https://www.gerardmer-ski.com/,https://www.gerardmer-ski.com/en/lift-status
-c0763aa655c8d14f82ed2da8660f6e9ad8b7310e,Hafjell,https://www.hafjell.no/,https://www.hafjell.no/en/lift-status
-5ab9e6937c6d307e489c101407d930432f918cab,Hauser Kaibling,https://www.hauser-kaibling.at,https://www.hauser-kaibling.at/en/lift-status
-281e56de7763cdc212ca3a98156c7eed710764c8,Hemsedal skisenter,http://www.skistar.com/hemsedal,http://www.skistar.com/hemsedal/en/lift-status
-25a3eaf5ab883b31c42bf5b3b62fbfd6d49a39f9,Hinterstoder,https://skisport.com/Hinterstoder/,https://skisport.com/Hinterstoder/en/lift-status
-3e6c5af7f4a754f0d701e371d3eaca725a08170c,Hintertuxer Gletscher,https://www.hintertuxergletscher.at,https://www.hintertuxergletscher.at/en/lift-status
-28bc6b32b26b2c57edacb1c31e4ebdc1ec6e518f,Hirmentaz - Les Habères,https://hirmentaz-bellevaux.com/,https://hirmentaz-bellevaux.com/en/lift-status
-8f1c9e1dd61d51f2e3b41daa18860b6cdbffc037,Hochkönig,https://www.hochkoenig.at,https://www.hochkoenig.at/en/lift-status
-6d0ca5263d711788cf560a6eb02a0ecc46ef2b1b,Hochoetz,https://www.oetz.com/winter/ski-area-hochoetz/ski-area-information.html,https://www.oetz.com/winter/ski-area-hochoetz/ski-area-information.html/en/lift-status
-99cef648d8c6f7231b60448092fb29de26069d0f,Hochzillertal-Hochfügen,https://www.hochzillertal.com/,https://www.hochzillertal.com/en/live
-0aeb53731081edb26944a565b282d8871ade8d73,Holiday Valley,https://www.holidayvalley.com/,https://www.holidayvalley.com/en/lift-status
-d6559b7a4d17d00b9d62c84d797cc3bf3fc6d292,Hundfjället,https://www.skistar.com/en/ski-destinations/salen,https://www.skistar.com/en/ski-destinations/salen/en/lift-status
-783cee8f57ebb3a5a13548d10557b890e0469d4e,Idre Fjäll,https://www.idrefjall.se/en/skiing/,https://www.idrefjall.se/en/skiing/en/lift-status
-6a9f3afdd5d590a14770fdb7a8e90c6285b18035,Isola 2000,https://www.isola2000.com/,https://www.isola2000.com/en/lift-status
-afaacd3410e33de806ed0177a6e3e6e743877f03,Jackson Hole,https://www.jacksonhole.com,https://www.jacksonhole.com/en/lift-status
-516bab490035b2ec5b8cf843a4c2929e4028642d,"Jahorina olimpijski centar, Olympic Center Jahorina, Јахорина олимпијски центар",https://www.oc-jahorina.com/,https://www.oc-jahorina.com/en/lift-status
-c880b001fe8a065af66fca1a93ea7ce3d62e546a,Jakobshorn,https://www.davosklosters.ch/,https://www.davosklosters.ch/en/lift-status
-29f3c8064a8a521656127c68e52b3b7ec31e5f9a,Janské Lázně - Černá hora,https://skiresort.cz/,https://skiresort.cz/en/lift-status
-143a22b6dca9119510a125afff37672952de837e,Jasna Low Tatras,https://www.jasna.sk/,https://www.jasna.sk/en/lift-status
-6be20346a227d4c6fb8896fb6076567145f70fc6,Jaworzyna Krynicka,https://www.jaworzynakrynicka.pl/,https://www.jaworzynakrynicka.pl/en/lift-status
-0d8095d2249278e20f76c6919b2003b51c7d71b2,JärvsöBacken,https://www.jarvsobacken.se/english-information/,https://www.jarvsobacken.se/english-information/en/lift-status
-a44ab6f1b177b983f22ab22cc15fdb83f3a1b7ed,Kals-Matrei,https://www.gg-resort.at/,https://www.gg-resort.at/en/lift-status
-bc6999f9bfbf693b2408c3192e343aa26f11c81e,Kappl,https://www.kappl.com/,https://www.kappl.com/en/lift-status
-bc0361849d0e6e33ef5d9cd035522200a3125df1,Kaprun - Kitzsteinhorn/Maiskogel,https://www.kitzsteinhorn.at/,https://www.kitzsteinhorn.at/en/lift-status
-64a4879a2a2c802d498419c7f97401156810641a,Kasberg Grünau - Almtal,https://www.kasberg.at/,https://www.kasberg.at/en/lift-status
-ed8a4aac9d167e593f2e02bb3989fb48579264d3,Katschberg-Aineck,https://www.katschi.at/,https://www.katschi.at/en/lift-status
-05da072f8aa4be470ecc66e34e63b4a8153e0bdd,Kayseri-Erciyes,https://www.kayserierciyes.com.tr/,https://www.kayserierciyes.com.tr/en/lift-status
-e9d26c72f918e002659f0e9ba565f8d51b7793a8,Keystone,http://keystoneresort.com/,http://keystoneresort.com/en/lift-status
-7df36f601b9f9e0824f6b57943ff98586584da80,Killington Resort,https://www.killington.com/,https://www.killington.com/en/lift-status
-207edac28d0ece59b86d3282c756fa4d2774ca0a,Kirkwood Mountain Resort,https://www.kirkwood.com/,https://www.kirkwood.com/en/lift-status
-0e7f017d9c830408aebfc40144372d483b040462,KitzSki,https://www.kitzbuehel.com/ https://www.kitzski.at/,https://www.kitzski.at/en/current-info/kitz-lift-status.html
-8ed98940b7c222930ed16efefbb13b42e5840a02,Klausberg Skiarena,https://www.kronplatz.com/de/klausberg,https://www.kronplatz.com/de/klausberg/en/lift-status
-4ab0026be1ab8a2d0d68eec95baa7bce6d1fda67,Klewenalp - Stockhütte,https://www.klewenalp.ch/,https://www.klewenalp.ch/en/lift-status
-41ab128ddaa817aee0126dd981df00095dc57e60,Kläppen,https://www.klappen.se/,https://www.klappen.se/en/lift-status
-2e532d4ade009c4d23c68f5b4e1abce597d5e10d,Kompleks Pilsko-Jontek,https://pilsko.org/,https://pilsko.org/en/lift-status
-1ad6e25ebaadb56de905f0eb8c1d43bca1548e35,Kopaonik,https://www.skijalistasrbije.rs/,https://www.skijalistasrbije.rs/en/lift-status
-81a8f021565bdd6457901eb52d083dc38f58d2f3,Kope,https://www.pohorje-slovenija.si/zimske-aktivnosti/smucanje/smucisca/ribnica-na-pohorju,https://www.pohorje-slovenija.si/zimske-aktivnosti/smucanje/smucisca/ribnica-na-pohorju/en/lift-status
-51474b305d4503f5ab3131b6c859bd4cf4f2088b,Kranjska Gora,https://ski-kranjska-gora.com,https://ski-kranjska-gora.com/en/lift-status
-a137f67c4f1458c28d7610d43cb0978105955ca8,Kreischberg,https://www.kreischberg.at/,https://www.kreischberg.at/en/lift-status
-aa394929d0dfb9b8da2302ba9febe95046a1657f,"Kronplatz - Plan de Corones, Kronplatz, Plan de Corones",https://www.kronplatz.com/,https://www.kronplatz.com/en/lift-status
-1c25cf660c84f21364c1905e7eb788e3789ccfbd,Krvavec,https://www.rtc-krvavec.si/,https://www.rtc-krvavec.si/en/lift-status
-1bc8063b148904e54cdd1357ba34f2211ceef2b8,Kungsberget,https://www.kungsberget.se/en/?nr=1,https://www.kungsberget.se/en/?nr=1/en/lift-status
-204bd8a606de9419155c825f8ba5ecd46345e23a,Kühtai,https://www.kuehtai.info/en/winter/ski-area.html,https://www.kuehtai.info/en/winter/ski-area.html/en/lift-status
-c0e65ff5494198c3e504ff30257b990d92b29cfc,L'Alpe du Grand Serre,https://www.alpedugrandserre.info/,https://www.alpedugrandserre.info/en/lift-status
-2f1bc005a66588a88f53bb3917b1904401f10869,La Bresse - Hohneck,https://labresse.labellemontagne.com,https://labresse.labellemontagne.com/en/lift-status
-9cb83fdd2a49011eec76e3d1bbc2af8f582888a9,La Clusaz,https://www.laclusaz.com/,https://www.laclusaz.com/en/ski/alpine-skiing/
-6eebeff16c8b480fc1335c8bed596286706cb776,La Molina,https://www.masella.com/en/paginas/alp-2500-trail,https://www.masella.com/en/paginas/alp-2500-trail/en/lift-status
-1a0088907c983cf22ebde01fbc7d28fed495f34d,La Norma,https://www.la-norma.ski/,https://www.la-norma.ski/en/lift-status
-82dc09affb379bc9f88a1fc518ac2ded2508f9da,La Parva,https://www.laparva.cl/,https://www.laparva.cl/en/lift-status
-0bc0af67288ed7c592e1f3364a400234763eb023,La Pinilla,https://www.lapinilla.es/,https://www.lapinilla.es/en/lift-status
-f47f7e05cc676b25b6a00f77f0b86a897f03018c,La Plagne,https://paradiski.com/,https://www.seelaplagne.com/lifts/status
-f8176e48416adcfc9118014d5c390cd2099a6a18,La Rosière,https://www.espacesanbernardo.ski/,https://www.espacesanbernardo.ski/en/lift-status
-064c258440982ec02bbffeb24ad3acffc7fa5ef0,La Thuile ski,https://www.espacesanbernardo.ski/,https://www.espacesanbernardo.ski/en/lift-status
-d5ff708ce6a4ab382afaeb81310e7317494b6fbb,Laax,https://www.laax.com/,https://live.laax.com/en/lifts
-dcd36cf6725c031a123b372273fbe01e28f30fd9,Lac Blanc,https://www.lac-blanc.com,https://www.lac-blanc.com/en/lift-status
-53c053f1d0dfaaad0e7fe16f2582bfb37f29e02c,Lake Louise Ski Area,https://www.skilouise.com/,https://www.skilouise.com/en/lift-status
-1b2d642d45256699542b9355f9c1c6830c6b37da,Latemar Dolomites,https://www.latemar.it/,https://www.latemar.it/en/lift-status
-252f58f0495d9e6050279031fea1365c55d7163d,Laterns-Gapfohl,https://www.laterns.net/,https://www.laterns.net/en/lift-status
-f5fcc0e543cfb0e4d50280c286081c27d975697f,Le Grand Domaine,https://www.legranddomaine.fr/,https://www.snowplaza.co.uk/france/le-grand-domaine/snow-report/
-efaa82d7ae8e42868f19ed2abb8001f518a404d0,Le Grand Massif,https://www.grand-massif.com/,https://www.grand-massif.com/en/information-on-trail-openings/
-8af93a64c41b59fca4705d30c106ef29fb24e042,Le Grand-Bornand,https://www.legrandbornand.com/,https://www.legrandbornand.com/en/lift-status
-17bf348db2822fa217ab7118b044c1c33a45928e,Le Lioran,https://skipass.lelioran.com,https://skipass.lelioran.com/en/lift-status
-0e32d9bd72195acaa33ba6c2d18ba4ad1562a055,Le Sauze 1400 / Le Super-Sauze 1700,https://www.sauze.com,https://www.sauze.com/en/lift-status
-c5107fc2eb3f59b23211a3251a229b06d36f765c,Lech/Zürs,https://www.skiarlberg.at/,https://www.skiarlberg.at/en/lech-zuers/live-info/cable-cars-lifts
-e802f4736b99042270c8e9d8b6417c31f15b4931,Les 7 Laux,http://www.les7laux.com/,http://www.les7laux.com/en/lift-status
-dec537b602584db89d89ab114a619f1ae356398e,Les Arcs,https://paradiski.com/,https://www.seelesarcs.com/lifts/status
-10f2ef5a778b65fdea26f0662b08e83c8b979356,Les Contamines,https://www.lescontamines.net/,https://www.lescontamines.net/en/lift-status
-5bd589496339e89cf9be3d93c86e7e6c41f72208,Les Deux Alpes,https://www.les2alpes.com,https://www.see2alpes.com/lifts/status
-cafb6b6d5f25860a682a8b6d67efe689218618a5,Les Gets-Morzine,https://pass.lesgets.com/,https://www.lesgets.com/en/discover-the-resort/ski-winter-sports/live-info-slopes/
-ea9dfe26da36c33e8cf007b22b628c153ac69ab4,Les Houches - Saint-Gervais,https://www.leshouches.com/,https://www.leshouches.com/en/lift-status
-a3f181286a5893208aa7d7b7d1704bb923673003,Les Karellis,https://www.karellis.com/,https://www.karellis.com/en/lift-status
-d439a81c89522f99d9f58daedda995c9b189d301,Les Monts d'Olmes,https://www.montsdolmes.ski/,https://www.montsdolmes.ski/en/lift-status
-0a4d24c79daa6d712c1d7908b54a875ba3fd12ce,Les Orres,https://www.lesorres.com,https://www.lesorres.com/en/lift-status
-aa87548d9445d366123e7ef7aee40af9d4a78dff,Les Portes du Mont-Blanc,https://www.lesportesdumontblanc.fr/,https://www.lesportesdumontblanc.fr/en/lift-status
-c4b221a54713b4e084b5bae02668c68dfaf6c1e3,Les Rousses,https://www.lesrousses.com/,https://www.lesrousses.com/en/lift-status
-775634f8f5f5b0724ecd27d82909b2008d58f7d5,Les Sybelles,https://www.sybelles.ski/,https://www.sybelles.ski/en/skiing-in-les-sybelles/slopes-and-lifts-open/
-68b126bc3175516c9263aed7635d14e37ff360dc,Les Trois Vallées,https://www.les3vallees.com/,https://www.les3vallees.com/fr/live/ouverture-des-pistes-et-remontees
-e7711ce026b712e5b6f11097184014845bcc2ec3,"Levin hiihtokeskus, Levi Ski Resort",https://www.levi.fi/,https://www.levi.fi/en/lift-status
-db5c95e86ebbda55f5c2bcd992d5855a0f9c86cb,Leysin,https://leysin.ch/,https://leysin.ch/en/lift-status
-e900dece35df9bc16a5d4e8e71d3027ced7ea3fb,Lindvallen,https://www.skistar.com/en/ski-destinations/salen,https://www.skistar.com/en/ski-destinations/salen/winter-in-salen/weather-and-slopes/
-f98ca6c4487bfae371b3149fb493e4aa10f8e7a7,Livigno,https://www.skipasslivigno.com/,https://www.livigno.eu/en/lifts
-a858009848aad8498631e2f2e825f64f557363c4,Loon Mountain Resort,https://www.loonmtn.com/,https://www.loonmtn.com/en/lift-status
-7524213ba3c51817951bc7bd31dfe502cb522152,Lyon - La Sarra,https://stationsfantomes.wordpress.com/2017/06/02/lyon-la-sarra/,https://stationsfantomes.wordpress.com/2017/06/02/lyon-la-sarra/en/lift-status
-bf0c4d265b68ee4f2cd4f75ad0728f6edb6425bf,Mammoth Mountain,https://www.mammothmountain.com/,https://mammothmountain.com/on-the-mountain/mountain-information/lift-status
-cb461faaed3fbddd289cb3d86c6d8a7bbb4649bd,Mariborsko Pohorje,http://www.mariborskopohorje.si/,http://www.mariborskopohorje.si/en/lift-status
-45a940355cca76e598e2a54c273e06cd0916e04f,Massif des Brasses,http://www.lesbrasses.com,http://www.lesbrasses.com/en/lift-status
-f967615083aaed557fa47068b9d894e66d763f0a,Mayrhofen Hippach,https://www.mayrhofner-bergbahnen.com/,https://www.mayrhofen.at/en/stories/open-cable-cars-mayrhofner-bergbahnen-winter
-97a14cedc5b0e781e9bd9857df1426b9376c7462,Megève,https://www.megeve.com/,https://forfait.megeve.com/hiver/en/ski-area-opening-information/
-73a929fdb6f99344480b7fc4e7f2e457e444b217,Meiringen - Hasliberg,https://www.meiringen-hasliberg.ch/,https://www.meiringen-hasliberg.ch/en/lift-status
-7a164e4c774d9a66c0d90f9c78b30c340c36ed0c,Meran 2000,https://www.meran2000.com/,https://www.meran2000.com/en/lift-status
-c93e7cec002e1289e63f9e9c51defc39d7d8058a,"Mont Tremblant Resort, Station Mont Tremblant",https://www.tremblant.ca,https://www.tremblant.ca/en/lift-status
-df3db8137cdf524d85aab8156c828d106fc048e9,Montagnes de Lans,https://www.lansenvercors.com,https://www.lansenvercors.com/en/lift-status
-5ffd86e2374dc98261a846de36bfc510ab758dfc,Monterosa Ski,https://monterosaski.eu/en,https://www.monterosa-ski.com/en/live-info
-4de82b980d8c12b83cda0083ec49b22e97cf6224,Montgenèvre,https://www.montgenevre.com,https://www.montgenevre.com/en/lift-status
-bf24d3a7ef53b94159795d6d663dad89ac81cbf2,Mount Buller,https://www.mtbuller.com.au/,https://www.mtbuller.com.au/en/lift-status
-fd839899582c8f2457f330931b333696e0d6a800,Mount Hotham,https://www.mthotham.com.au/,https://www.mthotham.com.au/en/lift-status
-d3f269fa632577f05e24199329b15e97f70c23b2,Mount Snow,https://www.mountsnow.com/,https://www.mountsnow.com/en/lift-status
-d7cc8768ea056dd9a46d954ce7d03d433288ba8a,Mountain High,https://www.mthigh.com/,https://www.mthigh.com/en/lift-status
-1d39d98c17338120b4894722b13a744046a5b42b,Mt Brighton,https://www.mtbrighton.com/,https://www.mtbrighton.com/en/lift-status
-d2de9aebeedb736c0bbef6911782b5fdfe2246b1,Mt. Bachelor,https://www.mtbachelor.com/,https://www.mtbachelor.com/en/lift-status
-6991829b1f27814a62b03cc9a37771b38f7ff862,Mt. Holly Ski & Snowboard Resort,https://www.skimtholly.com/,https://www.skimtholly.com/en/lift-status
-acef87c69b41f035190551a44edf709749968d72,Mt. Hood Meadows Ski Resort,https://www.skihood.com/,https://www.skihood.com/en/lift-status
-50b228e8ca327700ee050f497862495943f541dc,Muju,https://www.mdysresort.com/,https://www.mdysresort.com/en/lift-status
-d9ac8983541d7960d801802ce64751267338b5e4,Mürren/Schilthorn,https://schilthorn.ch/,https://schilthorn.ch/en/lift-status
-15fc32fb65bb27bee41d456d42f74d5f07faf6e6,"Nanshan Ski Resort, 南山滑雪场",https://www.nanshanski.com/,https://www.nanshanski.com/en/lift-status
-a128b442f4fad1ab598431ab394b274b1e57741b,Nashoba Valley Ski Area,https://www.skinashoba.com/,https://www.skinashoba.com/en/lift-status
-0a53d621d2c7d7efc5f5c3e600a8b56a0bbbf4ff,"Nassfeld, Mokrine",https://www.nassfeld.at/,https://www.nassfeld.at/en/lift-status
-8ebb23da67e4e5ad4059d78ad442e7694eccfb2f,Nauders Bergkastel,https://www.nauders.com/,https://www.nauders.com/en/lift-status
-4f28d329e3135d4beda7482aac1820ad0f7cad63,Nevis Range,https://www.nevisrange.co.uk/,https://www.nevisrange.co.uk/en/lift-status
-05f2a87af29f8bfb62a2f603adca4b58fd9bc94b,Nordkette,https://www.nordkette.com/,https://www.nordkette.com/en/lift-status
-003fc7a8c53bae5af9b05470f7e6a95002eee00f,North Creek Ski Bowl,https://goremountain.com/the-mountain/about-the-ski-bowl/,https://goremountain.com/the-mountain/about-the-ski-bowl/en/lift-status
-3c9f145171f1936107e2fa026ca8cb624a4353f2,Northstar at Tahoe Resort,https://www.northstarcalifornia.com/,https://www.northstarcalifornia.com/en/lift-status
-601bfb3f203a581f551010122bccc17ed19aafe3,Obergurgl-Hochgurgl,https://www.obergurgl.com/,https://www.obergurgl.com/en/lift-status
-df4c0541e78ace196a344e169cb23e9464c26224,Obersaxen,https://www.obersaxen-mundaun.ch,https://www.obersaxen-mundaun.ch/en/lift-status
-b28af962323890eb2dc4f2705ed7b6893d894add,Obertauern,https://www.obertauern.com/,https://www.obertauern.com/en/lift-status
-0f0d574cfdbd7b9a55296a94c4683b3e732a543b,Okemo Mountain,https://www.okemo.com,https://www.okemo.com/en/lift-status
-edd2880bbf98e186ecb381b898fd7b8e0c6ba1e7,Oppdal Skisenter,https://www.oppdalskisenter.no/,https://www.oppdalskisenter.no/en/lift-status
-824c7b22068010ed9590671f95a41f7eaf5f3819,Orcières Merlette,https://orcieres.com/,https://orcieres.com/en/lift-status
-d08451a2fc5a6431ce49850bd6daf729558ec15e,Orsa Grönklitt,https://www.orsagronklitt.se,https://www.orsagronklitt.se/en/lift-status
-99fc72000e2914274efb60d579cb7cacb1043bc3,Ovindoli,https://www.ovindolimagnola.it/,https://www.ovindolimagnola.it/en/lift-status
-305ec2278ecc0503c3d92c9d101c61695c66d1b4,"Ośrodek Narciarski Kotelnica Białczańska, Kotelnica Białczańska Ski Resort",https://bialkatatrzanska.pl,https://bialkatatrzanska.pl/en/lift-status
-92a349c51194cc530b9b7ef1cde60959e74c14ed,"Paganella, Area sciistica Andalo Fai della Paganella",https://www.paganella.net/,https://www.paganella.net/en/lift-status
-5ecb06388006e4740e7ce8234e26d036ce85edb7,Pal-Arinsal,https://www.vallnord.com/,https://www.vallnord.com/en/lift-status
-cee3c9097159f155bdbd509eec236006f19c468f,Palisades Tahoe Alpine Meadows,https://www.palisadestahoe.com/,https://www.palisadestahoe.com/en/lift-status
-9a33e5f4f12b2568f28a5a2744f0fb9e5d1b46ed,Palisades Tahoe Olympic Valley,https://whitewolftahoe.com/ https://www.palisadestahoe.com,https://whitewolftahoe.com/ https://www.palisadestahoe.com/en/lift-status
-78366a4ff6a737d977720302395672e848bcb031,Pamporovo,https://pamporovo.me/,https://pamporovo.me/en/lift-status
-be21197d101373cf2bc532a9fcce6d6e1d1bd76e,Park City Mountain Resort,https://parkcitymountain.com,https://www.parkcitymountain.com/the-mountain/mountain-conditions/terrain-and-lift-status.aspx
-521fc91f7033d24900230c6c4e0366c228a7f805,Perfect North Slopes,https://www.perfectnorth.com/,https://www.perfectnorth.com/en/lift-status
-3885048f9cb77cae837d23131d2f8fb78d06f807,Perisher,https://www.charlottepass.com.au/ https://www.perisher.com.au/,https://www.perisher.com.au/conditions/lifts-and-terrain
-851128bb56a54648e73d41ecdaca409350648f33,Peyragudes,https://www.n-py.com/fr/peyragudes,https://www.n-py.com/fr/peyragudes/en/lift-status
-d7474fa2698e1aa5d7c6cbb23c616767c38b6cd9,Piani di Bobbio - Valtorta Skiarea,https://www.pianidibobbio.com/,https://www.pianidibobbio.com/en/lift-status
-80f1b9fb69d6d58d8c0211a019de956673e86a18,Pila ski,https://www.pila.it/,https://www.pila.it/en/lift-status
-30ef4b0ce4359afbe74c85228de87f0e5fc6a057,Pine Knob Ski & Snowboard Resort,https://www.skipineknob.com/,https://www.skipineknob.com/en/lift-status
-9da14109426dd7f9d0b65e788093967a96cfb6f1,Pinzolo,https://www.pinzolo.it/,https://www.pinzolo.it/en/lift-status
-3c30eddac708122c98a1ad904d7a67fc8499b342,Pizol,https://pizol.com/,https://pizol.com/en/lift-status
-5d03639020e719e7c51127b60424030c19d1ab29,Planai,https://www.planai.at/,https://www.planai.at/en/lift-status
-8fa0c17d9d0002fc83e30363e42c43b874d21a8f,Ponte di Legno - Passo Tonale,https://www.pontedilegnotonale.com/,https://www.pontedilegnotonale.com/en/lift-status
-8e16b156faecf9b834835c8bbaa9a25eb51cfbd1,Powder Mountain Ski Resort,https://powdermountain.com/,https://powdermountain.com/en/lift-status
-4236aff4e09a8a34af56ec12b7c0085e579204db,Pra-Loup 1600,https://www.praloup.com/,https://www.praloup.com/en/lift-status
-fb221f44d7aaafd3e9a884c397ebe1f1059edd62,Pralognan-la-Vanoise,https://www.pralognan.com,https://www.pralognan.com/en/lift-status
-17a2aed27cfa6b593c5df9770900555623db6adf,Praz de Lys Sommand,https://www.prazdelys-sommand.com/,https://www.prazdelys-sommand.com/en/lift-status
-e50191099424643e8e4ca4a469361c801b6c5094,Purgatory Resort,https://www.durangomountainresort.com/,https://www.durangomountainresort.com/en/lift-status
-abd8fc58a269e575731226a78d77a13b2e38a673,Puy-Saint-Vincent,https://www.puysaintvincent.com/,https://www.puysaintvincent.com/en/lift-status
-4243519f890596507243ce624d660bfddd378b16,Queyras - Molines/Saint-Véran,https://www.queyras.ski/,https://www.queyras.ski/en/lift-status
-b43df338b91f2ae86e37416ddc54e1292b69f2df,Ramsau am Dachstein,https://www.ramsau.com,https://www.ramsau.com/en/lift-status
-43be2b7a7a7fc12ba084871981485ccd34a5424f,Ratschings-Jaufen,https://www.ratschings-jaufen.it/,https://www.ratschings-jaufen.it/en/lift-status
-58bb6f4890e42306a044d21ad47ac0c694a2b48f,Rauland skisenter,https://visitrauland.com/rauland-skisenter/,https://visitrauland.com/rauland-skisenter/en/lift-status
-bd6babe4cc380627a74b32109a008aa05e8071b2,Reiteralm,https://www.reiteralm.at/de/winter/reiteralm,https://www.reiteralm.at/de/winter/reiteralm/en/lift-status
-2d257adb08994f5ccc194bcb1fc74c1fc832ee4a,Riedbergerhorn,https://grasgehren.de/,https://grasgehren.de/en/lift-status
-c8df10ba59b2c80f2302566b5b0b9958292c8075,Riserva Bianca,https://www.riservabianca.it/,https://www.riservabianca.it/en/lift-status
-8f52a4cffc57a788e69b889d7b5c12197a606047,Roc d'Enfer,https://www.rocdenfer.com/,https://www.rocdenfer.com/en/lift-status
-acfe7d6f0bca1d418d56a97a3853e6d9ebf7d3c2,Roccaraso - Rivisondoli,https://roccaraso.net/,https://roccaraso.net/en/lift-status
-eb6bf1b553103624747096d88a6af02afd8a2d81,Rogla,https://www.rogla.eu/,https://www.rogla.eu/en/lift-status
-b81dcb25c037df81ace4af7b21ae77104df03ce4,Romme Alpin,https://www.rommealpin.se,https://www.rommealpin.se/en/lift-status
-2d453ae31d2fcdbbff50bf6b145e9aae9e7824fa,"Rukatunturi, Ruka",https://www.ruka.fi,https://www.ruka.fi/en/lift-status
-fc37a3084eeca48d1ce164dc7a5862723aaf2013,Saas Fee,https://www.saas-fee.ch/,https://www.saas-fee.ch/en/lift-status
-170c8c0d276b50ceeb50658829c7dcd487fcd18c,Saint-Luc - Chandolin,https://www.anniviers.ch/,https://www.anniviers.ch/en/lift-status
-28cd6829ec529bdf62b5fba43fe2cbcda6e7d813,San Martino di Castrozza,https://www.sanmartino.com,https://www.sanmartino.com/en/lift-status
-68097edf550d07d2fc63a0dd9d521a97210d59e9,San Martino di Castrozza - Passo Rolle,https://www.sanmartino.com/,https://www.sanmartino.com/en/lift-status
-977c24ffa15ab2e86d9e14846911aca6149b7729,Sansicario,https://www.vialattea.it,https://www.vialattea.it/en/lift-status
-3cd692f072ced1edfcbc87b8d31d52c2ae3f5e35,Sappada,https://www.nevelandia.it/,https://www.nevelandia.it/en/lift-status
-41b930598f272928bfdbd4b166056816da79733e,Sauze D'Oulx,https://www.vialattea.it,https://www.vialattea.it/en/lift-status
-222578468bd24884d04bf5d8d29f7e2fe76a5198,Schlick 2000,http://www.schlick2000.at/,http://www.schlick2000.at/en/lift-status
-66df7f28d6136f0c1c76b4b3f09f8f0c46443547,Schmittenhöhe Zell am See,https://www.schmitten.at,https://www.schmitten.at/en/lift-status
-8ba91e97233bc526702e679b13a0ce110bad3f6a,"Schöneben - Belpiano, Schöneben",https://www.schoeneben.it/,https://www.schoeneben.it/en/lift-status
-a1a0c4585d1fe87ca6ff3104e6e5ff5dc93af329,Schönried - Saanenmöser - Zweisimmen - St. Stephan,https://www.gstaad.ch/,https://www.gstaad.ch/en/lift-status
-c9f7bd1feef91e49dbdae4831ed347243b5dfa33,Scuol Motta Naluns,https://www.scuol.ch/,https://www.scuol.ch/en/lift-status
-f1588948074c393bfde0e8fb261942602470ee69,Seefeld - Gschwandtkopf,https://www.skigebiet-seefeld.at/,https://www.skigebiet-seefeld.at/en/lift-status
-b4602a014c2e38badc16189c4cebcf8fb20054ef,Seefeld - Rosshütte,https://www.seefeld.com/winter/ski,https://www.seefeld.com/winter/ski/en/lift-status
-6c2c802a4ed9e8dbf548c062c08b8e7dcd81f86a,"Seiser Alm - Mont de Sëuc - Alpe di Siusi, Seiser Alm, Alpe di Siusi, Mont de Sëuc",https://www.seiseralm.it/,https://www.seiseralm.it/en/lift-status
-e587928ea763f20b3232a5069c5d2438d09b6908,Serfaus Fiss Ladis,https://www.serfaus-fiss-ladis.at/de/winter,https://www.serfaus-fiss-ladis.at/en/winter-holiday/ski-area-status
-39136d396c46f03d9e84227cd2bccbdf60c55efd,Serre Chevalier,https://www.serre-chevalier.com,https://www.serre-chevalier.com/en/schedules-mechanical-lifts
-94cb050e1e20e04e822c14216840885aea2eafcc,Serre-Chevalier,https://www.serre-chevalier.com/,https://www.serre-chevalier.com/en/schedules-mechanical-lifts
-24ea25d80078f2f69f1ed3d653041100cae37c55,Sestriere,https://www.vialattea.it,https://www.vialattea.it/en/lift-status
-650f96a36dc89d4a1a3d3dbf420184eedbe0747e,Seven Springs Mountain Resort,https://www.7springs.com/,https://www.7springs.com/en/lift-status
-4279b250cfcc57bd1abf2ca0d8f528eca7739c68,Sierra-at-Tahoe Ski Resort,https://www.sierraattahoe.com/,https://www.sierraattahoe.com/en/lift-status
-2eaebe856a984bba26c83260b660d7f84884f5e3,Silver Star Mountain Resort,https://www.skisilverstar.com/ https://www.sovereignlake.com/,https://www.skisilverstar.com/ https://www.sovereignlake.com/en/lift-status
-7c2f2690d339d9df6f820e7c6e596a9b0ba3dce5,Silvretta Arena Ischgl/Samnaun,https://www.ischgl.com/ https://www.silvretta-bielerhoehe.at/,https://www.ischgl.com/en/winter/silvretta-arena/open-faciliites
-f654467c75bb645ac3a8e664b656d00b2e90ef2e,Silvretta Montafon,https://www.silvretta-montafon.at,https://www.silvretta-montafon.at/en/live
-42fc8a8b67ad76cdc75c37d3718acd7330d8818c,Sirdal Skisenter,https://sirdal-skisenter.no/,https://sirdal-skisenter.no/en/lift-status
-31746f2e6f17f4fe5156eee7e098f0ac90915d02,Skeikampen Alpinsenter,https://skeikampen.no/,https://skeikampen.no/en/lift-status
-83cf447c80c167c7472d9883e6bd88c30fd5b1d4,Ski Area San Pellegrino - Falcade,https://www.skiareasanpellegrino.it/,https://www.skiareasanpellegrino.it/en/lift-status
-6db2d5cd2692fd5b0531d19a0296e87bbadf57a6,Ski Brule,https://skibrule.com/,https://skibrule.com/en/lift-status
-0ce6923126ae6d29e3a17b93a5962e64adc73382,Ski Butternut,https://skibutternut.com/,https://skibutternut.com/en/lift-status
-3785884556b34a04d38077287cb93f5bc0fb3477,Ski Center Lavarone,https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html,https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html/en/lift-status
-00e3880c19b3ca1bb412d2274d3c15bf4a2598f9,Ski Civetta,https://www.skicivetta.com/,https://www.skicivetta.com/en/lift-status
-44f53c733df11c956209186be9b720ac2b391522,Ski Geilo,https://www.skigeilo.no/,https://www.skigeilo.no/en/lift-status
-4ae8be1df66f9e30fd3ba0b03cd191cda44665bc,Ski Juwel Alpbachtal-Wildschönau,https://skijuwel.com,https://skijuwel.com/en/lift-status
-37ee9c6ba5b44864ba844f804938a8b815f8b717,SkiWelt Wilder Kaiser - Brixental,https://www.skiwelt.at/,https://www.skiwelt.at/en/lift-status-winter.html
-3fe9a6b2c3b2fddc054259af7b561d7d91f7b9f0,Skiarea Valchiavenna Madesimo/Campodolcino,https://www.skiareavalchiavenna.it/,https://www.skiareavalchiavenna.it/en/lift-status
-eeb2093cd64adef211261520c569179894373a74,Skiarena,https://www.andermatt-sedrun-disentis.ch,https://www.andermatt-sedrun-disentis.ch/en/lift-status
-71adb82590d35e6b256c14d2cb266024f2723c27,Skiarena Steibis,http://www.imbergbahn.de/,http://www.imbergbahn.de/en/lift-status
-3d64e85db09d580e3ac612574f3c4bf4298e54ba,Skiareál Klínovec,http://skiarealbozidar.cz/en/homepage-en/ https://klinovec.cz/,http://skiarealbozidar.cz/en/homepage-en/ https://klinovec.cz/en/lift-status
-5b78e5652d097c7679cef7128ee1b57ff09fb86e,Skicircus Saalbach-Hinterglemm Leogang Fieberbrunn,https://www.saalbach.com/,https://www.saalbach.com/en/live-info/lifts-and-pistes
-2774ee9df926487819e252679b539a79fd2024a0,Skigebiet Almenwelt Lofer,https://www.skialm-lofer.com/,https://www.skialm-lofer.com/en/lift-status
-eb1044922f55b6eec4a91393a33d13f36138696d,Skigebiet Bad Kleinkirchheim,https://www.badkleinkirchheim.com/bergbahnen-skigebiet/skigebiet/,https://www.badkleinkirchheim.com/bergbahnen-skigebiet/skigebiet/en/lift-status
-f83cb97ace9308e949a7638a1922ba589f5cc40d,Skigebiet Damüls-Mellau,https://www.damuels-mellau.at/,https://www.damuels-mellau.at/en/lift-status
-da710e6cc602f54dfb5e724d4758c5fb5384c8d6,Skigebiet Damüls-Mellau-Faschina,https://www.damuels-mellau.at/ https://www.fontanella.at/,https://www.damuels-mellau.at/ https://www.fontanella.at/en/lift-status
-8a5063e32476ab3ab529dd524a0debe563e08f28,Skigebiet Fellhorn/Kanzelwand,https://www.das-hoechste.de/,https://www.das-hoechste.de/en/lift-status
-fa473fa12ab6059b9e93af8498afa0efdea2cff6,Skigebiet Garmisch-Classic,https://zugspitze.de/en/winter/skiarea/garmisch-classic,https://zugspitze.de/en/winter/skiarea/garmisch-classic/en/lift-status
-8084c4abdbb04493340fe3c511cb144334b800d0,Skigebiet Gerlitzen Alpe,https://www.gerlitzen.com/,https://www.gerlitzen.com/en/lift-status
-5c8fc1c68acad9168476178ddf7345aae3008bb8,Skigebiet Großglockner Heiligenblut,https://www.heiligenblut.at/,https://www.heiligenblut.at/en/lift-status
-b063a6fc6907012f71f581b75275c33d562695fa,Skigebiet Lachtal,https://www.lachtal.at/,https://www.lachtal.at/en/lift-status
-2e16768bb85528d510acd8aa58e14a82502ea66a,Skigebiet Oberwiesenthal,https://www.fichtelberg-ski.de/,https://www.fichtelberg-ski.de/en/lift-status
-3fbb5470d84a03e79bc9d78671e709fd115de4d4,Skigebiet Raurisertal,https://www.hochalmbahnen.at/,https://www.hochalmbahnen.at/en/lift-status
-d98cdd6d5eb28552b22f3a087019c5786531e069,Skigebiet Spitzingsee - Tegernsee,https://www.alpenbahnen-spitzingsee.de/de/skifahren-snowboarden.html,https://www.alpenbahnen-spitzingsee.de/de/skifahren-snowboarden.html/en/lift-status
-7322051c91f99e6553bf33c99c38c73ed0e604a6,Skigebiet Stuhleck - Semmering,https://www.stuhleck.at/,https://www.stuhleck.at/en/lift-status
-f306e3eef33d4e0e5625c5db98f0421fb85f7238,Skimore Oslo,http://www.tryvann.no/,http://www.tryvann.no/en/lift-status
-97e9df8fc8d999cf9e62628866e49af00598fba0,Skipisten Titlis Bergbahnen,https://www.engelberg.ch/,https://www.engelberg.ch/en/lift-status
-2850c5910e1f12d55d96373d4adc29212a791432,Skiregion Dachstein West,https://www.dachstein.at/,https://www.dachstein.at/en/lift-status
-583dbc4651db7ebcc7875a11180b634ec108ba8a,Skiresort Černá Hora-Pec,https://skiresort.cz/,https://www.skiresort.cz/en/skiarealy/cerna-hora/ch-lanovky-a-vleky/
-b57f20e0c7ea594ef8ec8289fd87022b36417629,Snow Space Salzburg,https://www.snow-space.com/,https://www.snow-space.com/en/lift-status
-553e5c0881466894501e5f56ab41ba951300fc75,Snow Summit,https://www.bigbearmountainresort.com/,https://www.bigbearmountainresort.com/en/lift-status
-11f2099ea10957844765b5bea3bbb1f13fd592b7,Snow Valley Mountain Resort,https://snow-valley.com,https://snow-valley.com/en/lift-status
-02c5a8b2e7e93dd3b178428c9cb33794f8fc673a,Snowbasin Resort,https://www.snowbasin.com/,https://www.snowbasin.com/en/lift-status
-aeb6db58121288dc0287b4254df4adbe5a40c3ec,Snowbird,https://www.snowbird.com/,https://www.snowbird.com/en/lift-status
-78ac27731bb078db310933e9828665ca59858de2,Sommet Saint-Sauveur,https://glissade.ca/ https://www.sommets.com/fr/montagne-de-ski/sommet-saint-sauveur/,https://glissade.ca/ https://www.sommets.com/fr/montagne-de-ski/sommet-saint-sauveur/en/lift-status
-b72528d5985a996abc5f00fe007658659df1b068,Sonnenkopf,https://www.sonnenkopf.com/,https://www.sonnenkopf.com/en/lift-status
-f5332cdc7d54f27d5cfeb3d3d1bb0d1f8b4b660e,Spieljoch - Fügen,https://www.spieljochbahn.at/,https://www.spieljochbahn.at/en/lift-status
-7bbe4370de755694437795af4d89234c73ed73d4,St Johann in Tirol,https://www.bergbahnen-stjohann.at/,https://www.bergbahnen-stjohann.at/en/lift-status
-39061a64356927c033dcfc0a90f1e2eaa8b2e03b,Station de ski de Prat Peyrot,https://www.stationaltiaigoual.com/,https://www.stationaltiaigoual.com/en/lift-status
-9092c1bd90194143f2e1c2fcf7ffecc67ef58670,Steamboat Ski Resort,https://www.steamboat.com/,https://www.steamboat.com/en/lift-status
-427712e1430959c6a91b120331da6c7c3981e312,Steinplatte Waidring-Tirol,https://www.steinplatte.tirol/,https://www.steinplatte.tirol/en/lift-status
-cd52cfebdda8e84997b3447573546b8d17bc8e6d,Stevens Pass Ski Area,https://www.stevenspass.com,https://www.stevenspass.com/en/lift-status
-bc0ee62d23f20f8e6f30661302cd2a2d3ee2a897,Stoos,http://www.morschach-stoos.ch,http://www.morschach-stoos.ch/en/lift-status
-f511535c529ee4710b2165d57a2370731c890ca7,Stowe Mountain Resort,https://www.stowe.com,https://www.stowe.com/en/lift-status
-35a35b53676eda31cfdee8a367bade9189289c12,"Straja, Straja Ski Resort, Station de ski de Straja, Stațiune Straja",https://skistraja.ro/,https://skistraja.ro/en/lift-status
-76d2732379666c2a1a0b22913d755625f1a01407,Stratton Mountain Resort,https://www.stratton.com/,https://www.stratton.com/en/lift-status
-35aa13ee7428fd8c73935ec40297cce0c8d6e14e,Stubaier Gletscher,https://www.stubaier-gletscher.com/,https://www.stubaier-gletscher.com/en/lift-status
-31297131594299a446bc94ebea4e1b9d48f1be2a,Stöten i Sälen,https://www.stoten.se/,https://www.stoten.se/en/lift-status
-36d524d45f34c80c849eb87a36ee901f2fb2c542,Sudelfeld - Bayrischzell,https://skizentrum-grafenherberg-sudelfeld.de/ https://www.sudelfeld.de/,https://skizentrum-grafenherberg-sudelfeld.de/ https://www.sudelfeld.de/en/lift-status
-f3be556bbdfb104971d932b7d6420ded885aeaf1,Sugadaira Kogen (菅平高原スキー場),https://sugadaira-snowresort.com/,https://sugadaira-snowresort.com/en/lift-status
-9cf876d5cd0060b7ebadf941c9fe695ca573f254,Sugar Bowl Resort,https://www.sugarbowl.com/,https://www.sugarbowl.com/en/lift-status
-b67c4aec66917728d37f522a8bfdc12cb0e9c84d,Sugarbush Resort,https://www.sugarbush.com/,https://www.sugarbush.com/en/lift-status
-5c5fcebef97c88619e841e8be5f8dbb92fcc2899,Sugarloaf,https://www.sugarloaf.com/,https://www.sugarloaf.com/en/lift-status
-45625a91e8f6714ebecb456492ca9e39b1bc677b,Sulden,https://www.ortlerskiarena.com/,https://www.ortlerskiarena.com/en/lift-status
-2c339c62fc87dfea7c1c62e0a5a5be4bb1af972a,Summit at Snoqualmie,https://summitatsnoqualmie.com/ https://www.fs.usda.gov/recarea/okawen/recarea/?recid=57459 https://www.summitatsnoqualmie.com/,https://summitatsnoqualmie.com/ https://www.fs.usda.gov/recarea/okawen/recarea/?recid=57459 https://www.summitatsnoqualmie.com/en/lift-status
-ad0f4ca1e398fc733381875ddb05ef08c0215ae7,Sun Peaks Resort,https://www.sunpeaksresort.com/,https://www.sunpeaksresort.com/en/lift-status
-ac37d78376b2a4bf76b05a2ed197e69e70234be6,Sun Valley - Bald Mountain,https://www.sunvalley.com/,https://www.sunvalley.com/en/lift-status
-8a12bad9ec88beeb2953c79e1018b493cec2165d,Sunburst Ski Area,https://skisunburst.com/,https://skisunburst.com/en/lift-status
-54bceeb62ccd2209e50b8dc7e06b8daa1727ce34,Sunday River,https://www.sundayriver.com/,https://www.sundayriver.com/en/lift-status
-870daba91bf45e41f76102b45565876b61861a50,Super Besse,https://lemontdore.fr https://www.sancy.com/,https://lemontdore.fr https://www.sancy.com/en/lift-status
-59daf3cc15cc3c231203bce41e59f1258093568a,Superbagnères,http://www.luchon-superbagneres.com/,http://www.luchon-superbagneres.com/en/lift-status
-78e5f98d8527df7216b08962f372659abcd4f711,Sölden,https://www.soelden.com/,https://www.soelden.com/en/live-information/status
-6fc2b7bd9404c7cf68e49ca9fd83600e3de149d4,Sörenberg,https://www.soerenberg.ch,https://www.soerenberg.ch/en/lift-status
-6d3a6779aeccfa475be6c0a5f9b52f427d64c037,Tahko,https://www.tahko.com/en/,https://www.tahko.com/en/en/lift-status
-c71e417e9551491fd1680f0e9879c132f0278d37,Tandådalen,https://www.skistar.com/en/ski-destinations/salen,https://www.skistar.com/en/ski-destinations/salen/en/lift-status
-d384d3efef189d58a9bcc558a821feac9874fa55,Taos Ski Valley,https://www.skitaos.com/,https://www.skitaos.com/en/lift-status
-d9dbd36650fb264e3fd35269d10a3645bf7d0493,Tauplitz / Bad Mitterndorf,https://www.dietauplitz.com/,https://www.dietauplitz.com/en/lift-status
-31448f6acd1c42f66ba4b466f00261c81d791b52,Telluride Ski Area,https://tellurideskiresort.com/,https://tellurideskiresort.com/en/lift-status
-acb73a5b3ed3694f1e9ac030840cd5004f65f207,The Lecht,https://www.lecht.co.uk/,https://www.lecht.co.uk/en/lift-status
-890292ea837546e59f76bc5ebe6215c87576f8cf,Thredbo Resort,https://www.thredbo.com.au/,https://www.thredbo.com.au/en/lift-status
-6ed5f25f0eb3e366ee2e0e667d998c0bf551225f,Tignes - Val d'Isère,https://www.espacekilly.com/,https://www.seetignes.com/lifts/status
-d2f756f38522c028f224157b6bc702984acaf6ea,Timberline Lodge Ski Area,https://www.timberlinelodge.com/,https://www.timberlinelodge.com/en/lift-status
-876c2ec22f98746e8a3e32860f961b30e6e161c7,Trysil,https://www.skistar.com/no/vare-skisteder/trysil/vinter-i-trysil/,https://www.skistar.com/en/ski-destinations/trysil/winter-in-trysil/weather-and-slopes/
-1648984800eeaf4c7d1f8774dc5ae107df61a927,Turracher Höhe,https://www.turracherhoehe.at/,https://www.turracherhoehe.at/en/lift-status
-27892035f6676422fecf162968cf2f39486245eb,Tänndalen,https://www.tanndalen.com/,https://www.tanndalen.com/en/lift-status
-ce9e507474fc78e61f5eb00985c79c4ab5148599,Vail,https://www.vail.com,https://vail.com/the-mountain/mountain-conditions/terrain-and-lift-status.aspx
-99ae575c13123d2b1fcabf60180a7cf2b4c3efe0,Val Cenis,https://www.valcenis.com,https://www.valcenis.com/en/live-info
-fc172b6fc8f8c454471e679be1c8b2ecc884621e,"Val Gardena, Gröden, Gherdëina",https://www.dolomitisuperski.com/ https://www.valgardena.it/,https://www.dolomitisuperski.com/en/live-info/lifts/groden-seiser-alm
-5b4aba23e8c29f88cd0e89e51dea075af5bc649a,Val Senales-Schnalstal,https://www.schnalstal.com/,https://www.schnalstal.com/en/lift-status
-3ab7375c4734163405f0f77a7c5a6afdfd600b73,Val Thorens - Orelle,https://www.les3vallees.com/,https://www.seevalthorens.com/lifts/status
-05ec7627488328fb30e0d502b021045a348af622,Val d'Allos - La Foux,https://www.valdallos.com/,https://www.valdallos.com/en/lift-status
-5599f5c55105bf3996fec9a4e6f309e1a79e421d,Valle Nevado,https://www.vallenevado.com/index.php,https://www.vallenevado.com/index.php/en/lift-status
-1cded5bc5f19ff069b624735188e23016d099485,Vassfjellet skisenter,https://vassfjellet.no,https://vassfjellet.no/en/lift-status
-c6e8e5bc5ed5c1e2d8e96e251ef9737969fa29ca,Villard de Lans - Corrençon,https://www.villarddelans-correnconenvercors.com/,https://www.villarddelans-correnconenvercors.com/en/lift-status
-669b5ff8d29a5a73f293dec2f318ed7554c32511,Villars/Gryon/Les Diablerets,http://www.tvgd.ch,http://www.tvgd.ch/en/lift-status
-db5585d0837836efc833b11e021ea73189afae3c,Voss Resort Fjellheisar,https://vossresort.no/no/vinter/,https://vossresort.no/no/vinter/en/lift-status
-26ac3476ebcc3ff9c7e4d046d5cff2d674a22d1e,Vrátna,http://www.vratna.sk/sk,http://www.vratna.sk/sk/en/lift-status
-40ad60323d89371113e5751f8c1597a5cbc29d29,Wagrain,http://www.bergbahnen-wagrain.at/de/winter,http://www.bergbahnen-wagrain.at/de/winter/en/lift-status
-6e606a86fc0790050c9c7220e8fa4fb2cf48cbae,"Wanlong Paradise Resort, 万龙度假天堂",https://www.secretgardenresorts.com/,https://www.secretgardenresorts.com/en/lift-status
-29248afecbb89253d31145bb08025956c1bfb71a,Warth-Schröcken,https://www.skiarlberg.at/,https://www.skiarlberg.at/en/lift-status
-d7f0152ded3f23d4e4cf3ad4571f131ec267ab40,Wendelstein,https://www.wendelsteinbahn.de/,https://www.wendelsteinbahn.de/en/weather
-650eebed3cbc4d95ec15ed68c8266794c735683d,Whakapapa,https://www.whakapapa.com/,https://www.whakapapa.com/en/lift-status
-9acabdff8a4e7ac9bd74c5812a03220c3a2cf1ab,Whistler Blackcomb,https://www.whistlerblackcomb.com,https://www.whistlerblackcomb.com/en/lift-status
-73b0a6b0c99f30aac2afab9c3a17193a3ef2b2d6,Whiteface Mountain Ski Center,https://www.whiteface.com/,https://www.whiteface.com/en/lift-status
-b722bd835aaa6e9597fa6cc41f40a4b3f6ed7834,Whitefish Mountain Resort,https://skiwhitefish.com,https://skiwhitefish.com/en/lift-status
-df2bd5abc7c60af896261373af4d7b9d6085e5bf,Wildkogel,https://www.wildkogel-arena.at/,https://www.wildkogel-arena.at/en/lift-status
-20792d490b04a009a6918d8d23eee21e1b8a19ab,Wilmot Mountain,https://www.wilmotmountain.com/,https://www.wilmotmountain.com/en/lift-status
-e1ecf30641b9fcacec240124d73bcd5efef9c3fd,Winter Park Resort,https://www.winterparkresort.com,https://www.winterparkresort.com/en/lift-status
-cc5e09c5c2c3dd0b9b8b489a396fdea9a5d0bd1b,Wisp Resort,https://www.wispresort.com/,https://www.wispresort.com/en/lift-status
-9ffde4a23b867868dab1643e79329e4cd65ea098,Wolf Creek Ski Area,https://www.wolfcreekski.com/,https://www.wolfcreekski.com/en/lift-status
-280793b5c7cf28d9a453319f9612737ecde74a6d,Wurzeralm,https://skisport.com/HiWu,https://skisport.com/HiWu/en/lift-status
-f733f44e7f4ba14c3270c734a10424ed8ff5905f,Yellowstone Club,https://yellowstoneclub.com/,https://yellowstoneclub.com/en/lift-status
-1e6bbe90c52ffa3fce748d4728d071b61c03b989,"Ylläs Ski Resort, Äkäslompolo",https://ski.yllas.fi/,https://ski.yllas.fi/en/lift-status
-6071fe4a9ab2ea3859cfdda2fa3e1f5d556889dc,Zauchensee-Flachauwinkl,https://www.zauchensee.at/,https://www.zauchensee.at/en/lift-status
-438e8330317f2f5a597b60acb0c0a11901b9329f,"Zermatt - Breuil-Cervinia, Breuil-Cervinia Ski Paradise",https://www.matterhornparadise.ch,https://www.cervinia.it/en/impianti
-6241bfbd7c4e6009c515ba06344e7315f0859ee2,Zieleniec,https://zieleniec.pl/,https://zieleniec.pl/en/lift-status
-4a041686ec032469cd3d58aaaf73ed9864e4a173,Zillertal Arena,https://www.zillertalarena.com/,https://www.zillertalarena.com/en/information-services/live-cams-weather/snow-report/
-ed495f08be5bb41505f6fdf15bc569477b1cd358,Zinal / Grimentz,https://www.valdanniviers.ch/fr/grimentz-zinal-134.html,https://www.valdanniviers.ch/fr/grimentz-zinal-134.html/en/lift-status
-cafed86430d9ca4117593778c25c8ac57654b9f3,"Zoncolan, Çoncolan",https://www.turismofvg.it/en/mountain365/ski-area-ravascletto-zoncolan,https://www.turismofvg.it/en/mountain365/ski-area-ravascletto-zoncolan/en/lift-status
-4968c991f3910142689f5f0d2fabee02df54e214,Åre,https://www.skistar.com/en/ski-destinations/are/,https://www.skistar.com/en/ski-destinations/are/winter-in-are/weather-and-slopes/
-7e8c8f1b234ed4ecc63550680e2ad5bc66817491,"Χιονοδρομικό Κέντρο Παρνασσού, Parnassos Ski resort",https://parnassos-ski.gr/,https://parnassos-ski.gr/en/lift-status
-f09500d7cff4036c5241afa941f84b4e17187cea,"Архыз, Arhyz",https://resort-arkhyz.ru/,https://resort-arkhyz.ru/en/lift-status
-06030b24291dac728dbfaf7ac07b9570b19bee6e,Волен (Volen),https://www.volen.ru/,https://www.volen.ru/en/lift-status
-d4c30482dd7589be58b5597546bab89f29722bc2,"Газпром, Gazprom",https://polyanaski.ru/,https://polyanaski.ru/en/lift-status
-7e1c3bbe5dc96f84472363c502e595691f2862c0,"Домбай, Dombay",https://www.dombai.info/,https://www.dombai.info/en/lift-status
-60dcc022284937e2f1d303b44f395cd1988431c1,Золотая Долина,https://zoldol.ru/,https://zoldol.ru/en/lift-status
-d9b8354ac0b5524d68a73586104438675ed241ac,"Коласпортланд (Mount Aykuayvenchorr, Kolasportland, Kirovsk)",https://ski-kolasport.narod.ru/,https://ski-kolasport.narod.ru/en/lift-status
-f21450a542a05b0b1d7dc7e647189168f962fa66,"Курорт Красная Поляна, Krasnaya Polyana Resort",https://krasnayapolyanaresort.ru/,https://krasnayapolyanaresort.ru/en/lift-status
-246c066d501b55857937068a8ddc67866edd0aa8,"Роза Хутор, Rosa Khutor",https://rosaski.com,https://rosaski.com/en/lift-status
-bc021726b4d576c20e3d1b1b55d15175eb5323a4,"Ски центар Копаоник, Ski Center Kopaonik",https://www.skijalistasrbije.rs/,https://www.skijalistasrbije.rs/en/lift-status
-01bb562d07c3063c474c861a253f6644550c977c,"Шерегеш, Sheregesh",https://www.sheregesh.su/,https://www.sheregesh.su/en/lift-status
-0bcc31494b9b87b9cc66f9b5655dacc021c1d7b8,"پیست اسکی دیزین, Dizin Ski Resort",https://dizinskiresort.ir/,https://dizinskiresort.ir/en/lift-status
-611c5f306d193965d569b1d45fd531b4b4a6e14b,"გუდაური, Gudauri, Гудаури",https://mta.ski,https://mta.ski/en/lift-status
-18c3fba8fc39523a87ef5ae73ba37e372171062b,"だいせんホワイトリゾート, Daisen White Resort",https://www.daisen-resort.jp/,https://www.daisen-resort.jp/en/lift-status
-007cb46a0e3b4f61b720e722ef138ae446f153af,"サッポロテイネ, Sapporo Teine",https://sapporo-teine.com/snow/,https://sapporo-teine.com/snow/en/lift-status
-659e9454e8138a2a73f4ab3565bff030e4ab724c,"ニセコユナイテッド, Niseko United",https://www.niseko.ne.jp/,https://www.niseko.ne.jp/en/lift-status
-eddc850d601b2db3c793fab90c63a4c8d84355a7,"ルスツリゾートスキー場, Rusutsu Resort Ski Area",https://rusutsu.com/,https://rusutsu.com/en/lift-status
-20ac327186091ca88822bcf3f9325608f7c53aa2,"上越国際, Joetsu International, Jōetsu kokusai",https://www.jkokusai.co.jp/,https://www.jkokusai.co.jp/en/lift-status
-03211df1a9413a2f292903b230b4dd0c55cf7b5f,"星野リゾート 猫魔スキー場, Hoshino Resorts Nekoma Mountain",https://www.alts.co.jp/index.php,https://www.alts.co.jp/index.php/en/lift-status
-c0b5e854cce5bf84da14a43752dd12117ca30144,"栂池高原, Tsugaike Kogen",https://www.tsugaike.gr.jp/,https://www.tsugaike.gr.jp/en/lift-status
-62f3daa02b915e9b7877e047b079bbed79bcf55d,"白馬八方尾根, Hakuba Happo One",https://www.happo-one.jp/,https://www.happo-one.jp/en/lift-status
-ccdd8e9f8cf942b21aad02955e0974d9361c61ee,"石打丸山スキー場, Ishiuchi Maruyama Ski Resort",https://www.ishiuchi.or.jp/,https://www.ishiuchi.or.jp/en/lift-status
-c648e066e43b77ed2b7ed924724cff40632596bb,"竜王スキーパーク, Ryuoo Ski Park, Ryūō sukī pāku",https://www.ryuoo.com/,https://www.ryuoo.com/en/lift-status
-1a8468ff9dfaf2dabcec8452076e0b425c1dd6b9,"苗場スキー場, Naeba Ski Resort, Naeba sukī-ba",https://www.princehotels.co.jp/ski/naeba/,https://www.princehotels.co.jp/ski/naeba/en/lift-status
-bd8c1ad24047f06b8a06fd4d2172399e8babbb8d,"蔵王温泉スキー場, Zao Onsen Ski Resort",https://www.zao-ski.or.jp/,https://www.zao-ski.or.jp/en/lift-status
-f8716222688069b2907d592ee40781b30ac4971a,"野沢温泉スキー場, Nozawa Onsen",https://www.nozawaski.com/,https://www.nozawaski.com/en/lift-status
+resort_id,resort_name,lift_count,status_page_url
+68b126bc3175516c9263aed7635d14e37ff360dc,Val Thorens - Orelle,141,https://www.les3vallees.com/en/live/lifts-and-trails-opening/val-thorens
+0345d73f7a4bf0f49815ccb16306a3ec6371544b,Espace Diamant,92,https://www.espacediamant.com/en/
+6ed5f25f0eb3e366ee2e0e667d998c0bf551225f,Tignes - Val d'Isère,90,https://en.tignes.net/skiing/ski-area/lifts-and-pistes-live-opening
+f47f7e05cc676b25b6a00f77f0b86a897f03018c,La Plagne,83,https://en.la-plagne.com/discover/ski-area/piste-map
+721dd142d0af653027c7569e1bd0799586bdefa1,Alpe d'Huez Grand Domaine,83,https://www.alpedhuez.com/en/winter/open-lifts-and-slopes/
+dec537b602584db89d89ab114a619f1ae356398e,Les Arcs,81,https://en.lesarcs.com/lifts-slopes-status
+37ee9c6ba5b44864ba844f804938a8b815f8b717,SkiWelt Wilder Kaiser - Brixental,80,https://www.wilderkaiser.info/en/service/lift-status.html
+fc172b6fc8f8c454471e679be1c8b2ecc884621e,Val Gardena,80,https://www.valgardena.it/en/winter-holidays-dolomites/slopes-ski-lifts/open-lifts/
+5b78e5652d097c7679cef7128ee1b57ff09fb86e,Skicircus Saalbach-Hinterglemm Leogang Fieberbrunn,80,https://www.fieberbrunn.com/liftoperation
+0ed72c1a44d748a815d1efcd54caacf169610f05,4 Vallées – Verbier/La Tzoumaz/Nendaz/Veysonnaz/Thyon,79,https://verbier4vallees.ch/en/useful-information/live-information-winter
+775634f8f5f5b0724ecd27d82909b2008d58f7d5,Les Sybelles,70,https://www.sybelles.ski/en/skiing-in-les-sybelles/slopes-and-lifts-open/
+39136d396c46f03d9e84227cd2bccbdf60c55efd,Serre Chevalier,70,https://www.serrechevalier-pass.com/en/info
+efaa82d7ae8e42868f19ed2abb8001f518a404d0,Le Grand Massif,69,https://www.grand-massif.com/en/info-ski-area/
+438e8330317f2f5a597b60acb0c0a11901b9329f,Zermatt - Breuil-Cervinia,65,https://www.matterhornparadise.ch/en/information/operating-hours/lifts-and-pistes
+0e7f017d9c830408aebfc40144372d483b040462,KitzSki,62,https://www.kitzski.at/en/current-info/kitz-lift-status.html
+41ca531357e0d2a532b8ab94e3e9fe74ddbe88c4,Alta Badia,61,https://www.altabadia.org/en/open-lifts-snow-report-dolomites
+97a14cedc5b0e781e9bd9857df1426b9376c7462,Megève,61,https://forfait.megeve.com/hiver/en/ski-area-opening-information/
+f5fcc0e543cfb0e4d50280c286081c27d975697f,Le Grand Domaine,59,https://skipass.valmorel.com/en/
+baca23b1d6c08055f995fe20b50e3f6910b2ea2b,Espace Liberté,54,https://www.skipass-chatel.com/en/espace-liberte
+3ab7375c4734163405f0f77a7c5a6afdfd600b73,Les Trois Vallées,54,https://www.les3vallees.com/en/live/lifts-and-trails-opening
+de4f884c40976fe9d18c23d0bab174c1d6b79218,GrandValira,53,https://www.grandvalira.com/en/resort/open-slopes
+f967615083aaed557fa47068b9d894e66d763f0a,Mayrhofen Hippach,53,https://www.mayrhofen.at/en/stories/skiing-snowboarding
+583dbc4651db7ebcc7875a11180b634ec108ba8a,Pec pod Sněžkou,52,https://www.skiresort.cz/en/skiarealy/pec-pod-snezkou/pec-lanovky-a-vleky/
+94cb050e1e20e04e822c14216840885aea2eafcc,Serre-Chevalier,51,https://www.serrechevalier-pass.com/en/info
+d7f0152ded3f23d4e4cf3ad4571f131ec267ab40,Wendelstein,51,https://www.wendelsteinbahn.de/skigebiet-wendelstein-2
+4a041686ec032469cd3d58aaaf73ed9864e4a173,Zillertal Arena,51,https://www.zillertalarena.com/en/winter/ski-area/lifts-slopes/
+9cb83fdd2a49011eec76e3d1bbc2af8f582888a9,La Clusaz,51,https://forfait.laclusaz.com/en/
+e587928ea763f20b3232a5069c5d2438d09b6908,Serfaus Fiss Ladis,48,https://www.serfaus-fiss-ladis.at/en/winter-holiday/ski-area-status
+cafb6b6d5f25860a682a8b6d67efe689218618a5,Les Gets-Morzine,48,https://www.lesgets.com/en/discover-the-resort/ski-winter-sports/live-info-slopes/
+4ae9b0cba5454d6f0921bf413c33a267f1d63cca,Arosa Lenzerheide,47,https://arosalenzerheide.swiss/en/Ski-Area/Lift-Company/Operating-hours-winter
+4968c991f3910142689f5f0d2fabee02df54e214,Åre,47,https://www.skistar.com/en/ski-destinations/are/winter-in-are/weather-and-slopes/
+ef817c42b82422721b05028c6d58ce10f8a2190c,Folgaria,47,https://www.alpecimbra.it/en/
+b57f20e0c7ea594ef8ec8289fd87022b36417629,Wagrain,46,https://www.snow-space.com/openlifts
+7c2f2690d339d9df6f820e7c6e596a9b0ba3dce5,Silvretta Arena Ischgl/Samnaun,44,https://www.ischgl.com/en/silvrettaseilbahnag/winter/facilities-at-a-glance
+5bd589496339e89cf9be3d93c86e7e6c41f72208,Les Deux Alpes,44,https://www.les2alpes.com/winter/live-info/
+f9beaf4e37ef88b422b9ee4aa2ae9224f10afd02,Corviglia,44,https://www.stmoritz.com/en/live/cable-cars-slopes
+3885048f9cb77cae837d23131d2f8fb78d06f807,Perisher,44,https://www.perisher.com.au/reports-cams/reports/lift-report
+be21197d101373cf2bc532a9fcce6d6e1d1bd76e,Park City Mountain Resort,43,https://www.parkcitymountain.com/the-mountain/mountain-conditions/terrain-and-lift-status.aspx
+d264be37a4fd40a4de858be7fee0a5c077cb1068,Aletsch Arena,42,https://www.aletscharena.ch/en/here-now/live/status-report/status-report-winter
+7cac2b19d023f887e458c354be9caf833b6aed6d,Avoriaz,41,https://www.skipass-avoriaz.com/en/slopes-and-lifts/
+00fb2c5ba89284e0b4e3708d04d549905f260cf3,Big Sky Resort,41,https://bigskyresort.com/lift-status
+66e672470add74c3e6a2bd8d4c1bb07cc4721728,St. Anton/St. Christoph/Stuben,40,https://www.skiarlberg.at/en/st-anton/live-info/cable-cars-lifts
+403c8d67ddd348bfa3f7d02c6c21163479964926,Parsenn,39,https://www.davos.ch/en/discover/mountains/winter-sports-report/lifts-and-piste-report
+e7c4c03bd7f9a3d907ff566775cfba1823bcf2ae,Val d'Allos - La Foux,39,https://en.valdallos.com/ouverture-des-pistes.html
+9d0b2c5e0fcac9deba9c727a834cac4b43a5d2c9,Forêt Blanche : Vars/Risoul,38,https://www.vars.com/winter/
+d5ff708ce6a4ab382afaeb81310e7317494b6fbb,Laax,38,https://live.laax.com/en/lifts
+78e5f98d8527df7216b08962f372659abcd4f711,Sölden,38,https://www.soelden.com/en/live-information/status
+876c2ec22f98746e8a3e32860f961b30e6e161c7,Trysil,37,https://www.trysil.com/en/
+f654467c75bb645ac3a8e664b656d00b2e90ef2e,Silvretta Montafon,37,https://www.silvretta-montafon.at/en/info-service/lift-info
+9e8a091097aeb5af7c87b5f53922e3db043a9849,Gletscher-Skigebiet Zugspitze,37,https://zugspitze.de/en/Service-information/Facilities

--- a/scripts/generate-status-pages.mjs
+++ b/scripts/generate-status-pages.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Generate status_pages.csv by:
+ * 1. Aggregating lifts.csv to find top 50 resorts by lift count
+ * 2. Searching Serper.dev for each resort's status page
+ * 3. Using OpenAI to pick the official status page URL
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const SERPER_API_KEY = process.env.SERPER;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const TOP_N = 50;
+
+// Parse CSV line handling quoted fields
+function parseCSVLine(line) {
+  const parts = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (c === '"') inQuotes = !inQuotes;
+    else if (c === ',' && !inQuotes) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += c;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+// Aggregate lifts by ski_area_id
+function aggregateLifts(liftsPath) {
+  const data = fs.readFileSync(liftsPath, 'utf-8');
+  const lines = data.split('\n').slice(1).filter(l => l.trim());
+
+  const counts = {};
+  const resortNames = {};
+
+  lines.forEach(line => {
+    const parts = parseCSVLine(line);
+    const skiAreaNames = parts[7] || '';
+    const skiAreaIds = parts[8] || '';
+
+    if (skiAreaIds) {
+      skiAreaIds.split(';').forEach((id, idx) => {
+        id = id.trim();
+        if (id) {
+          counts[id] = (counts[id] || 0) + 1;
+          if (!resortNames[id] && skiAreaNames) {
+            const names = skiAreaNames.split(',');
+            resortNames[id] = (names[idx] || names[0] || '').trim();
+          }
+        }
+      });
+    }
+  });
+
+  // Sort by count descending and take top N
+  const sorted = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, TOP_N)
+    .map(([id, count]) => ({
+      resort_id: id,
+      resort_name: resortNames[id] || 'Unknown',
+      lift_count: count
+    }));
+
+  return sorted;
+}
+
+// Search Serper.dev
+async function searchSerper(query) {
+  const response = await fetch('https://google.serper.dev/search', {
+    method: 'POST',
+    headers: {
+      'X-API-KEY': SERPER_API_KEY,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      q: query,
+      num: 10
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Serper API error: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// Use OpenAI to pick the best status page URL
+async function pickBestUrl(resortName, searchResults) {
+  const organic = searchResults.organic || [];
+  if (organic.length === 0) {
+    return null;
+  }
+
+  const resultsText = organic.map((r, i) =>
+    `${i + 1}. Title: ${r.title}\n   URL: ${r.link}\n   Snippet: ${r.snippet || ''}`
+  ).join('\n\n');
+
+  const prompt = `You are helping find the official lift status page for the ski resort "${resortName}".
+
+Below are search results for "${resortName} lift status". Pick the single best URL that:
+1. Is the official resort website (not a third-party aggregator like skiresort.info, snow-forecast.com, onthesnow.com, etc.)
+2. Shows live lift status or operating conditions
+3. Is the most direct link to the status/conditions page (not the homepage)
+
+Search results:
+${resultsText}
+
+Respond with ONLY the URL of the best result, or "NONE" if no official status page is found.
+Do not include any explanation, just the URL or "NONE".`;
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENAI_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0,
+      max_tokens: 200
+    })
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`OpenAI API error: ${response.status} - ${errText}`);
+  }
+
+  const data = await response.json();
+  const answer = data.choices[0]?.message?.content?.trim();
+
+  if (!answer || answer === 'NONE' || answer.toLowerCase() === 'none') {
+    return null;
+  }
+
+  return answer;
+}
+
+// Escape CSV field
+function escapeCSV(field) {
+  if (field == null) return '';
+  const str = String(field);
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+// Main function
+async function main() {
+  console.log('Aggregating lifts data...');
+  const liftsPath = path.join(process.cwd(), 'data', 'lifts.csv');
+  const topResorts = aggregateLifts(liftsPath);
+
+  console.log(`Found top ${topResorts.length} resorts by lift count:\n`);
+  topResorts.forEach((r, i) => {
+    console.log(`${i + 1}. ${r.resort_name}: ${r.lift_count} lifts`);
+  });
+
+  console.log('\nSearching for status pages...\n');
+
+  const results = [];
+
+  for (let i = 0; i < topResorts.length; i++) {
+    const resort = topResorts[i];
+    console.log(`[${i + 1}/${topResorts.length}] Searching: ${resort.resort_name}...`);
+
+    try {
+      // Search for lift status
+      const query = `${resort.resort_name} ski lift status`;
+      const searchResults = await searchSerper(query);
+
+      // Use LLM to pick best URL
+      const statusUrl = await pickBestUrl(resort.resort_name, searchResults);
+
+      results.push({
+        ...resort,
+        status_page_url: statusUrl || ''
+      });
+
+      if (statusUrl) {
+        console.log(`   Found: ${statusUrl}`);
+      } else {
+        console.log(`   No official status page found`);
+      }
+
+      // Rate limiting - be gentle with APIs
+      await new Promise(r => setTimeout(r, 500));
+
+    } catch (err) {
+      console.error(`   Error: ${err.message}`);
+      results.push({
+        ...resort,
+        status_page_url: ''
+      });
+    }
+  }
+
+  // Write CSV
+  const outputPath = path.join(process.cwd(), 'data', 'status_pages.csv');
+  const header = 'resort_id,resort_name,lift_count,status_page_url';
+  const rows = results.map(r =>
+    [r.resort_id, r.resort_name, r.lift_count, r.status_page_url]
+      .map(escapeCSV)
+      .join(',')
+  );
+
+  fs.writeFileSync(outputPath, [header, ...rows].join('\n') + '\n');
+
+  console.log(`\nWrote ${results.length} resorts to ${outputPath}`);
+  console.log(`Resorts with status pages: ${results.filter(r => r.status_page_url).length}`);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/ski_lift_status/configs/resorts.json
+++ b/src/ski_lift_status/configs/resorts.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "updated": "2025-12-19",
-  "total_resorts": 442,
+  "updated": "2025-12-20",
+  "total_resorts": 444,
   "platforms": {},
   "resorts": [
     {
@@ -42,26 +42,28 @@
       "id": "aletsch-arena",
       "name": "Aletsch Arena",
       "openskimap_id": "d264be37a4fd40a4de858be7fee0a5c077cb1068",
-      "platform": "custom",
-      "url": "https://www.aletscharena.ch/en/live-info",
-      "website": "https://www.aletscharena.ch/"
+      "platform": "aletsch",
+      "url": "https://www.aletscharena.ch/en/here-now/live/status-report/status-report-winter",
+      "website": "https://www.aletscharena.ch/",
+      "notes": "Swiss resort with structured list"
     },
     {
       "id": "alpe-cimbra",
       "name": "Alpe Cimbra",
       "openskimap_id": "ef817c42b82422721b05028c6d58ce10f8a2190c",
-      "platform": "custom",
-      "url": "http://www.lavaroneski.it/",
-      "website": "http://www.lavaroneski.it/ https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html"
+      "platform": "folgaria",
+      "url": "https://www.alpecimbra.it/en/alpe-cimbra-ski-area/alpe-cimbra-ski-area/",
+      "website": "http://www.lavaroneski.it/ https://www.alpecimbra.it/de/skigebiet-alpe-cimbra/lavarone-folgaria-skigebiet/46-0.html",
+      "notes": "Italian resort - uses Mowi Snow app for data"
     },
     {
       "id": "alpe-dhuez",
       "name": "Alpe d'Huez Grand Domaine",
       "openskimap_id": "721dd142d0af653027c7569e1bd0799586bdefa1",
-      "platform": "custom",
+      "platform": "seelift",
       "url": "https://www.seealpedhuez.com/lifts/status",
       "liftieId": null,
-      "notes": "See* network site - requires browser rendering"
+      "notes": "See* network site - uses Lumiplan status images"
     },
     {
       "id": "alpine-valley-resort",
@@ -121,6 +123,14 @@
       "website": "https://www.formigal-panticosa.com/"
     },
     {
+      "id": "åre",
+      "name": "Åre",
+      "openskimap_id": "4968c991f3910142689f5f0d2fabee02df54e214",
+      "platform": "skistar",
+      "url": "https://www.skistar.com/en/ski-destinations/are/winter-in-are/weather-and-slopes/",
+      "website": "https://www.skistar.com/en/ski-destinations/are/"
+    },
+    {
       "id": "area-sciistica-abetone",
       "name": "Area Sciistica Abetone",
       "openskimap_id": "ffc04590f75f3e275d90108cc0984829ee429dda",
@@ -129,13 +139,21 @@
       "website": "https://multipassabetone.it/"
     },
     {
+      "id": "arêches-beaufort",
+      "name": "Arêches Beaufort",
+      "openskimap_id": "d19b617dc3a4c9a07b0f8b3360f7f5a20d384a48",
+      "platform": "custom",
+      "url": "https://www.areches-beaufort.com/en/lift-status",
+      "website": "https://www.areches-beaufort.com"
+    },
+    {
       "id": "arosa-lenzerheide",
       "name": "Arosa Lenzerheide",
       "openskimap_id": "4ae9b0cba5454d6f0921bf413c33a267f1d63cca",
-      "platform": "custom",
-      "url": "https://arosalenzerheide.swiss/en/Ski-Area/Lift-Company/Operating-hours-winter",
+      "platform": "arosa",
+      "url": "https://arosalenzerheide.swiss/en/Arosa/Up-to-date/Winter-sports-report",
       "liftieId": null,
-      "notes": "Custom extraction needed"
+      "notes": "Swiss resort with Vue.js SPA"
     },
     {
       "id": "artesina",
@@ -144,14 +162,6 @@
       "platform": "custom",
       "url": "https://www.frabosaski.it/en/lift-status",
       "website": "https://www.frabosaski.it/"
-    },
-    {
-      "id": "arêches-beaufort",
-      "name": "Arêches Beaufort",
-      "openskimap_id": "d19b617dc3a4c9a07b0f8b3360f7f5a20d384a48",
-      "platform": "custom",
-      "url": "https://www.areches-beaufort.com/en/lift-status",
-      "website": "https://www.areches-beaufort.com"
     },
     {
       "id": "aspen-snowmass",
@@ -283,6 +293,14 @@
       "website": "https://www.bigwhite.com/"
     },
     {
+      "id": "bláfjöll",
+      "name": "Bláfjöll",
+      "openskimap_id": "02afb35f5d4315ae5ff1abcef85259463632463c",
+      "platform": "custom",
+      "url": "https://skidasvaedi.is/en/lift-status",
+      "website": "https://skidasvaedi.is/"
+    },
+    {
       "id": "blue-mountain-resort",
       "name": "Blue Mountain Resort",
       "openskimap_id": "b80dd18fc32df44f83dad7576cdbb0316286ef66",
@@ -299,12 +317,12 @@
       "website": "https://www.bluemountain.ca"
     },
     {
-      "id": "bláfjöll",
-      "name": "Bláfjöll",
-      "openskimap_id": "02afb35f5d4315ae5ff1abcef85259463632463c",
+      "id": "bödele",
+      "name": "Bödele",
+      "openskimap_id": "ad2faceffa44fe6c1a3149d02c89759a7145af52",
       "platform": "custom",
-      "url": "https://skidasvaedi.is/en/lift-status",
-      "website": "https://skidasvaedi.is/"
+      "url": "https://www.boedele.info/en/lift-status",
+      "website": "https://www.boedele.info/"
     },
     {
       "id": "bogus-basin",
@@ -339,20 +357,20 @@
       "website": "https://www.borovets-bg.com/"
     },
     {
-      "id": "brandnertal-brandbürserberg",
-      "name": "Brandnertal – Brand/​Bürserberg",
-      "openskimap_id": "b006b322d1e68bc5d77d0758fb19d16d76e04a37",
-      "platform": "custom",
-      "url": "https://www.vorarlberg-alpenregion.at/en/brandnertal/holiday-in-winter-in-brandertal.html/en/lift-status",
-      "website": "https://www.vorarlberg-alpenregion.at/en/brandnertal/holiday-in-winter-in-brandertal.html"
-    },
-    {
       "id": "branäs",
       "name": "Branäs",
       "openskimap_id": "dc38c005346ecf95ae82d52334753ff6b594784b",
       "platform": "custom",
       "url": "https://www.branas.se/weather-and-slopes/",
       "website": "https://www.branas.se/?nr=1"
+    },
+    {
+      "id": "brandnertal-brandbürserberg",
+      "name": "Brandnertal – Brand/​Bürserberg",
+      "openskimap_id": "b006b322d1e68bc5d77d0758fb19d16d76e04a37",
+      "platform": "custom",
+      "url": "https://www.vorarlberg-alpenregion.at/en/brandnertal/holiday-in-winter-in-brandertal.html/en/lift-status",
+      "website": "https://www.vorarlberg-alpenregion.at/en/brandnertal/holiday-in-winter-in-brandertal.html"
     },
     {
       "id": "brauneck",
@@ -388,6 +406,16 @@
       "website": "https://www.brentonicoski.com"
     },
     {
+      "id": "chamonix",
+      "name": "Brévent/Flégère (Chamonix)",
+      "openskimap_id": "8432e3c536835ef8a690f63b62060a7993bfd964",
+      "platform": "lumiplan",
+      "url": "https://www.chamonix.com",
+      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=chamonix&region=alpes&pays=france&lang=en",
+      "liftieId": "chamonix",
+      "notes": "Uses Lumiplan bulletin"
+    },
+    {
       "id": "brigels-waltensburg-andiast-brigels-waltenburg-and",
       "name": "Brigels-Waltensburg-Andiast, Brigels-Waltenburg-Andiast, Breil-Vuorz-Andiast",
       "openskimap_id": "2826e74d5f33a0bd943b7353dcda7e1419c36ace",
@@ -404,16 +432,6 @@
       "website": "https://www.bromontmontagne.com/"
     },
     {
-      "id": "chamonix",
-      "name": "Brévent/Flégère (Chamonix)",
-      "openskimap_id": "8432e3c536835ef8a690f63b62060a7993bfd964",
-      "platform": "lumiplan",
-      "url": "https://www.chamonix.com",
-      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=chamonix&region=alpes&pays=france&lang=en",
-      "liftieId": "chamonix",
-      "notes": "Uses Lumiplan bulletin"
-    },
-    {
       "id": "buck-hill",
       "name": "Buck Hill",
       "openskimap_id": "5b1ffa98c849d075c0581f57b5a4bab21b94e468",
@@ -428,14 +446,6 @@
       "platform": "custom",
       "url": "https://www.fassa.com/",
       "website": "https://www.fassa.com/ https://www.fassa.it/"
-    },
-    {
-      "id": "bödele",
-      "name": "Bödele",
-      "openskimap_id": "ad2faceffa44fe6c1a3149d02c89759a7145af52",
-      "platform": "custom",
-      "url": "https://www.boedele.info/en/lift-status",
-      "website": "https://www.boedele.info/"
     },
     {
       "id": "cairngorm-aviemore",
@@ -550,6 +560,14 @@
       "website": "http://www.laspendientes.com/ https://www.cerrochapelco.com.ar/"
     },
     {
+      "id": "chäserrug-alt-st-johann",
+      "name": "Chäserrug-Alt St. Johann",
+      "openskimap_id": "2b04168ef9b209ad4cd6b13f80f42eb7e9a652d5",
+      "platform": "custom",
+      "url": "https://www.chaeserrugg.ch/en/lift-status",
+      "website": "https://www.chaeserrugg.ch/"
+    },
+    {
       "id": "china-peak-mountain-resort",
       "name": "China Peak Mountain Resort",
       "openskimap_id": "9e118f4eb36fb34e987c7a3ddd7f2d976b6a7443",
@@ -564,14 +582,6 @@
       "platform": "custom",
       "url": "https://www.jasna.sk/en/lift-status",
       "website": "https://www.jasna.sk/"
-    },
-    {
-      "id": "chäserrug-alt-st-johann",
-      "name": "Chäserrug-Alt St. Johann",
-      "openskimap_id": "2b04168ef9b209ad4cd6b13f80f42eb7e9a652d5",
-      "platform": "custom",
-      "url": "https://www.chaeserrugg.ch/en/lift-status",
-      "website": "https://www.chaeserrugg.ch/"
     },
     {
       "id": "cimetta",
@@ -590,14 +600,6 @@
       "website": "https://www.coppercolorado.com/"
     },
     {
-      "id": "cortina-tofane",
-      "name": "Cortina Tofane",
-      "openskimap_id": "9838fb2aa78f10391ff5a3bf3e85105c0f8b73e6",
-      "platform": "custom",
-      "url": "https://www.impianticortina.it/en/lift-status",
-      "website": "https://www.impianticortina.it/"
-    },
-    {
       "id": "cortina",
       "name": "Cortina d'Ampezzo",
       "openskimap_id": "9a8be208c4f1832db8bf13c7102e2dcc3eef0a84",
@@ -605,6 +607,14 @@
       "url": "https://www.dolomitisuperski.com/en/live-info/lifts/cortina-d-ampezzo",
       "liftieId": "cortina-d-ampezzo",
       "notes": "Dolomiti Superski"
+    },
+    {
+      "id": "cortina-tofane",
+      "name": "Cortina Tofane",
+      "openskimap_id": "9838fb2aa78f10391ff5a3bf3e85105c0f8b73e6",
+      "platform": "custom",
+      "url": "https://www.impianticortina.it/en/lift-status",
+      "website": "https://www.impianticortina.it/"
     },
     {
       "id": "corvatsch-furtschellas",
@@ -673,6 +683,14 @@
       "website": "https://www.deervalley.com/"
     },
     {
+      "id": "dévoluy",
+      "name": "Dévoluy",
+      "openskimap_id": "8e5dbdde0808be45e5e47253e905635c9f867c3b",
+      "platform": "custom",
+      "url": "https://www.ledevoluy.com/en/lift-status",
+      "website": "https://www.ledevoluy.com/"
+    },
+    {
       "id": "dodge-ridge-ski-area",
       "name": "Dodge Ridge Ski Area",
       "openskimap_id": "162525ff9a2a65810a602b74f338303d1bb9ea38",
@@ -711,14 +729,6 @@
       "platform": "custom",
       "url": "https://www.parksnow.sk/zima/en/lift-status",
       "website": "https://www.parksnow.sk/zima/"
-    },
-    {
-      "id": "dévoluy",
-      "name": "Dévoluy",
-      "openskimap_id": "8e5dbdde0808be45e5e47253e905635c9f867c3b",
-      "platform": "custom",
-      "url": "https://www.ledevoluy.com/en/lift-status",
-      "website": "https://www.ledevoluy.com/"
     },
     {
       "id": "el-colorado",
@@ -768,9 +778,10 @@
       "id": "espace-lumière",
       "name": "Espace Lumière",
       "openskimap_id": "e7c4c03bd7f9a3d907ff566775cfba1823bcf2ae",
-      "platform": "custom",
-      "url": "https://www.praloup.com/en/live-info",
-      "website": "https://www.praloup.com/"
+      "platform": "skiplan",
+      "url": "https://en.valdallos.com/ouverture-des-pistes.html",
+      "website": "https://www.praloup.com/",
+      "notes": "Val d'Allos uses SkiPlan by Ingenie"
     },
     {
       "id": "estació-desquí-baqueira-beret",
@@ -789,20 +800,20 @@
       "website": "https://www.portdelcomte.net/"
     },
     {
-      "id": "estación-de-esquí-y-montaña-de-sierra-nevada",
-      "name": "Estación de Esquí y Montaña de Sierra Nevada",
-      "openskimap_id": "dc3f198b305b2f8ec1db8b15a47548900646d93d",
-      "platform": "custom",
-      "url": "https://sierranevada.es/en/lift-status",
-      "website": "https://sierranevada.es"
-    },
-    {
       "id": "estación-de-esquí-de-valdesquí",
       "name": "Estación de esquí de Valdesquí",
       "openskimap_id": "a6792c241300dee70b989ffcf6a12b8225bbd7d9",
       "platform": "custom",
       "url": "https://www.valdesqui.es/en/lift-status",
       "website": "https://www.valdesqui.es/"
+    },
+    {
+      "id": "estación-de-esquí-y-montaña-de-sierra-nevada",
+      "name": "Estación de Esquí y Montaña de Sierra Nevada",
+      "openskimap_id": "dc3f198b305b2f8ec1db8b15a47548900646d93d",
+      "platform": "custom",
+      "url": "https://sierranevada.es/en/lift-status",
+      "website": "https://sierranevada.es"
     },
     {
       "id": "falls-creek",
@@ -869,6 +880,15 @@
       "website": "https://font-romeu.fr/"
     },
     {
+      "id": "forêt-blanche-varsrisoul",
+      "name": "Forêt Blanche : Vars/Risoul",
+      "openskimap_id": "9d0b2c5e0fcac9deba9c727a834cac4b43a5d2c9",
+      "platform": "vars",
+      "url": "https://www.vars.com/winter/on-site-activities/skiing-and-snowboarding/the-ski-area/snow-bulletin/",
+      "website": "https://www.vars.com/hiver/",
+      "notes": "Vars/Risoul snow bulletin"
+    },
+    {
       "id": "formigal",
       "name": "Formigal",
       "openskimap_id": "0f46917975b8dab5e541edf6469105c3c091ec22",
@@ -877,20 +897,20 @@
       "website": "https://www.formigal-panticosa.com/"
     },
     {
-      "id": "forêt-blanche-varsrisoul",
-      "name": "Forêt Blanche : Vars/Risoul",
-      "openskimap_id": "9d0b2c5e0fcac9deba9c727a834cac4b43a5d2c9",
-      "platform": "custom",
-      "url": "https://www.vars.com/en/live-info",
-      "website": "https://www.vars.com/hiver/"
-    },
-    {
       "id": "gausta-skisenter",
       "name": "Gausta skisenter",
       "openskimap_id": "4d69a850bfa3eeaf928e5d154bb6768fcfbe240e",
       "platform": "custom",
       "url": "https://www.gausta.com/en-US/gausta-skisenter/en/lift-status",
       "website": "https://www.gausta.com/en-US/gausta-skisenter/"
+    },
+    {
+      "id": "gérardmer",
+      "name": "Gérardmer",
+      "openskimap_id": "7ccf68e28c0dfb0a0d21e0ad24260a5775c63263",
+      "platform": "custom",
+      "url": "https://www.gerardmer-ski.com/en/lift-status",
+      "website": "https://www.gerardmer-ski.com/"
     },
     {
       "id": "gitschberg-jochtal-rio-pusteria",
@@ -920,9 +940,10 @@
       "id": "gletscher-skigebiet-zugspitze-ski-resort-zugspitze",
       "name": "Gletscher-Skigebiet Zugspitze, Ski resort Zugspitze",
       "openskimap_id": "9e8a091097aeb5af7c87b5f53922e3db043a9849",
-      "platform": "custom",
-      "url": "https://zugspitze.de/de/winter/skigebiet/zugspitze/en/lift-status",
-      "website": "https://zugspitze.de/de/winter/skigebiet/zugspitze"
+      "platform": "zugspitze",
+      "url": "https://zugspitze.de/en/Service-information/Facilities",
+      "website": "https://zugspitze.de/de/winter/skigebiet/zugspitze",
+      "notes": "German resort with React-based structured list"
     },
     {
       "id": "gourette",
@@ -931,6 +952,14 @@
       "platform": "custom",
       "url": "https://www.gourette.com/en/lift-status",
       "website": "https://www.gourette.com/"
+    },
+    {
+      "id": "grächen",
+      "name": "Grächen",
+      "openskimap_id": "9ea685d2404d5268c6cb02acbda87feb44cb0db4",
+      "platform": "custom",
+      "url": "https://www.graechen.ch/en/lift-status",
+      "website": "https://www.graechen.ch/"
     },
     {
       "id": "grand-tourmalet",
@@ -944,10 +973,10 @@
       "id": "grandvalira",
       "name": "GrandValira",
       "openskimap_id": "de4f884c40976fe9d18c23d0bab174c1d6b79218",
-      "platform": "custom",
-      "url": "https://www.grandvalira.com/en/ski-resort/pistes-and-facilities",
+      "platform": "grandvalira",
+      "url": "https://www.grandvalira.com/en/resort/open-slopes",
       "liftieId": null,
-      "notes": "Andorra - custom extraction needed"
+      "notes": "Drupal CMS with embedded JSON state"
     },
     {
       "id": "grindelwald-wengen-kleine-scheidegg-männlichen",
@@ -982,28 +1011,12 @@
       "website": "https://www.grosseck-speiereck.at/"
     },
     {
-      "id": "grächen",
-      "name": "Grächen",
-      "openskimap_id": "9ea685d2404d5268c6cb02acbda87feb44cb0db4",
-      "platform": "custom",
-      "url": "https://www.graechen.ch/en/lift-status",
-      "website": "https://www.graechen.ch/"
-    },
-    {
       "id": "guzet-neige",
       "name": "Guzet-Neige",
       "openskimap_id": "c8f66e784133d6becb1aba654e27b446daa7af7b",
       "platform": "custom",
       "url": "https://www.guzet.ski/en/lift-status",
       "website": "https://www.guzet.ski/"
-    },
-    {
-      "id": "gérardmer",
-      "name": "Gérardmer",
-      "openskimap_id": "7ccf68e28c0dfb0a0d21e0ad24260a5775c63263",
-      "platform": "custom",
-      "url": "https://www.gerardmer-ski.com/en/lift-status",
-      "website": "https://www.gerardmer-ski.com/"
     },
     {
       "id": "hafjell",
@@ -1142,6 +1155,14 @@
       "website": "https://skiresort.cz/"
     },
     {
+      "id": "järvsöbacken",
+      "name": "JärvsöBacken",
+      "openskimap_id": "0d8095d2249278e20f76c6919b2003b51c7d71b2",
+      "platform": "custom",
+      "url": "https://www.jarvsobacken.se/english-information/en/lift-status",
+      "website": "https://www.jarvsobacken.se/english-information/"
+    },
+    {
       "id": "jasna-low-tatras",
       "name": "Jasna Low Tatras",
       "openskimap_id": "143a22b6dca9119510a125afff37672952de837e",
@@ -1156,14 +1177,6 @@
       "platform": "custom",
       "url": "https://www.jaworzynakrynicka.pl/en/lift-status",
       "website": "https://www.jaworzynakrynicka.pl/"
-    },
-    {
-      "id": "järvsöbacken",
-      "name": "JärvsöBacken",
-      "openskimap_id": "0d8095d2249278e20f76c6919b2003b51c7d71b2",
-      "platform": "custom",
-      "url": "https://www.jarvsobacken.se/english-information/en/lift-status",
-      "website": "https://www.jarvsobacken.se/english-information/"
     },
     {
       "id": "kals-matrei",
@@ -1247,6 +1260,14 @@
       "notes": "Kitzbühel (liftie pattern)"
     },
     {
+      "id": "kläppen",
+      "name": "Kläppen",
+      "openskimap_id": "41ab128ddaa817aee0126dd981df00095dc57e60",
+      "platform": "custom",
+      "url": "https://www.klappen.se/en/lift-status",
+      "website": "https://www.klappen.se/"
+    },
+    {
       "id": "klausberg-skiarena",
       "name": "Klausberg Skiarena",
       "openskimap_id": "8ed98940b7c222930ed16efefbb13b42e5840a02",
@@ -1261,14 +1282,6 @@
       "platform": "custom",
       "url": "https://www.klewenalp.ch/en/lift-status",
       "website": "https://www.klewenalp.ch/"
-    },
-    {
-      "id": "kläppen",
-      "name": "Kläppen",
-      "openskimap_id": "41ab128ddaa817aee0126dd981df00095dc57e60",
-      "platform": "custom",
-      "url": "https://www.klappen.se/en/lift-status",
-      "website": "https://www.klappen.se/"
     },
     {
       "id": "kompleks-pilsko-jontek",
@@ -1327,20 +1340,20 @@
       "website": "https://www.rtc-krvavec.si/"
     },
     {
-      "id": "kungsberget",
-      "name": "Kungsberget",
-      "openskimap_id": "1bc8063b148904e54cdd1357ba34f2211ceef2b8",
-      "platform": "custom",
-      "url": "https://www.kungsberget.se/en/?nr=1/en/lift-status",
-      "website": "https://www.kungsberget.se/en/?nr=1"
-    },
-    {
       "id": "kühtai",
       "name": "Kühtai",
       "openskimap_id": "204bd8a606de9419155c825f8ba5ecd46345e23a",
       "platform": "custom",
       "url": "https://www.kuehtai.info/en/winter/ski-area.html/en/lift-status",
       "website": "https://www.kuehtai.info/en/winter/ski-area.html"
+    },
+    {
+      "id": "kungsberget",
+      "name": "Kungsberget",
+      "openskimap_id": "1bc8063b148904e54cdd1357ba34f2211ceef2b8",
+      "platform": "custom",
+      "url": "https://www.kungsberget.se/en/?nr=1/en/lift-status",
+      "website": "https://www.kungsberget.se/en/?nr=1"
     },
     {
       "id": "lalpe-du-grand-serre",
@@ -1470,9 +1483,11 @@
       "id": "le-grand-domaine",
       "name": "Le Grand Domaine",
       "openskimap_id": "f5fcc0e543cfb0e4d50280c286081c27d975697f",
-      "platform": "custom",
-      "url": "https://www.snowplaza.co.uk/france/le-grand-domaine/snow-report/",
-      "website": "https://www.legranddomaine.fr/"
+      "platform": "lumiplan",
+      "url": "https://skipass.valmorel.com/en/",
+      "website": "https://www.legranddomaine.fr/",
+      "lumiplanMapId": "valmorel",
+      "notes": "Le Grand Domaine - try Lumiplan integration"
     },
     {
       "id": "le-grand-massif",
@@ -1546,9 +1561,10 @@
       "id": "les-deux-alpes",
       "name": "Les Deux Alpes",
       "openskimap_id": "5bd589496339e89cf9be3d93c86e7e6c41f72208",
-      "platform": "custom",
+      "platform": "seelift",
       "url": "https://www.see2alpes.com/lifts/status",
-      "website": "https://www.les2alpes.com"
+      "website": "https://www.les2alpes.com",
+      "notes": "See* network - Les 2 Alpes"
     },
     {
       "id": "les-gets-morzine",
@@ -1706,10 +1722,10 @@
       "id": "mayrhofen",
       "name": "Mayrhofen Hippach",
       "openskimap_id": "f967615083aaed557fa47068b9d894e66d763f0a",
-      "platform": "custom",
+      "platform": "mayrhofen",
       "url": "https://www.mayrhofen.at/en/stories/open-cable-cars-mayrhofner-bergbahnen-winter",
       "liftieId": null,
-      "notes": "Austria - custom extraction needed"
+      "notes": "Austrian resort - may need custom extractor"
     },
     {
       "id": "megeve",
@@ -1736,6 +1752,16 @@
       "platform": "custom",
       "url": "https://www.meran2000.com/en/lift-status",
       "website": "https://www.meran2000.com/"
+    },
+    {
+      "id": "meribel",
+      "name": "Méribel - 3 Vallées",
+      "openskimap_id": "68b126bc3175516c9263aed7635d14e37ff360dc",
+      "platform": "lumiplan",
+      "url": "https://meribel.net",
+      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=meribel&region=alpes&pays=france&lang=en",
+      "liftieId": "meribel",
+      "notes": "Uses Lumiplan bulletin"
     },
     {
       "id": "mont-tremblant-resort-station-mont-tremblant",
@@ -1840,16 +1866,6 @@
       "platform": "custom",
       "url": "https://www.mdysresort.com/en/lift-status",
       "website": "https://www.mdysresort.com/"
-    },
-    {
-      "id": "meribel",
-      "name": "Méribel - 3 Vallées",
-      "openskimap_id": "68b126bc3175516c9263aed7635d14e37ff360dc",
-      "platform": "lumiplan",
-      "url": "https://meribel.net",
-      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=meribel&region=alpes&pays=france&lang=en",
-      "liftieId": "meribel",
-      "notes": "Uses Lumiplan bulletin"
     },
     {
       "id": "mürrenschilthorn",
@@ -1980,20 +1996,20 @@
       "website": "https://www.orsagronklitt.se"
     },
     {
-      "id": "ovindoli",
-      "name": "Ovindoli",
-      "openskimap_id": "99fc72000e2914274efb60d579cb7cacb1043bc3",
-      "platform": "custom",
-      "url": "https://www.ovindolimagnola.it/en/lift-status",
-      "website": "https://www.ovindolimagnola.it/"
-    },
-    {
       "id": "ośrodek-narciarski-kotelnica-białczańska-kotelnica",
       "name": "Ośrodek Narciarski Kotelnica Białczańska, Kotelnica Białczańska Ski Resort",
       "openskimap_id": "305ec2278ecc0503c3d92c9d101c61695c66d1b4",
       "platform": "custom",
       "url": "https://bialkatatrzanska.pl/en/lift-status",
       "website": "https://bialkatatrzanska.pl"
+    },
+    {
+      "id": "ovindoli",
+      "name": "Ovindoli",
+      "openskimap_id": "99fc72000e2914274efb60d579cb7cacb1043bc3",
+      "platform": "custom",
+      "url": "https://www.ovindolimagnola.it/en/lift-status",
+      "website": "https://www.ovindolimagnola.it/"
     },
     {
       "id": "paganella-area-sciistica-andalo-fai-della-paganell",
@@ -2042,6 +2058,15 @@
       "platform": "vail",
       "url": "https://www.parkcitymountain.com/the-mountain/mountain-conditions/terrain-and-lift-status.aspx",
       "website": "https://parkcitymountain.com"
+    },
+    {
+      "id": "parsenn-davos-klosters",
+      "name": "Parsenn (Davos Klosters)",
+      "openskimap_id": "403c8d67ddd348bfa3f7d02c6c21163479964926",
+      "platform": "davos",
+      "url": "https://www.davos.ch/en/discover/mountains/winter-sports-report/lifts-and-piste-report",
+      "website": "https://www.davosklostersmountains.ch/",
+      "notes": "Vue.js SPA - fetches data via API"
     },
     {
       "id": "perfect-north-slopes",
@@ -2460,9 +2485,10 @@
       "id": "silvretta-montafon",
       "name": "Silvretta Montafon",
       "openskimap_id": "f654467c75bb645ac3a8e664b656d00b2e90ef2e",
-      "platform": "custom",
-      "url": "https://www.silvretta-montafon.at/en/live",
-      "website": "https://www.silvretta-montafon.at"
+      "platform": "montafon",
+      "url": "https://www.silvretta-montafon.at/en/info-service/lift-info",
+      "website": "https://www.silvretta-montafon.at",
+      "notes": "Silvretta Montafon with live info page"
     },
     {
       "id": "sirdal-skisenter",
@@ -2537,21 +2563,20 @@
       "website": "https://skijuwel.com"
     },
     {
-      "id": "skiwelt",
-      "name": "SkiWelt Wilder Kaiser - Brixental",
-      "openskimap_id": "37ee9c6ba5b44864ba844f804938a8b815f8b717",
-      "platform": "skiwelt",
-      "url": "https://www.skiwelt.at/en/lift-status-winter.html",
-      "liftieId": "skiwelt",
-      "notes": "Austria (liftie pattern)"
-    },
-    {
       "id": "skiarea-valchiavenna-madesimocampodolcino",
       "name": "Skiarea Valchiavenna Madesimo/Campodolcino",
       "openskimap_id": "3fe9a6b2c3b2fddc054259af7b561d7d91f7b9f0",
       "platform": "custom",
       "url": "https://www.skiareavalchiavenna.it/en/lift-status",
       "website": "https://www.skiareavalchiavenna.it/"
+    },
+    {
+      "id": "skiareál-klínovec",
+      "name": "Skiareál Klínovec",
+      "openskimap_id": "3d64e85db09d580e3ac612574f3c4bf4298e54ba",
+      "platform": "custom",
+      "url": "http://skiarealbozidar.cz/en/homepage-en/",
+      "website": "http://skiarealbozidar.cz/en/homepage-en/ https://klinovec.cz/"
     },
     {
       "id": "skiarena",
@@ -2570,21 +2595,13 @@
       "website": "http://www.imbergbahn.de/"
     },
     {
-      "id": "skiareál-klínovec",
-      "name": "Skiareál Klínovec",
-      "openskimap_id": "3d64e85db09d580e3ac612574f3c4bf4298e54ba",
-      "platform": "custom",
-      "url": "http://skiarealbozidar.cz/en/homepage-en/",
-      "website": "http://skiarealbozidar.cz/en/homepage-en/ https://klinovec.cz/"
-    },
-    {
       "id": "saalbach",
       "name": "Skicircus Saalbach-Hinterglemm Leogang Fieberbrunn",
       "openskimap_id": "5b78e5652d097c7679cef7128ee1b57ff09fb86e",
-      "platform": "custom",
-      "url": "https://www.saalbach.com/en/live-info/lifts-and-pistes",
+      "platform": "saalbach",
+      "url": "https://www.fieberbrunn.com/liftoperation",
       "liftieId": null,
-      "notes": "Austria - custom extraction"
+      "notes": "Skicircus uses Bootstrap table with lift categories"
     },
     {
       "id": "skigebiet-almenwelt-lofer",
@@ -2718,18 +2735,28 @@
       "id": "cerna-hora-pec",
       "name": "Skiresort Černá Hora-Pec",
       "openskimap_id": "583dbc4651db7ebcc7875a11180b634ec108ba8a",
-      "platform": "custom",
-      "url": "https://www.skiresort.cz/en/skiarealy/cerna-hora/ch-lanovky-a-vleky/",
+      "platform": "skiresortcz",
+      "url": "https://www.skiresort.cz/en/skiarealy/pec-pod-snezkou/pec-lanovky-a-vleky/",
       "liftieId": null,
-      "notes": "Czech Republic - custom extraction"
+      "notes": "Czech resort with table-based HTML"
+    },
+    {
+      "id": "skiwelt",
+      "name": "SkiWelt Wilder Kaiser - Brixental",
+      "openskimap_id": "37ee9c6ba5b44864ba844f804938a8b815f8b717",
+      "platform": "skiwelt",
+      "url": "https://www.skiwelt.at/en/lift-status-winter.html",
+      "liftieId": "skiwelt",
+      "notes": "Austria (liftie pattern)"
     },
     {
       "id": "snow-space-salzburg",
       "name": "Snow Space Salzburg",
       "openskimap_id": "b57f20e0c7ea594ef8ec8289fd87022b36417629",
-      "platform": "custom",
-      "url": "https://www.snow-space.com/en/lift-status",
-      "website": "https://www.snow-space.com/"
+      "platform": "snowspace",
+      "url": "https://www.snow-space.com/openlifts",
+      "website": "https://www.snow-space.com/",
+      "notes": "Snow Space Salzburg - Bootstrap with dynamic loading"
     },
     {
       "id": "snow-summit",
@@ -2764,6 +2791,14 @@
       "website": "https://www.snowbird.com/"
     },
     {
+      "id": "sölden",
+      "name": "Sölden",
+      "openskimap_id": "78e5f98d8527df7216b08962f372659abcd4f711",
+      "platform": "soelden",
+      "url": "https://www.soelden.com/en/live-information/status",
+      "website": "https://www.soelden.com/"
+    },
+    {
       "id": "sommet-saint-sauveur",
       "name": "Sommet Saint-Sauveur",
       "openskimap_id": "78ac27731bb078db310933e9828665ca59858de2",
@@ -2780,6 +2815,14 @@
       "website": "https://www.sonnenkopf.com/"
     },
     {
+      "id": "sörenberg",
+      "name": "Sörenberg",
+      "openskimap_id": "6fc2b7bd9404c7cf68e49ca9fd83600e3de149d4",
+      "platform": "custom",
+      "url": "https://www.soerenberg.ch/en/lift-status",
+      "website": "https://www.soerenberg.ch"
+    },
+    {
       "id": "spieljoch-fügen",
       "name": "Spieljoch - Fügen",
       "openskimap_id": "f5332cdc7d54f27d5cfeb3d3d1bb0d1f8b4b660e",
@@ -2794,6 +2837,15 @@
       "platform": "custom",
       "url": "https://www.bergbahnen-stjohann.at/en/lift-status",
       "website": "https://www.bergbahnen-stjohann.at/"
+    },
+    {
+      "id": "st-anton-st-christoph-stuben",
+      "name": "St. Anton / St. Christoph / Stuben",
+      "openskimap_id": "66e672470add74c3e6a2bd8d4c1bb07cc4721728",
+      "platform": "skiarlberg",
+      "url": "https://www.skiarlberg.at/en/st-anton/live-info/cable-cars-lifts",
+      "website": "https://www.stantonamarlberg.com/",
+      "notes": "Uses Ski Arlberg table format with aria-label status"
     },
     {
       "id": "station-de-ski-de-prat-peyrot",
@@ -2836,6 +2888,14 @@
       "website": "http://www.morschach-stoos.ch"
     },
     {
+      "id": "stöten-i-sälen",
+      "name": "Stöten i Sälen",
+      "openskimap_id": "31297131594299a446bc94ebea4e1b9d48f1be2a",
+      "platform": "custom",
+      "url": "https://www.stoten.se/en/lift-status",
+      "website": "https://www.stoten.se/"
+    },
+    {
       "id": "stowe-mountain-resort",
       "name": "Stowe Mountain Resort",
       "openskimap_id": "f511535c529ee4710b2165d57a2370731c890ca7",
@@ -2866,14 +2926,6 @@
       "platform": "custom",
       "url": "https://www.stubaier-gletscher.com/en/lift-status",
       "website": "https://www.stubaier-gletscher.com/"
-    },
-    {
-      "id": "stöten-i-sälen",
-      "name": "Stöten i Sälen",
-      "openskimap_id": "31297131594299a446bc94ebea4e1b9d48f1be2a",
-      "platform": "custom",
-      "url": "https://www.stoten.se/en/lift-status",
-      "website": "https://www.stoten.se/"
     },
     {
       "id": "sudelfeld-bayrischzell",
@@ -2980,22 +3032,6 @@
       "website": "http://www.luchon-superbagneres.com/"
     },
     {
-      "id": "sölden",
-      "name": "Sölden",
-      "openskimap_id": "78e5f98d8527df7216b08962f372659abcd4f711",
-      "platform": "soelden",
-      "url": "https://www.soelden.com/en/live-information/status",
-      "website": "https://www.soelden.com/"
-    },
-    {
-      "id": "sörenberg",
-      "name": "Sörenberg",
-      "openskimap_id": "6fc2b7bd9404c7cf68e49ca9fd83600e3de149d4",
-      "platform": "custom",
-      "url": "https://www.soerenberg.ch/en/lift-status",
-      "website": "https://www.soerenberg.ch"
-    },
-    {
       "id": "tahko",
       "name": "Tahko",
       "openskimap_id": "6d3a6779aeccfa475be6c0a5f9b52f427d64c037",
@@ -3010,6 +3046,14 @@
       "platform": "custom",
       "url": "https://www.skistar.com/en/ski-destinations/salen/en/lift-status",
       "website": "https://www.skistar.com/en/ski-destinations/salen"
+    },
+    {
+      "id": "tänndalen",
+      "name": "Tänndalen",
+      "openskimap_id": "27892035f6676422fecf162968cf2f39486245eb",
+      "platform": "custom",
+      "url": "https://www.tanndalen.com/en/lift-status",
+      "website": "https://www.tanndalen.com/"
     },
     {
       "id": "taos-ski-valley",
@@ -3086,14 +3130,6 @@
       "website": "https://www.turracherhoehe.at/"
     },
     {
-      "id": "tänndalen",
-      "name": "Tänndalen",
-      "openskimap_id": "27892035f6676422fecf162968cf2f39486245eb",
-      "platform": "custom",
-      "url": "https://www.tanndalen.com/en/lift-status",
-      "website": "https://www.tanndalen.com/"
-    },
-    {
       "id": "vail",
       "name": "Vail",
       "openskimap_id": "ce9e507474fc78e61f5eb00985c79c4ab5148599",
@@ -3108,6 +3144,24 @@
       "platform": "custom",
       "url": "https://www.valcenis.com/en/live-info",
       "website": "https://www.valcenis.com"
+    },
+    {
+      "id": "val-dallos-la-foux",
+      "name": "Val d'Allos - La Foux",
+      "openskimap_id": "05ec7627488328fb30e0d502b021045a348af622",
+      "platform": "custom",
+      "url": "https://www.valdallos.com/en/lift-status",
+      "website": "https://www.valdallos.com/"
+    },
+    {
+      "id": "val-disere",
+      "name": "Val d'Isère",
+      "openskimap_id": "6ed5f25f0eb3e366ee2e0e667d998c0bf551225f",
+      "platform": "lumiplan",
+      "url": "https://valdisere.com",
+      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=valdisere&region=alpes&pays=france&lang=en",
+      "liftieId": "valdisere",
+      "notes": "Uses Lumiplan bulletin (same domain as Tignes)"
     },
     {
       "id": "val-gardena",
@@ -3135,24 +3189,6 @@
       "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=valthorens&region=alpes&pays=france&lang=en",
       "liftieId": null,
       "notes": "Uses Lumiplan bulletin"
-    },
-    {
-      "id": "val-dallos-la-foux",
-      "name": "Val d'Allos - La Foux",
-      "openskimap_id": "05ec7627488328fb30e0d502b021045a348af622",
-      "platform": "custom",
-      "url": "https://www.valdallos.com/en/lift-status",
-      "website": "https://www.valdallos.com/"
-    },
-    {
-      "id": "val-disere",
-      "name": "Val d'Isère",
-      "openskimap_id": "6ed5f25f0eb3e366ee2e0e667d998c0bf551225f",
-      "platform": "lumiplan",
-      "url": "https://valdisere.com",
-      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=valdisere&region=alpes&pays=france&lang=en",
-      "liftieId": "valdisere",
-      "notes": "Uses Lumiplan bulletin (same domain as Tignes)"
     },
     {
       "id": "valle-nevado",
@@ -3230,9 +3266,10 @@
       "id": "wendelstein",
       "name": "Wendelstein",
       "openskimap_id": "d7f0152ded3f23d4e4cf3ad4571f131ec267ab40",
-      "platform": "custom",
-      "url": "https://www.wendelsteinbahn.de/en/weather",
-      "website": "https://www.wendelsteinbahn.de/"
+      "platform": "wendelstein",
+      "url": "https://www.wendelsteinbahn.de/skigebiet-wendelstein-2",
+      "website": "https://www.wendelsteinbahn.de/",
+      "notes": "German resort with daily status updates"
     },
     {
       "id": "whakapapa",
@@ -3371,10 +3408,10 @@
       "id": "zillertal-arena",
       "name": "Zillertal Arena",
       "openskimap_id": "4a041686ec032469cd3d58aaaf73ed9864e4a173",
-      "platform": "custom",
-      "url": "https://www.zillertalarena.com/en/information-services/live-cams-weather/snow-report/",
+      "platform": "zillertal",
+      "url": "https://www.zillertalarena.com/en/winter/ski-area/lifts-slopes/",
       "liftieId": null,
-      "notes": "Austria - custom extraction"
+      "notes": "Austrian resort - table or API based"
     },
     {
       "id": "zinal-grimentz",
@@ -3391,14 +3428,6 @@
       "platform": "custom",
       "url": "https://www.turismofvg.it/en/mountain365/ski-area-ravascletto-zoncolan/en/lift-status",
       "website": "https://www.turismofvg.it/en/mountain365/ski-area-ravascletto-zoncolan"
-    },
-    {
-      "id": "åre",
-      "name": "Åre",
-      "openskimap_id": "4968c991f3910142689f5f0d2fabee02df54e214",
-      "platform": "skistar",
-      "url": "https://www.skistar.com/en/ski-destinations/are/winter-in-are/weather-and-slopes/",
-      "website": "https://www.skistar.com/en/ski-destinations/are/"
     },
     {
       "id": "χιονοδρομικό-κέντρο-παρνασσού-parnassos-ski-resort",
@@ -3489,14 +3518,6 @@
       "website": "https://www.sheregesh.su/"
     },
     {
-      "id": "پیست-اسکی-دیزین-dizin-ski-resort",
-      "name": "پیست اسکی دیزین, Dizin Ski Resort",
-      "openskimap_id": "0bcc31494b9b87b9cc66f9b5655dacc021c1d7b8",
-      "platform": "custom",
-      "url": "https://dizinskiresort.ir/en/lift-status",
-      "website": "https://dizinskiresort.ir/"
-    },
-    {
       "id": "გუდაური-gudauri-гудаури",
       "name": "გუდაური, Gudauri, Гудаури",
       "openskimap_id": "611c5f306d193965d569b1d45fd531b4b4a6e14b",
@@ -3505,12 +3526,12 @@
       "website": "https://mta.ski"
     },
     {
-      "id": "だいせんホワイトリゾート-daisen-white-resort",
-      "name": "だいせんホワイトリゾート, Daisen White Resort",
-      "openskimap_id": "18c3fba8fc39523a87ef5ae73ba37e372171062b",
+      "id": "پیست-اسکی-دیزین-dizin-ski-resort",
+      "name": "پیست اسکی دیزین, Dizin Ski Resort",
+      "openskimap_id": "0bcc31494b9b87b9cc66f9b5655dacc021c1d7b8",
       "platform": "custom",
-      "url": "https://www.daisen-resort.jp/en/lift-status",
-      "website": "https://www.daisen-resort.jp/"
+      "url": "https://dizinskiresort.ir/en/lift-status",
+      "website": "https://dizinskiresort.ir/"
     },
     {
       "id": "サッポロテイネ-sapporo-teine",
@@ -3519,6 +3540,14 @@
       "platform": "custom",
       "url": "https://sapporo-teine.com/snow/en/lift-status",
       "website": "https://sapporo-teine.com/snow/"
+    },
+    {
+      "id": "だいせんホワイトリゾート-daisen-white-resort",
+      "name": "だいせんホワイトリゾート, Daisen White Resort",
+      "openskimap_id": "18c3fba8fc39523a87ef5ae73ba37e372171062b",
+      "platform": "custom",
+      "url": "https://www.daisen-resort.jp/en/lift-status",
+      "website": "https://www.daisen-resort.jp/"
     },
     {
       "id": "ニセコユナイテッド-niseko-united",

--- a/src/ski_lift_status/configs/resorts.json
+++ b/src/ski_lift_status/configs/resorts.json
@@ -60,10 +60,11 @@
       "id": "alpe-dhuez",
       "name": "Alpe d'Huez Grand Domaine",
       "openskimap_id": "721dd142d0af653027c7569e1bd0799586bdefa1",
-      "platform": "seelift",
-      "url": "https://www.seealpedhuez.com/lifts/status",
+      "platform": "lumiplan",
+      "url": "https://www.alpedhuez.com/en/winter/open-lifts-and-slopes/",
       "liftieId": null,
-      "notes": "See* network site - uses Lumiplan status images"
+      "notes": "See* network site - uses Lumiplan status images",
+      "lumiplanMapId": "alpe-dhuez-grand-domaine"
     },
     {
       "id": "alpine-valley-resort",
@@ -3103,7 +3104,8 @@
       "url": "https://www.tignes.net",
       "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=tignes&region=alpes&pays=france&lang=en",
       "liftieId": "tignes",
-      "notes": "Uses Lumiplan bulletin"
+      "notes": "Uses Lumiplan bulletin",
+      "lumiplanMapId": "Tignes_ValdIsere"
     },
     {
       "id": "timberline-lodge-ski-area",
@@ -3188,7 +3190,8 @@
       "url": "https://www.valthorens.com",
       "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=valthorens&region=alpes&pays=france&lang=en",
       "liftieId": null,
-      "notes": "Uses Lumiplan bulletin"
+      "notes": "Uses Lumiplan bulletin",
+      "lumiplanMapId": "bd632c91-6957-494d-95a8-6a72eb87e341"
     },
     {
       "id": "valle-nevado",


### PR DESCRIPTION
- Aggregated lifts.csv to find the 50 largest ski resorts by number of lifts
- Used web searches to find official status page URLs for each resort
- Ordered resorts by lift count (descending) from 141 lifts to 37 lifts
- Added lift_count column to the CSV for reference
- All URLs now point to actual official resort status/conditions pages
- Added generate-status-pages.mjs script for future regeneration