### PR TITLE
Fix test-configs workflow failing due to missing @actions/core

### DIFF
--- a/.github/workflows/test-configs.yml
+++ b/.github/workflows/test-configs.yml
@@ -114,11 +114,13 @@ jobs:
           const failingJson = JSON.stringify(failing);
           fs.writeFileSync('failing-resorts.json', failingJson);
 
-          // Set outputs
-          const core = require('@actions/core');
-          if (typeof core !== 'undefined' && core.setOutput) {
+          // Set outputs (try @actions/core, but it may not be installed in inline scripts)
+          try {
+            const core = require('@actions/core');
             core.setOutput('failing_resorts', failingJson);
             core.setOutput('has_failures', failing.length > 0 ? 'true' : 'false');
+          } catch (e) {
+            // @actions/core not available, will use backup method below
           }
           ANALYZE
 


### PR DESCRIPTION
Wrap the require('@actions/core') call in a try-catch block since
the inline Node.js script doesn't have access to installed npm packages.
The backup method using $GITHUB_OUTPUT environment file handles
setting outputs correctly when @actions/core is unavailable.