### PR TITLE
Fix Austrian resort extractors with JSON APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# Ski Lift Status - Development Notes
+
+## Architecture Principles
+
+### Runner.js Extraction Design
+The `runner.js` file performs all resort data extraction using **direct HTTP requests only**:
+- NO browser rendering or JavaScript execution (except jsdom for HTML parsing as last resort)
+- Prefer stable JSON API endpoints over HTML scraping
+- Each resort config should specify a `dataUrl` pointing to a JSON API when available
+- HTML parsing should be a fallback, not the primary method
+
+### Why This Matters
+- JSON APIs are more stable than HTML structure (less likely to break on site redesigns)
+- Direct HTTP is faster and more reliable than browser automation
+- Configs are easier to maintain and debug with clean API endpoints
+
+## XHR Fetcher Tool (For Discovery/Debugging Only)
+
+**IMPORTANT**: The XHR Fetcher is a development tool for discovering API endpoints. It should NOT be used in runner.js - it's only for building configs and debugging sites.
+
+For pages that use JavaScript to load data dynamically, use the XHR Fetcher service to discover API endpoints:
+
+**Environment Variables:**
+- `XHR_FETCH_URL` - The base URL for the xhr-fetcher service
+- `XHR_FETCH_KEY` - API key for authentication
+
+**Usage:**
+
+### Analyze endpoint (discover APIs)
+```bash
+curl -s -X POST "$XHR_FETCH_URL/analyze" \
+  -H "Authorization: Bearer $XHR_FETCH_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com/lift-status", "timeout": 60000}'
+```
+
+Response includes:
+- `primaryDataSource` - Type of data source (json-api, graphql, nextjs-embedded, etc.)
+- `detectedAPIs` - Array of discovered API endpoints with:
+  - `url` - The actual API URL
+  - `schema` - JSON schema of the response
+  - `sample` - Sample response data
+
+### Fetch endpoint (get full page data)
+```bash
+curl -s -X POST "$XHR_FETCH_URL/fetch" \
+  -H "Authorization: Bearer $XHR_FETCH_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "waitUntil": "networkidle",
+    "timeout": 60000
+  }'
+```
+
+Parameters:
+- `url` (required): Target URL
+- `waitUntil`: Navigation trigger (`load`, `domcontentloaded`, `networkidle`)
+- `timeout`: Max wait time (default: 60s, max: 360s)
+- `waitForSelector`: CSS selector to wait for
+- `additionalWaitMs`: Extra delay after loading
+
+Documentation: https://github.com/marcushyett/xhr-fetcher
+
+## Discovered API Endpoints
+
+### SkiWelt (skiwelt platform)
+```
+https://www.skiwelt.at/webapi/micadoweb?api=Micado.Ski.Web/Micado.Ski.Web.IO.Api.FacilityApi/List.api&client=https%3A%2F%2Fsgm.skiwelt.at&lang=en&region=skiwelt&season=winter&typeIDs=1
+```
+Response: `items[].title`, `items[].state` ("opened"/"closed")
+
+### KitzSki (kitzski platform)
+```
+https://www.kitzski.at/webapi/micadoweb?api=SkigebieteManager/Micado.SkigebieteManager.Plugin.FacilityApi/ListFacilities.api&extensions=o&client=https%3A%2F%2Fsgm.kitzski.at&lang=en&region=kitzski&season=winter&type=lift
+```
+Response: `facilities[].title`, `facilities[].status` (1=open, 0=closed)
+
+### Sölden (soelden/intermaps platform)
+```
+https://winter.intermaps.com/soelden/data?lang=en
+```
+Response: `lifts[].popup.title`, `lifts[].status` ("open"/"closed"), `slopes[].popup.title`, `slopes[].status`
+
+## Project Structure
+
+- `src/ski_lift_status/configs/runner.js` - Main extraction logic
+- `src/ski_lift_status/configs/resorts.json` - Resort configuration
+- `data/lifts.csv` - OpenSkiMap lift reference data
+- `data/runs.csv` - OpenSkiMap run reference data
+
+## Testing a specific resort
+```bash
+cd /home/user/ski-lift-status/src/ski_lift_status/configs
+node runner.js <resort-id>
+```

--- a/src/ski_lift_status/configs/resorts.json
+++ b/src/ski_lift_status/configs/resorts.json
@@ -365,7 +365,7 @@
       "name": "Skicircus Saalbach-Hinterglemm Leogang Fieberbrunn",
       "openskimap_id": "5b78e5652d097c7679cef7128ee1b57ff09fb86e",
       "platform": "saalbach",
-      "url": "https://www.saalbach.com/en/winter/skiarea/lifts-slopes",
+      "url": "https://www.saalbach.com/en/live-info/lifts-and-pistes",
       "liftieId": "saalbach-hinterglemm",
       "notes": "Austrian Skicircus resort"
     },


### PR DESCRIPTION
- SkiWelt: Updated to use Micado JSON API (was returning 0 lifts, now 83)
- KitzSki: Updated to use Micado JSON API (was returning 0 lifts, now 59)
- Sölden: Updated to use Intermaps JSON API (was returning 0 lifts, now 31 lifts + 58 runs)
- Mayrhofen: Updated to use Intermaps JSON API (was returning 0 lifts, now 48 lifts + 61 runs)
- Saalbach: Fixed URL to correct live-info page

Added CLAUDE.md with xhr-fetcher documentation for discovering API endpoints