### PR TITLE
Fix broken resort configs and add test failure criteria

### DIFF
--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -1,0 +1,266 @@
+# Debugging Guide: Finding Scraping Methods for Ski Resorts
+
+This guide explains how to discover and implement data extraction for new ski resort websites.
+
+## Core Principle
+
+**Always prefer JSON APIs over HTML scraping.** Modern ski resort websites are typically Single Page Applications (SPAs) that load data dynamically. If a page displays lift status, there MUST be an API providing that data. Your job is to find it.
+
+## Step 1: Initial Page Analysis
+
+### Check the Network Tab
+
+1. Open the resort's lift status page in Chrome/Firefox
+2. Open DevTools (F12) → Network tab
+3. Refresh the page
+4. Filter by "XHR" or "Fetch"
+5. Look for JSON responses containing lift/run data
+
+Common API patterns:
+- `/api/lifts`, `/api/facilities`, `/api/status`
+- `?type=lift`, `?category=remontees`
+- GraphQL endpoints (`/graphql`, `/__graphql`)
+
+### Check Page Source
+
+Look for embedded data in the HTML:
+
+```bash
+curl -s "https://example.com/lift-status" | grep -E "window\.__|\{\"lifts\"|REMONTEE|facilities"
+```
+
+Common patterns:
+- `window.__NUXT__` - Nuxt.js apps
+- `window.__NEXT_DATA__` - Next.js apps
+- `window.__DATA__` or `window.initialData` - Custom SPAs
+- `<script type="application/json">` - Embedded JSON
+
+## Step 2: Using XHR Fetcher
+
+For JavaScript-heavy pages that require rendering, use the XHR Fetcher service:
+
+### Analyze Endpoint (Recommended First Step)
+
+```bash
+curl -s -X POST "$XHR_FETCH_URL/analyze" \
+  -H "Authorization: Bearer $XHR_FETCH_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com/lift-status", "timeout": 60000}'
+```
+
+The response includes:
+- `primaryDataSource`: Type of data (json-api, graphql, nextjs-embedded, etc.)
+- `detectedAPIs`: Array of discovered endpoints with URLs and sample data
+- `pageMetadata`: Framework detection (React, Vue, Angular, etc.)
+
+### Fetch Endpoint (Full Page Rendering)
+
+```bash
+curl -s -X POST "$XHR_FETCH_URL/fetch" \
+  -H "Authorization: Bearer $XHR_FETCH_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "waitUntil": "networkidle",
+    "timeout": 60000
+  }'
+```
+
+Use `waitUntil: "networkidle"` for SPAs that load data after initial render.
+
+## Step 3: Identifying Platform Types
+
+### Known Platforms
+
+Check if the resort uses a known platform:
+
+| Indicator | Platform | Documentation |
+|-----------|----------|---------------|
+| `intermaps.com` in source | Intermaps | [intermaps.md](platforms/intermaps.md) |
+| `lumiplan` in URLs | Lumiplan | [lumiplan.md](platforms/lumiplan.md) |
+| `micadoweb` or `sgm.*.at` | Micado | [micado.md](platforms/micado.md) |
+| `digisnow` or SKIPLAN XML | Skiplan | [skiplan.md](platforms/skiplan.md) |
+| `TerrainStatusFeed` | Vail/Epic | [vail.md](platforms/vail.md) |
+| `window.__NUXT__` | Nuxt.js | [nuxtjs.md](platforms/nuxtjs.md) |
+| `window.__NEXT_DATA__` | Next.js | See below |
+| `dolomitisuperski.com` | Dolomiti | [dolomiti.md](platforms/dolomiti.md) |
+
+### Framework Detection
+
+**Next.js Sites:**
+```javascript
+// Look for this in page source
+<script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{...}}}</script>
+```
+
+**Nuxt.js Sites:**
+```javascript
+// Look for this pattern
+window.__NUXT__ = { state: { ... } }
+// Or IIFE format
+window.__NUXT__ = (function(a,b,c) { return {...} })(...);
+```
+
+**Vue.js (Generic):**
+- Look for `v-` attributes, `data-v-` prefixes
+- Check for Vue devtools hook: `__VUE__`
+
+**React (Generic):**
+- Look for `data-reactroot`, `__REACT_DEVTOOLS_GLOBAL_HOOK__`
+- Often uses `window.__PRELOADED_STATE__` or similar
+
+## Step 4: HTML Scraping (Last Resort)
+
+Only use HTML scraping when no API is available. Server-rendered pages may require this approach.
+
+### Common HTML Structures
+
+**Tables:**
+```javascript
+const rows = doc.querySelectorAll('table.lifts tr');
+rows.forEach(row => {
+  const name = row.querySelector('td:nth-child(1)')?.textContent;
+  const status = row.querySelector('td:nth-child(2)')?.textContent;
+});
+```
+
+**List Items:**
+```javascript
+const items = doc.querySelectorAll('.lift-item, .facility-row');
+items.forEach(item => {
+  const name = item.querySelector('.name, .title, h3')?.textContent;
+  const statusEl = item.querySelector('.status, .indicator, .state');
+});
+```
+
+**Status Indicators:**
+
+Look for status in:
+- CSS classes: `.open`, `.closed`, `.status-open`, `.indicator.green`
+- Image filenames: `open.png`, `green.svg`, `status_1.gif`
+- Data attributes: `data-status="open"`, `data-state="1"`
+- Text content: "Open", "Closed", "Ouvert", "Fermé"
+
+### Status Normalization
+
+Common status values and their meanings:
+
+| Raw Value | Normalized |
+|-----------|------------|
+| `O`, `open`, `opened`, `1`, `true`, `green` | `open` |
+| `F`, `closed`, `0`, `false`, `red` | `closed` |
+| `P`, `scheduled`, `planned`, `expected` | `scheduled` |
+| `A`, `avalanche` | `closed` (with note) |
+
+Multilingual status:
+- French: `ouvert` (open), `fermé` (closed), `prévu` (scheduled)
+- German: `offen` (open), `geschlossen` (closed)
+- Italian: `aperto` (open), `chiuso` (closed)
+
+## Step 5: Finding the Right Page
+
+### If the Given URL Doesn't Have Data
+
+1. **Navigate to the official website** and look for:
+   - "Lift Status", "Bergbahnen", "Remontées", "Impianti"
+   - "Trail Map", "Conditions", "Snow Report"
+   - "Live" or "Real-time" status pages
+
+2. **Check for embedded iframes:**
+   ```bash
+   curl -s "https://example.com/conditions" | grep -i "iframe\|src="
+   ```
+
+   The iframe source may point to a data provider like Lumiplan or Intermaps.
+
+3. **Check mobile app APIs:**
+   - Sometimes the mobile app uses a cleaner API
+   - Look for app download links and search for the app's API endpoints
+
+4. **Check sitemap:**
+   ```bash
+   curl -s "https://example.com/sitemap.xml" | grep -i "lift\|status\|conditions"
+   ```
+
+### Common URL Patterns
+
+| Language | Possible URLs |
+|----------|---------------|
+| English | `/lifts`, `/lift-status`, `/conditions`, `/terrain` |
+| French | `/remontees`, `/etat-pistes`, `/domaine-skiable` |
+| German | `/lifte`, `/bergbahnen`, `/anlagen`, `/pistenbericht` |
+| Italian | `/impianti`, `/piste`, `/stato-piste` |
+
+## Step 6: Testing and Validation
+
+### Run the Extractor
+
+```bash
+cd /home/user/ski-lift-status/src/ski_lift_status/configs
+node runner.js <resort-id>
+```
+
+### Check Output Quality
+
+A working extractor should return:
+- More than 2 lifts (unless it's a tiny resort)
+- More than 2 runs (unless runs aren't tracked)
+- Valid status values (open/closed/scheduled)
+- Reasonable lift names (not HTML artifacts)
+
+### Common Issues
+
+**Empty Results:**
+- API endpoint changed
+- Data loads asynchronously (need XHR fetcher)
+- Geo-blocking or WAF protection
+
+**Wrong Data:**
+- Parsing wrong element selectors
+- Status mapping incorrect
+- Summer season (lifts may show as closed)
+
+**Partial Data:**
+- Multiple data sources needed
+- Pagination not handled
+- Some facilities in different category
+
+## Step 7: Implementation Checklist
+
+When adding a new resort:
+
+1. [ ] Identify the data source (API preferred)
+2. [ ] Document the endpoint in CLAUDE.md if reusable
+3. [ ] Add config to `resorts.json` with `dataUrl` if applicable
+4. [ ] Implement extractor in `runner.js` if new platform
+5. [ ] Test with `node runner.js <resort-id>`
+6. [ ] Verify lift count meets minimum threshold (>2 lifts AND >2 runs)
+7. [ ] Add platform documentation if new platform type
+
+## Troubleshooting Specific Scenarios
+
+### WAF/Bot Protection
+
+Some sites block automated requests:
+- Add realistic User-Agent headers
+- Respect rate limits
+- Consider if data is available elsewhere
+
+### SSL/TLS Errors
+
+Some older systems have certificate issues:
+- Try HTTP instead of HTTPS
+- Check if there's an alternative endpoint
+
+### CORS Issues
+
+If API returns CORS errors:
+- The API is meant for browser-only access
+- Look for a different endpoint or use XHR fetcher
+
+### Empty JSON/No Lifts Showing
+
+During off-season:
+- Resorts may return empty arrays
+- Check if there's a "winter" vs "summer" mode
+- Look for `season=winter` parameters

--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -264,3 +264,71 @@ During off-season:
 - Resorts may return empty arrays
 - Check if there's a "winter" vs "summer" mode
 - Look for `season=winter` parameters
+
+## Known Difficult Resorts
+
+These resorts require special handling due to their technical implementations:
+
+### Swiss Resorts (Vue.js SPAs)
+
+The following Swiss resorts use Vue.js single-page applications that require JavaScript rendering:
+
+| Resort | URL | Challenge |
+|--------|-----|-----------|
+| Arosa Lenzerheide | arosalenzerheide.swiss | Vue.js SPA, data loaded via AJAX |
+| Parsenn (Davos) | davosklostersmountains.ch | Vue.js SPA, custom API undocumented |
+| Corviglia (St. Moritz) | mountains.ch | TYPO3 CMS with JavaScript loading |
+| Aletsch Arena | aletscharena.ch | TYPO3 CMS, JavaScript-rendered tables |
+
+**Approach:** Use XHR Fetcher `/analyze` endpoint to discover their internal APIs. These sites typically have Vue/Axios-based data fetching that can be intercepted.
+
+### French Resorts with Empty Lumiplan Bulletins
+
+Some French resorts are configured for Lumiplan but the bulletin data is empty:
+
+| Resort | Station Name | Issue |
+|--------|--------------|-------|
+| Espace Lumière | espacelumiere | Empty `pistes_remontees` div |
+| Le Grand Domaine | legranddomaine | No lift data in bulletin |
+| Serre-Chevalier | serrechevalier | Uses ingenie.fr instead of Lumiplan |
+
+**Approach:**
+1. Check if the resort has a `lumiplanMapId` for the JSON API
+2. Look for alternative data providers (ingenie.fr, Skiplan, etc.)
+3. Some resorts may use their own mobile app API
+
+### Andorran/Spanish Resorts
+
+| Resort | Platform | Challenge |
+|--------|----------|-----------|
+| GrandValira | Drupal | Embedded JSON in page state, complex extraction |
+
+**Approach:** Look for `drupalSettings` or `ajaxPageState` in page source containing facilities data.
+
+### North American Resorts
+
+| Resort | Platform | Challenge |
+|--------|----------|-----------|
+| Park City | Vail/Epic | WAF blocks automated requests |
+| Big Sky | Custom | JavaScript SPA with custom API |
+
+**Approach:**
+- Vail resorts: Try using the My Epic app API if accessible
+- Custom SPAs: Use XHR Fetcher to discover API endpoints
+
+### Alternative Data Sources
+
+When direct resort APIs fail, consider:
+
+1. **Third-party aggregators:**
+   - skiresort.info - Comprehensive but may require scraping
+   - bergfex.com - European focus
+   - snow-forecast.com - Global coverage
+
+2. **Regional tourism APIs:**
+   - myswitzerland.com - Swiss resorts
+   - france-montagnes.com - French resorts
+
+3. **Mobile app traffic analysis:**
+   - Many resorts have mobile apps with cleaner APIs
+   - Use network proxy to discover endpoints

--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -1,0 +1,43 @@
+# Ski Resort Platform Documentation
+
+This directory contains documentation for each ski resort platform/technology used to extract lift and run status data.
+
+## Platform Categories
+
+### Third-Party Data Providers
+
+| Platform | Technology | Used By | Status |
+|----------|------------|---------|--------|
+| [Intermaps](intermaps.md) | JSON API | Austrian/German resorts | Active |
+| [Lumiplan](lumiplan.md) | HTML/JSON | French resorts | Active |
+| [Micado](micado.md) | JSON API | Austrian resorts | Active |
+| [Skiplan](skiplan.md) | JSON/XML API | French resorts | Active |
+| [Infosnow](infosnow.md) | HTML | Swiss resorts | Partial |
+
+### Resort Network Platforms
+
+| Platform | Technology | Used By | Status |
+|----------|------------|---------|--------|
+| [Vail/Epic](vail.md) | JS/JSON | US Vail resorts | Blocked |
+| [SkiStar](skistar.md) | HTML/SimpleView | Scandinavian resorts | Active |
+| [Dolomiti Superski](dolomiti.md) | HTML | Italian resorts | Active |
+
+### Framework-Based
+
+| Platform | Technology | Detection | Status |
+|----------|------------|-----------|--------|
+| [Nuxt.js](nuxtjs.md) | Embedded JSON | `window.__NUXT__` | Active |
+| [Next.js](nextjs.md) | Embedded JSON | `__NEXT_DATA__` | Varies |
+
+### Individual Resort Implementations
+
+See [individual-resorts.md](individual-resorts.md) for resorts with custom implementations.
+
+## Quick Reference
+
+To add a new resort:
+
+1. Use the [debugging guide](../debugging-guide.md) to identify the data source
+2. Check if it matches an existing platform
+3. Add to `resorts.json` with appropriate platform type
+4. Test with `node runner.js <resort-id>`

--- a/docs/platforms/dolomiti.md
+++ b/docs/platforms/dolomiti.md
@@ -1,0 +1,54 @@
+# Dolomiti Superski Platform
+
+## Overview
+
+Dolomiti Superski is an Italian ski consortium covering multiple valleys in the Dolomites. Their websites use HTML tables for lift status.
+
+## Data Source
+
+Lift status is displayed in HTML tables on resort pages.
+
+## HTML Structure
+
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>...</td>
+      <td>Lift Name</td>
+      <td>...</td>
+      <td class="green">●</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+## Status Indicators
+
+| Class | Status |
+|-------|--------|
+| `green` | open |
+| `red` | closed |
+
+## Implementation
+
+See `extractDolomiti()` in runner.js.
+
+The extractor:
+1. Fetches the status page
+2. Parses table rows
+3. Extracts name from column 2
+4. Checks column 4 class for status
+
+## Known Resorts
+
+| Resort | Coverage |
+|--------|----------|
+| Alta Badia | Dolomiti Superski |
+| Val Gardena | Dolomiti Superski |
+
+## Notes
+
+- HTML structure may vary by resort within the network
+- Some resorts may have different column layouts
+- Consider using XHR fetcher to discover any hidden APIs

--- a/docs/platforms/individual-resorts.md
+++ b/docs/platforms/individual-resorts.md
@@ -1,0 +1,129 @@
+# Individual Resort Implementations
+
+This document covers resorts with custom implementations that don't fit into a standard platform category.
+
+## Laax (Switzerland)
+
+**Platform:** `laax`
+
+**Data Source:** Server-rendered HTML at `https://live.laax.com/de/anlagen`
+
+**HTML Structure:**
+```html
+<div class="widget lift">
+  <div class="indicator open"></div>
+  <div class="h3">Lift Name</div>
+</div>
+```
+
+**Status Classes:**
+- `indicator open` - open
+- `indicator closed` - closed
+- `indicator in-preparation` - scheduled
+
+---
+
+## Swiss Resorts (Infosnow)
+
+**Platform:** `infosnow`
+
+Used by some Swiss resorts via the Infosnow system.
+
+**Data Source:** `http://www.infosnow.ch/~apgmontagne/?lang=en&pid={id}&tab=web-wi`
+
+**HTML Structure:**
+```html
+<table>
+  <tr>
+    <td><img class="icon" src="status/open.png"></td>
+    <td>Lift Name</td>
+  </tr>
+</table>
+```
+
+---
+
+## Davos/Parsenn (Switzerland)
+
+**Platform:** `davos`
+
+**Issue:** Uses Vue.js SPA that loads data dynamically.
+
+**Workaround:** Look for embedded JSON in script tags or identify API endpoints.
+
+---
+
+## Arosa Lenzerheide (Switzerland)
+
+**Platform:** `arosa`
+
+Similar to Davos - Vue.js SPA requiring API discovery.
+
+---
+
+## St. Moritz/Corviglia (Switzerland)
+
+**Platform:** `stmoritz`
+
+**Data Source:** HTML tables on status pages.
+
+---
+
+## GrandValira (Andorra)
+
+**Platform:** `grandvalira`
+
+**Technology:** Drupal CMS with embedded JSON data.
+
+---
+
+## Livigno (Italy)
+
+**Platform:** `livigno`
+
+**Data Source:** HTML tables/lists with lift status.
+
+---
+
+## Baqueira (Spain)
+
+**Platform:** `baqueira`
+
+**Data Source:** HTML tables with status images.
+
+---
+
+## Perisher (Australia)
+
+**Platform:** `perisher`
+
+**Data Source:** HTML lift status page.
+
+---
+
+## Big Sky (USA)
+
+**Platform:** `bigsky`
+
+**Data Source:** Embedded JSON in script tags.
+
+**Issue:** May require JavaScript execution for full data.
+
+---
+
+## Deer Valley (USA)
+
+**Platform:** `deervalley`
+
+**Data Source:** Embedded JSON or HTML tables.
+
+---
+
+## Adding New Custom Resorts
+
+1. Analyze the page structure using browser DevTools
+2. Check for embedded JSON (`window.__DATA__`, `__NUXT__`, etc.)
+3. Look for API calls in Network tab
+4. Create extractor function in runner.js
+5. Add to platform switch statement
+6. Test with `node runner.js <resort-id>`

--- a/docs/platforms/infosnow.md
+++ b/docs/platforms/infosnow.md
@@ -1,0 +1,49 @@
+# Infosnow Platform
+
+## Overview
+
+Infosnow is a Swiss ski resort information system. It provides HTML-based lift status pages.
+
+## Data Source
+
+```
+http://www.infosnow.ch/~apgmontagne/?lang=en&pid={resort_id}&tab=web-wi
+```
+
+### Resort IDs
+
+| Resort | PID |
+|--------|-----|
+| Verbier | 31 |
+
+## HTML Structure
+
+```html
+<table>
+  <tr>
+    <td><img class="icon" src="status/{status}.png"></td>
+    <td>Lift Name</td>
+  </tr>
+</table>
+```
+
+## Status Images
+
+| Image Filename | Status |
+|----------------|--------|
+| `open.png`, `green.png` | open |
+| `closed.png`, `red.png` | closed |
+
+## Implementation
+
+See `extractInfosnow()` in runner.js.
+
+## Current Status
+
+The Infosnow platform may have limited availability or inconsistent responses. Some Swiss resorts may have moved to different platforms.
+
+## Notes
+
+- HTTP (not HTTPS) endpoint
+- May have SSL/TLS compatibility issues
+- Consider alternative data sources for Swiss resorts

--- a/docs/platforms/intermaps.md
+++ b/docs/platforms/intermaps.md
@@ -1,0 +1,84 @@
+# Intermaps Platform
+
+## Overview
+
+Intermaps is a mapping and data platform used by many Austrian and German ski resorts. It provides a JSON API with lift and slope status data.
+
+## API Endpoint
+
+```
+https://winter.intermaps.com/{resort_id}/data?lang=en
+```
+
+### Resort IDs
+
+| Resort | Intermaps ID |
+|--------|-------------|
+| Sölden | `soelden` |
+| Ischgl | `silvretta_arena` |
+| Saalbach Hinterglemm Leogang Fieberbrunn | `saalbach_hinterglemm_leogang_fieberbrunn` |
+| Mayrhofen | `mayrhofen` |
+| Zillertal Arena | `zillertal_arena` |
+
+## Response Structure
+
+```json
+{
+  "lifts": [
+    {
+      "popup": {
+        "title": "Lift Name",
+        "desc": "yes",
+        "lynx-type": "lift",
+        "subtitle": "6-chair lift",
+        "additional-info": {
+          "length": 1750,
+          "capacity": 2450,
+          "altitude-valley": 1348,
+          "altitude-mountain": 1920
+        }
+      },
+      "status": "open",
+      "id": "L_59413"
+    }
+  ],
+  "slopes": [
+    {
+      "popup": {
+        "title": "Run Name",
+        "subtitle": "red"
+      },
+      "status": "open",
+      "id": "P_12345"
+    }
+  ]
+}
+```
+
+## Status Values
+
+| API Status | Normalized |
+|------------|------------|
+| `open` | open |
+| `closed` | closed |
+| `scheduled` | scheduled |
+
+## Detection
+
+Look for:
+- `intermaps.com` in embedded iframes or data sources
+- `data-src="https://winter.intermaps.com/{id}"` attributes
+- References to "Intermaps" in page source
+
+## Implementation
+
+See `extractSoelden()`, `extractIschgl()`, `extractSaalbach()` in runner.js.
+
+All use the same API structure, differing only in the resort ID.
+
+## Notes
+
+- The API provides both lifts and slopes (runs)
+- Lift types are in `popup.subtitle` (e.g., "6-chair lift", "cable car", "T-bar")
+- Additional metadata includes altitude and capacity
+- Language parameter (`lang=en`) provides English names

--- a/docs/platforms/lumiplan.md
+++ b/docs/platforms/lumiplan.md
@@ -1,0 +1,140 @@
+# Lumiplan Platform
+
+## Overview
+
+Lumiplan is a French company providing ski resort information systems. They offer two main data sources:
+
+1. **HTML Bulletin** - Traditional web pages with lift/run status
+2. **JSON API** - Interactive map services API (newer)
+
+## Bulletin HTML (Legacy)
+
+### Endpoint
+
+```
+https://bulletin.lumiplan.pro/bulletin.php?station={station_name}&region=alpes&pays=france&lang=en
+```
+
+### Station Names
+
+| Resort | Station Name |
+|--------|-------------|
+| La Plagne | `la-plagne` |
+| Méribel | `alpina-mottaret` |
+| Courchevel | `courchevel` |
+| Val Thorens | `les3vallees` |
+
+### HTML Formats
+
+#### New Format (POI_info)
+
+Used by resorts like La Plagne:
+
+```html
+<div class="POI_info">
+  <span class="nom">Lift Name</span>
+  <img class="img_type" src="image/TC.svg">
+  <img class="img_status" src="image/lp_runway_trail_opened.svg">
+</div>
+```
+
+#### Old Format (prl_group)
+
+Used by 3 Vallées resorts:
+
+```html
+<div class="prl_group" title="Lift Name">
+  <img class="img_type" src="...">
+  <img class="image_status" src="etats/O.svg">
+</div>
+```
+
+### Status Images
+
+| Image | Status |
+|-------|--------|
+| `_opened` / `_open` | open |
+| `_scheduled` | scheduled |
+| `_closed` | closed |
+| `etats/O.svg` | open |
+| `etats/P.svg` | scheduled |
+| `etats/F.svg` or `H.svg` | closed |
+
+### Variant: Summary Format
+
+Some resorts (e.g., Serre-Chevalier) show only summary statistics (e.g., "12/20 lifts open") without individual lift names. These require the JSON API or alternative data sources.
+
+## JSON API (lumiplanMapId)
+
+### Endpoints
+
+```
+https://lumiplay.link/interactive-map-services/public/map/{mapId}/staticPoiData?lang=en
+https://lumiplay.link/interactive-map-services/public/map/{mapId}/dynamicPoiData?lang=en
+```
+
+### Map IDs
+
+| Resort | Map ID |
+|--------|--------|
+| (example) | `09110215-8a54-42cd-991a-1c534bfb5115` |
+
+### Response Structure
+
+**staticPoiData:**
+```json
+{
+  "items": [
+    {
+      "data": {
+        "id": "123",
+        "name": "Lift Name",
+        "type": "LIFT",
+        "liftType": "GONDOLA"
+      }
+    }
+  ]
+}
+```
+
+**dynamicPoiData:**
+```json
+{
+  "items": [
+    {
+      "id": "123",
+      "openingStatus": "OPEN"
+    }
+  ]
+}
+```
+
+### Status Values
+
+| API Status | Normalized |
+|------------|------------|
+| `OPEN` | open |
+| `FORECAST` | scheduled |
+| `DELAYED` | scheduled |
+| `CLOSED` | closed |
+| `OUT_OF_PERIOD` | closed |
+
+## Configuration
+
+In `resorts.json`:
+
+```json
+{
+  "platform": "lumiplan",
+  "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=...",
+  "lumiplanMapId": "optional-map-id-for-json-api"
+}
+```
+
+If `lumiplanMapId` is provided, the JSON API is used. Otherwise, HTML parsing is attempted.
+
+## Troubleshooting
+
+1. **Empty results**: Check if the station name is correct
+2. **Only summary data**: Resort may use new format without individual items
+3. **Different HTML structure**: May need to find the correct station name (some resorts have multiple)

--- a/docs/platforms/micado.md
+++ b/docs/platforms/micado.md
@@ -1,0 +1,90 @@
+# Micado Platform
+
+## Overview
+
+Micado provides ski resort management software used by Austrian resorts. The platform offers a JSON API through the SkigebieteManager (SGM) system.
+
+## API Endpoints
+
+### SkiWelt Format
+
+```
+https://www.skiwelt.at/webapi/micadoweb?api=Micado.Ski.Web/Micado.Ski.Web.IO.Api.FacilityApi/List.api&client=https%3A%2F%2Fsgm.skiwelt.at&lang=en&region=skiwelt&season=winter&typeIDs=1
+```
+
+### KitzSki Format
+
+```
+https://www.kitzski.at/webapi/micadoweb?api=SkigebieteManager/Micado.SkigebieteManager.Plugin.FacilityApi/ListFacilities.api&extensions=o&client=https%3A%2F%2Fsgm.kitzski.at&lang=en&region=kitzski&season=winter&type=lift
+```
+
+## Response Structure
+
+### SkiWelt Response
+
+```json
+{
+  "items": [
+    {
+      "title": "Lift Name",
+      "state": "opened"
+    }
+  ]
+}
+```
+
+### KitzSki Response
+
+```json
+{
+  "facilities": [
+    {
+      "title": "Lift Name",
+      "status": 1
+    }
+  ]
+}
+```
+
+## Status Values
+
+### SkiWelt
+
+| API State | Normalized |
+|-----------|------------|
+| `opened` | open |
+| `open` | open |
+| `scheduled` | scheduled |
+| (other) | closed |
+
+### KitzSki
+
+| API Status | Normalized |
+|------------|------------|
+| `1` | open |
+| `0` | closed |
+
+## Detection
+
+Look for:
+- `webapi/micadoweb` in network requests
+- `sgm.*.at` domains in iframes or scripts
+- "Micado" or "SkigebieteManager" in source
+
+## Implementation
+
+See `extractSkiwelt()` and `extractKitzski()` in runner.js.
+
+## Known Resorts
+
+| Resort | Platform Variant |
+|--------|-----------------|
+| SkiWelt | skiwelt |
+| KitzSki (Kitzbühel) | kitzski |
+
+## Notes
+
+- API parameters differ between resort implementations
+- `typeIDs=1` typically filters for lifts
+- The `client` parameter specifies the SGM instance
+- Both summer and winter seasons are supported via `season` parameter

--- a/docs/platforms/nuxtjs.md
+++ b/docs/platforms/nuxtjs.md
@@ -1,0 +1,89 @@
+# Nuxt.js Sites
+
+## Overview
+
+Nuxt.js is a Vue.js framework that often embeds initial state data in the HTML. Ski resort sites built with Nuxt.js can be scraped by extracting this embedded data.
+
+## Detection
+
+Look for:
+- `window.__NUXT__` in page source
+- Vue.js indicators (`v-`, `data-v-`)
+- `_nuxt/` in asset URLs
+
+## Data Formats
+
+### Simple Object Format
+
+```html
+<script>window.__NUXT__ = { state: { ... } };</script>
+```
+
+### IIFE Format
+
+```html
+<script>window.__NUXT__ = (function(a,b,c) { return {...} })(val1, val2, val3);</script>
+```
+
+## Extraction
+
+The `extractNuxtData()` function handles multiple Nuxt formats:
+
+1. Parses script tags containing `window.__NUXT__`
+2. Executes the JavaScript in a sandboxed VM
+3. Returns the parsed data object
+
+## Data Paths
+
+Common data paths in Nuxt ski resort sites:
+
+```javascript
+// Cervinia/Italian resorts
+$.state.impianti.SECTEUR[*].REMONTEE[*]
+$.state.impianti.SECTEUR[*].PISTE[*]
+
+// Item structure
+{
+  "@attributes": {
+    "nom": "Lift Name",
+    "etat": "O"
+  }
+}
+```
+
+## Configuration
+
+```json
+{
+  "platform": "nuxt",
+  "url": "https://example.com/lifts",
+  "config": {
+    "lifts": "$.state.impianti.SECTEUR[*].REMONTEE[*]",
+    "runs": "$.state.impianti.SECTEUR[*].PISTE[*]",
+    "name": "@attributes.nom",
+    "status": "@attributes.etat",
+    "statusMap": {
+      "O": "open",
+      "A": "open",
+      "F": "closed",
+      "P": "scheduled"
+    }
+  }
+}
+```
+
+## Implementation
+
+See `extractNuxt()` in runner.js.
+
+## Known Resorts
+
+| Resort | Data Path |
+|--------|-----------|
+| Cervinia | `state.impianti.SECTEUR[*].REMONTEE[*]` |
+
+## Troubleshooting
+
+1. **IIFE not parsing**: Check for complex JavaScript that may need additional handling
+2. **Empty data**: The state may load asynchronously - may need XHR fetcher
+3. **Different structure**: Each Nuxt site may have unique data paths

--- a/docs/platforms/skiplan.md
+++ b/docs/platforms/skiplan.md
@@ -1,0 +1,91 @@
+# Skiplan Platform
+
+## Overview
+
+Skiplan (also known as SKIPLAN) is a French ski resort management system. It provides data in both JSON and XML formats.
+
+## Variants
+
+### SKIPLAN XML (skiplanxml)
+
+Used by resorts that expose the raw SKIPLAN XML data, often through WordPress API endpoints.
+
+#### Endpoint Example
+
+```
+https://backoffice.avoriaz.com/wp-json/api/avoriaz/get_digisnow
+```
+
+#### Response Structure
+
+```xml
+<REMONTEE nom="Lift Name" etat="O"/>
+<PISTE nom="Run Name" etat="F"/>
+```
+
+#### Status Codes
+
+| Code | Status |
+|------|--------|
+| `O` | open (ouvert) |
+| `P` | scheduled (prévu) |
+| `F` | closed (fermé) |
+
+### Skiplan JSON (skiplan)
+
+Used by resorts with JSON API endpoints.
+
+#### Response Structure
+
+```json
+{
+  "remontees": [
+    {
+      "nom": "Lift Name",
+      "etat": "O"
+    }
+  ],
+  "pistes": [
+    {
+      "nom": "Run Name",
+      "etat": "F"
+    }
+  ]
+}
+```
+
+Alternative field names:
+- `nom` / `name` / `libelle`
+- `etat` / `status` / `ouverture`
+
+## Detection
+
+Look for:
+- `digisnow` in API URLs
+- SKIPLAN XML format in responses
+- WordPress JSON API patterns (`/wp-json/api/`)
+
+## Configuration
+
+```json
+{
+  "platform": "skiplanxml",
+  "dataUrl": "https://backoffice.example.com/wp-json/api/resort/get_digisnow"
+}
+```
+
+## Implementation
+
+See `extractSkiplanXml()` and `extractSkiplan()` in runner.js.
+
+## Known Resorts
+
+| Resort | Format |
+|--------|--------|
+| Avoriaz | SKIPLAN XML |
+
+## Notes
+
+- XML attributes may be escaped with backslashes (`\"`)
+- Entity encoding may need handling (`&apos;`, `&amp;`)
+- The digisnow endpoint is typically exposed via WordPress REST API

--- a/docs/platforms/skistar.md
+++ b/docs/platforms/skistar.md
@@ -1,0 +1,60 @@
+# SkiStar Platform
+
+## Overview
+
+SkiStar operates ski resorts primarily in Sweden and Norway. They use a React-based SPA with SimpleView components.
+
+## Data Source
+
+SkiStar pages load lift data via SimpleView URLs embedded in data attributes.
+
+## Detection
+
+Look for:
+- `data-url*="SimpleView"` attributes
+- `lpv-list__item` class elements
+- SkiStar branding/domains
+
+## HTML Structure
+
+```html
+<div data-url="/api/path/SimpleView?param=value">...</div>
+
+<!-- After fetch -->
+<div class="lpv-list__item">
+  <span class="lpv-list__item-name">Lift Name</span>
+  <span class="lpv-list__item-status lpv-list__item-status--is-open">Open</span>
+</div>
+```
+
+## Status Classes
+
+| Class | Status |
+|-------|--------|
+| `lpv-list__item-status--is-open` | open |
+| (default) | closed |
+
+## Implementation
+
+See `extractSkistar()` in runner.js.
+
+The extractor:
+1. Fetches main page
+2. Finds SimpleView URLs in data attributes
+3. Fetches each SimpleView content
+4. Parses lift items from the response
+
+## Known Resorts
+
+| Resort | Country |
+|--------|---------|
+| Åre | Sweden |
+| Trysil | Norway |
+| Sälen | Sweden |
+| Hemsedal | Norway |
+
+## Notes
+
+- Multiple SimpleView requests may be needed
+- React hydration may affect initial HTML
+- Consider XHR fetcher for discovering API endpoints

--- a/docs/platforms/vail.md
+++ b/docs/platforms/vail.md
@@ -1,0 +1,80 @@
+# Vail Resorts / Epic Platform
+
+## Overview
+
+Vail Resorts operates the Epic Pass network including major US resorts. They use a JavaScript-based TerrainStatusFeed system.
+
+## Data Source
+
+Lift status is embedded in JavaScript on terrain status pages:
+
+```javascript
+FR.TerrainStatusFeed = {
+  Lifts: [
+    { Name: "Lift Name", Status: 1 }
+  ]
+};
+```
+
+## Status Values
+
+| Status Code | Meaning |
+|-------------|---------|
+| 0 | closed |
+| 1 | open |
+| 2 | hold |
+| 3 | scheduled |
+
+## Known Resorts
+
+| Resort | URL Pattern |
+|--------|------------|
+| Vail | `/the-mountain/mountain-conditions/terrain-and-lift-status.aspx` |
+| Beaver Creek | Same pattern |
+| Park City | Same pattern |
+| Whistler Blackcomb | Same pattern |
+| Stowe | Same pattern |
+
+## Current Status: BLOCKED
+
+As of December 2024, Vail Resorts websites are **blocking automated requests** with:
+- WAF (Web Application Firewall) challenges
+- Akamai bot detection
+- SSL/TLS restrictions
+
+### Error Messages
+
+```
+403 Forbidden
+"Access Denied"
+"Request blocked by WAF"
+```
+
+## Workarounds Attempted
+
+1. **User-Agent spoofing** - Not sufficient
+2. **Different endpoints** - All blocked
+3. **Mobile site** - Also blocked
+
+## Alternative Data Sources
+
+Consider:
+- Official Vail Resorts mobile app APIs (requires reverse engineering)
+- Third-party aggregators
+- RSS feeds (if available)
+
+## Implementation
+
+See `extractVail()` in runner.js.
+
+The extractor:
+1. Fetches the terrain status page
+2. Looks for `TerrainStatusFeed` in script tags
+3. Parses the JavaScript object
+4. Extracts lift names and status codes
+
+## Notes
+
+- This platform is inherited from the liftie project
+- Implementation may need updating if Vail changes their frontend
+- Consider monitoring for API changes or new endpoints

--- a/src/ski_lift_status/configs/resorts.json
+++ b/src/ski_lift_status/configs/resorts.json
@@ -241,11 +241,11 @@
       "id": "les-gets-morzine",
       "name": "Les Gets-Morzine",
       "openskimap_id": "cafb6b6d5f25860a682a8b6d67efe689218618a5",
-      "platform": "lumiplan",
+      "platform": "intermaps",
       "url": "https://www.lesgets.com/en/discover-the-resort/ski-winter-sports/live-info-slopes/",
-      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=morzine---avoriaz---les-gets&region=alpes&pays=france&lang=en",
+      "dataUrl": "https://winter.intermaps.com/portes_du_soleil/data?lang=en",
       "liftieId": "morzine",
-      "notes": "Uses Lumiplan bulletin (Portes du Soleil domain)"
+      "notes": "Uses Intermaps API (Portes du Soleil domain)"
     },
     {
       "id": "les-sybelles",

--- a/src/ski_lift_status/configs/resorts.json
+++ b/src/ski_lift_status/configs/resorts.json
@@ -72,10 +72,10 @@
       "id": "avoriaz",
       "name": "Avoriaz",
       "openskimap_id": "7cac2b19d023f887e458c354be9caf833b6aed6d",
-      "platform": "lumiplan",
+      "platform": "skiplanxml",
       "url": "https://www.avoriaz.com",
-      "dataUrl": "https://bulletin.lumiplan.pro/bulletin.php?station=morzine---avoriaz---les-gets&region=alpes&pays=france&lang=en",
-      "notes": "Uses Lumiplan bulletin (Portes du Soleil domain)"
+      "dataUrl": "https://backoffice.avoriaz.com/wp-json/api/avoriaz/get_digisnow",
+      "notes": "Uses SKIPLAN XML API via digisnow (Portes du Soleil domain)"
     },
     {
       "id": "big-sky-resort",
@@ -311,9 +311,9 @@
       "name": "Parsenn (Davos Klosters)",
       "openskimap_id": "403c8d67ddd348bfa3f7d02c6c21163479964926",
       "platform": "davos",
-      "url": "https://www.parsenn.com/en/mountains/winter/live-info/current-operating-infos",
+      "url": "https://www.davosklostersmountains.ch/en/mountains/winter/live-info/current-operating-infos",
       "website": "https://www.davosklostersmountains.ch/",
-      "notes": "Swiss resort - uses davosklostersmountains.ch API"
+      "notes": "Swiss resort - uses davosklostersmountains.ch domain"
     },
     {
       "id": "perisher",


### PR DESCRIPTION
- Add SKIPLAN XML extractor for resorts using digisnow API (Avoriaz)
- Fix Ischgl extractor to use Intermaps JSON API
- Fix Davos config to use correct domain (davosklostersmountains.ch)
- Update Avoriaz config to use skiplanxml platform with digisnow API
- Add test failure criteria: exit with error if any resort has ≤2 lifts AND ≤2 runs
- Display summary of resorts with insufficient data in test output

Fixed resorts:
- Avoriaz: Now extracting 35 lifts and 76 runs
- Silvretta Arena Ischgl: Now extracting 46 lifts and 89 runs
- Davos: Resolved certificate error (was using wrong domain)