### PR TITLE
Analyze Tignes ski map API endpoints

### DIFF
--- a/lumiplan-maps/.gitignore
+++ b/lumiplan-maps/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lumiplan-maps/README.md
+++ b/lumiplan-maps/README.md
@@ -1,0 +1,126 @@
+# Lumiplan Ski Data
+
+A Node.js module for fetching real-time ski resort lift and run data from Lumiplan interactive maps, with fuzzy matching to OpenSkiMap IDs.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Quick Start
+
+```javascript
+import { getSkiAreaData, getAvailableMaps } from 'lumiplan-ski-data';
+
+// List available maps
+console.log(getAvailableMaps());
+
+// Get full data for a ski area
+const data = await getSkiAreaData('tignes-valdisere');
+console.log(data.lifts);  // Array of lifts with real-time status
+console.log(data.runs);   // Array of runs with real-time status
+
+// Get just lift status summary
+const liftStatus = await getLiftStatus('paradiski');
+console.log(`${liftStatus.open}/${liftStatus.total} lifts open`);
+```
+
+## Available Maps
+
+| ID | Name | Resorts |
+|----|------|---------|
+| `tignes-valdisere` | Espace Killy | Tignes, Val d'Isère |
+| `paradiski` | Paradiski | Les Arcs, La Plagne, Peisey-Vallandry |
+| `les-3-vallees` | Les 3 Vallées | Courchevel, Méribel, Val Thorens, Les Menuires, Orelle |
+| `aussois` | Aussois | Aussois |
+| `orcieres` | Orcières | Orcières Merlette 1850 |
+| `vaujany` | Alpe d'Huez Grand Domaine | Vaujany, Oz, Alpe d'Huez |
+
+## API
+
+### `getSkiAreaData(mapId, options?)`
+
+Fetches complete lift and run data for a ski area.
+
+**Parameters:**
+- `mapId` - One of the available map IDs
+- `options.lang` - Language code (default: 'en')
+- `options.matchOsm` - Whether to match with OpenSkiMap IDs (default: true)
+
+**Returns:**
+```javascript
+{
+  lifts: [{
+    id: 5226,
+    name: 'TK DE COMBE FOLLE',
+    type: 'drag_lift',
+    status: 'open',
+    operating: true,
+    capacity: 1,
+    duration: 4,
+    length: 869,
+    osmMatch: { osmId: '...', osmName: '...', confidence: 'high' }
+  }, ...],
+  runs: [{
+    id: 5483,
+    name: 'COL MADELEINE',
+    type: 'downhill_skiing',
+    difficulty: 'easy',
+    status: 'scheduled',
+    groomingStatus: 'GROOMED',
+    snowQuality: 'HARD_PACKED',
+    length: 982,
+    osmMatch: { osmId: '...', osmName: '...', confidence: 'medium' }
+  }, ...],
+  resorts: [...],
+  metadata: {
+    fetchedAt: '2024-01-15T10:30:00.000Z',
+    language: 'en',
+    mapId: 'tignes-valdisere',
+    displayName: 'Tignes - Val d\'Isère (Espace Killy)'
+  }
+}
+```
+
+### `getLiftStatus(mapId)`
+
+Get a summary of lift status.
+
+### `getRunStatus(mapId)`
+
+Get a summary of run status.
+
+### `getAvailableMaps()`
+
+Get list of available map configurations.
+
+## CLI
+
+```bash
+# Show available maps
+node src/cli.js --help
+
+# Get data for a resort
+node src/cli.js tignes-valdisere
+
+# Get summary only
+node src/cli.js paradiski --summary
+
+# Output as JSON
+node src/cli.js les-3-vallees --json
+```
+
+## Generating OpenSkiMap Data
+
+To enable OpenSkiMap ID matching, generate the data files:
+
+```bash
+node src/generate-osm-data.js
+```
+
+This reads from the parent `ski-lift-status/data/*.csv` files and creates JSON files in `data/`.
+
+## License
+
+MIT

--- a/lumiplan-maps/data/aussois-lifts.json
+++ b/lumiplan-maps/data/aussois-lifts.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "fe867b1c837e9a9009b96fd09cbd86b073d1dec4",
+    "name": "Grand Jeu",
+    "type": "chair_lift"
+  },
+  {
+    "id": "eb493e83bdf2afbd25e57bb0b3bbb8667d17fb5a",
+    "name": "Armoise",
+    "type": "chair_lift"
+  },
+  {
+    "id": "d7799ef660cd19b865919007bc4805e53c831774",
+    "name": "Plan Sec",
+    "type": "drag_lift"
+  },
+  {
+    "id": "5b55ec4053d7ea19fb6eb7a7376e8e0f25151c87",
+    "name": "Éterlou",
+    "type": "chair_lift"
+  },
+  {
+    "id": "7cfb38ecbccb1cb8ed22df95466be6d2c5691dad",
+    "name": "Fournache",
+    "type": "chair_lift"
+  },
+  {
+    "id": "77ff9879eaf4cc784e180c9e31c42c7fd7866d36",
+    "name": "Charrière",
+    "type": "drag_lift"
+  },
+  {
+    "id": "d8b607c292bb5b1f1974d9d249c60a401fc961dd",
+    "name": "Mulinière",
+    "type": "drag_lift"
+  },
+  {
+    "id": "180d96a4277bb3e91a7e8315f6a239c040f33df5",
+    "name": "Praz Carraz",
+    "type": "platter"
+  },
+  {
+    "id": "d196a1ce9c38938cc929394439240d580f2c1995",
+    "name": "Praz Carraz",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "a1b340061911c906b7cb38b1e9768534b78097ea",
+    "name": "Baby la Dotta",
+    "type": "rope_tow"
+  }
+]

--- a/lumiplan-maps/data/aussois-runs.json
+++ b/lumiplan-maps/data/aussois-runs.json
@@ -1,0 +1,257 @@
+[
+  {
+    "id": "fba6ed05d27501dceccf3e56db24fb5dba25ae91",
+    "name": "stade de compétition",
+    "type": ""
+  },
+  {
+    "id": "94b844354458e7723bbaa3f7fcaa32792be1f673",
+    "name": "Charrière",
+    "type": "novice"
+  },
+  {
+    "id": "850ec2944b059d09c14bfdc66642b89277aef02e",
+    "name": "Mulinières",
+    "type": "novice"
+  },
+  {
+    "id": "f34bae63cd5b601c2e8878ad04311cfc65c69d66",
+    "name": "Ortet",
+    "type": "easy"
+  },
+  {
+    "id": "b96bf936f46d69a264ddf66e8fdfa43bd0e91473",
+    "name": "ortet",
+    "type": "easy"
+  },
+  {
+    "id": "011390666e8650f9bd2f2be53eea01788d397f56",
+    "name": "Eterlou",
+    "type": "novice"
+  },
+  {
+    "id": "a02e8ea6ff88971770b9b26ad3007c85eb4a3ddf",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "106afe0d9342c9060549330cb2ebde8859b07382",
+    "name": "Marmot Park",
+    "type": "novice"
+  },
+  {
+    "id": "10b34f6b2e6c7cb5e7001ac63603abc99c4359de",
+    "name": "Léon",
+    "type": "easy"
+  },
+  {
+    "id": "9502ec15781e7a29cb6c8d657d3f424d5bccd831",
+    "name": "La Fournache",
+    "type": "intermediate"
+  },
+  {
+    "id": "b61d892438b56b1f5baae3da3358a42b6649094a",
+    "name": "L'Armoise",
+    "type": "easy"
+  },
+  {
+    "id": "2cc0efe44d991ebdd0e155e4bc2797f4279b9b2c",
+    "name": "La Fournache",
+    "type": "intermediate"
+  },
+  {
+    "id": "fe9dcb124ba1906165912c71163fac5a317f4da8",
+    "name": "La Stella",
+    "type": "intermediate"
+  },
+  {
+    "id": "6e2cdabf66cde08b176e201a5fdd8ee1d7d90a38",
+    "name": "Les Côtes",
+    "type": "intermediate"
+  },
+  {
+    "id": "8507b20fb590968c854feda8c5ed93bfa1a8b734",
+    "name": "Les Roches",
+    "type": "advanced"
+  },
+  {
+    "id": "0aa51ff3d75bbf8eb041fa7a303b723910bcd7e2",
+    "name": "Plan sec",
+    "type": "intermediate"
+  },
+  {
+    "id": "9389d9be7da83aeb26cbf80be64c7239d784be13",
+    "name": "Les Côtes",
+    "type": "intermediate"
+  },
+  {
+    "id": "f5585d2e0006dc82493697ebc8a018d01f5c2dc1",
+    "name": "Les Côtes",
+    "type": "novice"
+  },
+  {
+    "id": "1dd64afc747ccdd5d7ef7e2039afde431d52fbb9",
+    "name": "Les Cotes",
+    "type": "novice"
+  },
+  {
+    "id": "46662aa91478afe970e2ac037267e3eb4805b878",
+    "name": "La Choulière",
+    "type": "intermediate"
+  },
+  {
+    "id": "c480a0c48600694754884c338232505d56a6036f",
+    "name": "Les Côtes",
+    "type": "novice"
+  },
+  {
+    "id": "f79ba7f516f1906ce343591d2f3ed28ae3c6698f",
+    "name": "Les Sétives",
+    "type": "intermediate"
+  },
+  {
+    "id": "3c697dffa850b5987c0ea640ac172a463c5b9b3f",
+    "name": "Les Sétives",
+    "type": "intermediate"
+  },
+  {
+    "id": "509fc60c57710626441ff24b16b93438a17e2881",
+    "name": "Paerot",
+    "type": "easy"
+  },
+  {
+    "id": "625f55ee8fde1f4b32f017a71e4a3b167e1364fb",
+    "name": "Les Balmes",
+    "type": "advanced"
+  },
+  {
+    "id": "bc82aa75f6fbda39ccafb4e9a1ad1e2cb4008c75",
+    "name": "Paerot",
+    "type": "intermediate"
+  },
+  {
+    "id": "9ac069dc3f3690a0cc363b821a79a74a22710bb0",
+    "name": "Liaison Plan sec",
+    "type": "intermediate"
+  },
+  {
+    "id": "a18a563e7fcebffe862ef13b53495f19460aa9db",
+    "name": "Les Côtes",
+    "type": "novice"
+  },
+  {
+    "id": "bb772ebf74bc83299908e0ee0bd77e38cd544cc8",
+    "name": "Toutoune",
+    "type": "easy"
+  },
+  {
+    "id": "cd6075d38e3196227d26eff67ff14d5dc73623de",
+    "name": "Toutoune",
+    "type": "easy"
+  },
+  {
+    "id": "a6c0da76c89868f278047d4431d729df3084489c",
+    "name": "Le Col",
+    "type": "advanced"
+  },
+  {
+    "id": "b38e5958cae975a17a17844fe9c9f618a25f8c3f",
+    "name": "La Choulière",
+    "type": "intermediate"
+  },
+  {
+    "id": "c98c0a5bc7fe014351b28a75f32e21b88b0c1569",
+    "name": "Le Chamois",
+    "type": "easy"
+  },
+  {
+    "id": "faa9d611096b644889ca04b879c8cd628a9601e9",
+    "name": "Le Chamois",
+    "type": "easy"
+  },
+  {
+    "id": "df50908cc36a88fd3295e13f72e2a73e6f7dd9d5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4c3337e5830ba928c197ac94527dcbd7bd0cd377",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "33722b6af66796d7f20c016502770595bfcdf57b",
+    "name": "Praz Carraz",
+    "type": "novice"
+  },
+  {
+    "id": "c63a2403963be5c307ba0e91a87c174006bc9c7e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e42bf77b2eae94ac55083e3cc63d9f1e72d802d4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "11faaac3758f5c45af921c147e22fefac9edc278",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "4dab364646a8591bf07995913a097f6a3569ce11",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2a3c2b92cdc0f5853ce5b1cca1adec8e679166a6",
+    "name": "Retour Côtes",
+    "type": "novice"
+  },
+  {
+    "id": "e900a725a576243def93bade7314cfb1bca882b3",
+    "name": "ortet",
+    "type": "easy"
+  },
+  {
+    "id": "4d6b4dffa3c4a8599c772d27751e4089018b8c74",
+    "name": "Les Côtes",
+    "type": "novice"
+  },
+  {
+    "id": "c4f9cfbfe33ea20c21a6018b02a2424595864fed",
+    "name": "Les Côtes",
+    "type": "novice"
+  },
+  {
+    "id": "b876def149cc0b91bcb77a07a2fc58c0e4e49584",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "fc2497ce9cd1da9480a76c2efb99e9eaaafb0e70",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d9f176ae25aa55c1c9444aad1ffce0c35dfbef75",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "61c422360dcf5003fd7518afe626221067f57f3b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "e6f71f3b17e39e839f6fe3a1cff83300e275d340",
+    "name": "Les Côtes",
+    "type": "intermediate"
+  },
+  {
+    "id": "1b32c6649c2e361c56655723af5d4f8e0ac46da4",
+    "name": "",
+    "type": ""
+  }
+]

--- a/lumiplan-maps/data/les-3-vallees-lifts.json
+++ b/lumiplan-maps/data/les-3-vallees-lifts.json
@@ -1,0 +1,852 @@
+[
+  {
+    "id": "11effb194edfdc7596d7fbcc4d28fe2fa13dee65",
+    "name": "Cascades",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c167ad3a1dc0944dabe1e33a9a569d437f03bbd3",
+    "name": "Portette",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8afd62f8166761f072fdf933443120a8814c3d41",
+    "name": "Caron",
+    "type": "gondola"
+  },
+  {
+    "id": "5e77fecae646b69475a60c3e69710e74986592d1",
+    "name": "Cime Caron",
+    "type": "cable_car"
+  },
+  {
+    "id": "fa88e87f3f81f1c75f13ebb27a14f94afa0a48d2",
+    "name": "Boismint",
+    "type": "chair_lift"
+  },
+  {
+    "id": "df2ad5e8ae201547e582fd7c10306f129ecb11c3",
+    "name": "Tortollet",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2c4f0f964b219c68fc36660b3298eaf8d5fa3ae0",
+    "name": "Roc 1",
+    "type": "gondola"
+  },
+  {
+    "id": "371a4dd6cbbc91cff314aca3ff76138ce40d8772",
+    "name": "Cairn",
+    "type": "gondola"
+  },
+  {
+    "id": "3f09708a53c2eb7c6e20eb7e4409d2a086e34079",
+    "name": "Masse",
+    "type": "platter"
+  },
+  {
+    "id": "87b2d06aae11db7e5c8962852f85d9eee0de7687",
+    "name": "Moutière",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c77754a1985c26dca24533ec43e2006ffa5a3e9f",
+    "name": "Grand Fond",
+    "type": "gondola"
+  },
+  {
+    "id": "3f6a078de9bf263ff8ef29faa0b8e7f062f8b2cd",
+    "name": "Rosaël",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a4a692f8fc73d8d7fea232440ff379e99d31fef3",
+    "name": "Peyron",
+    "type": "chair_lift"
+  },
+  {
+    "id": "dd806ae57a2d4df0166f38cae4078a839e0cc1eb",
+    "name": "Bouchet",
+    "type": "chair_lift"
+  },
+  {
+    "id": "ec0c767a31bb29faac3414f0fcc9fdbf67cb5bbd",
+    "name": "Plateau 2",
+    "type": "platter"
+  },
+  {
+    "id": "27d27b94e311b4cb1bdf510c99119a071d9d6e74",
+    "name": "Moraine",
+    "type": "gondola"
+  },
+  {
+    "id": "9a242f8d210edc568f6e2df202c03fc1a6ec406d",
+    "name": "Plein Sud",
+    "type": "chair_lift"
+  },
+  {
+    "id": "af3bce64bc75415b0490f9c90ac08299e5ced573",
+    "name": "Funitel 3 Vallées",
+    "type": "cable_car"
+  },
+  {
+    "id": "df3671475b35952edae0eb55fbabbb8a2306a1c1",
+    "name": "3 Vallées",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b86db0b216d52cde870ed69d1e977362456a63fd",
+    "name": "Mont de la Chambre",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a64e664c3a30ab0b0be8319b7aa1726f3565d5d3",
+    "name": "Becca",
+    "type": "chair_lift"
+  },
+  {
+    "id": "193013821dd3f7d93c660318255bbcd4fe2c7c81",
+    "name": "Roc 2",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2dd9120149481df51f9122a7eca3f02c76c60a1c",
+    "name": "Plan des Mains",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3512bc99a29f90979ae83a1db624a79c9014d915",
+    "name": "Bruyères 2",
+    "type": "gondola"
+  },
+  {
+    "id": "3ab2d5c2e9046988437203072810fe4adf6f2a82",
+    "name": "Mont Vallon",
+    "type": "gondola"
+  },
+  {
+    "id": "9f39ecbcf630f6859560ddbdb48750544d66bdee",
+    "name": "Bouquetin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b1823d9eadaf56b356dac9da258e9d42b0fb2b1c",
+    "name": "Granges",
+    "type": "chair_lift"
+  },
+  {
+    "id": "5267f116a2033cb41ffb2a6594568d137e9269c1",
+    "name": "Doron",
+    "type": "chair_lift"
+  },
+  {
+    "id": "7c1f8a6caa0335cb4c4952bf002161e9067ee0f8",
+    "name": "Menuires",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c553f9a05089246b49621477792d920cddb0de7d",
+    "name": "Pas du Lac 1",
+    "type": "gondola"
+  },
+  {
+    "id": "d3d0482f26c610f5c3c7152f7013bd656ece14e7",
+    "name": "Pas du Lac 2",
+    "type": "gondola"
+  },
+  {
+    "id": "61f139ee6afc22c023ccee621a8eb620a7f9e647",
+    "name": "Aiguille du Fruit",
+    "type": "chair_lift"
+  },
+  {
+    "id": "49f8570aec81b633e78afc743a38e01524a41f9b",
+    "name": "Marmottes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9cd4030a4a4dcc20be960cbf2757b46f6dce50a3",
+    "name": "Suisses",
+    "type": "chair_lift"
+  },
+  {
+    "id": "95cf21e73da3aaf7e987ebb1217c6954286b5548",
+    "name": "Vizelle",
+    "type": "gondola"
+  },
+  {
+    "id": "0c853538a0efe3e5cc5b75070d18b7fe29fe56f9",
+    "name": "Chanrossa",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3019b814c2d64e25897640c3644f8a9024349b32",
+    "name": "Saint Martin Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "7d2f5218911e9c0157058ab41bcc0baecd9d1b92",
+    "name": "Pionniers",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2f7afb71e8531cf5fce59efe393eaf9e8d9ed309",
+    "name": "La Tania",
+    "type": "gondola"
+  },
+  {
+    "id": "9bd864251473b8cf474b7d914d3601750f0f299b",
+    "name": "Dou des Lanches",
+    "type": "chair_lift"
+  },
+  {
+    "id": "20ed4928835689b627d2b61e780ad5b32fe8ebbe",
+    "name": "Sources",
+    "type": "platter"
+  },
+  {
+    "id": "5cc4884368363d12e2363d47bed85a3b60b66a25",
+    "name": "Rocher de l'Ombre",
+    "type": "platter"
+  },
+  {
+    "id": "ee4037cd2e30c6ea128056f6aac0e9d5663dcc06",
+    "name": "TCD10 Chenus",
+    "type": "gondola"
+  },
+  {
+    "id": "68180a71f2ee7685e634fffb36e6c6af303fc2c4",
+    "name": "Tougnète 1",
+    "type": "gondola"
+  },
+  {
+    "id": "2243a976092e58442c4548d79648ade99f601af3",
+    "name": "Rhodos 1",
+    "type": "gondola"
+  },
+  {
+    "id": "c958ba88f10fad33db9f0748f382152e8cefaf0e",
+    "name": "Saint Martin 1",
+    "type": "gondola"
+  },
+  {
+    "id": "75db497abbf1b48f7d331f69ea8c79c33469d867",
+    "name": "Caves",
+    "type": "platter"
+  },
+  {
+    "id": "50f584915a9bff33001607babf9685b76f7fa3b2",
+    "name": "Loze",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a9de5e7c2be747d84b2a8b7dc85f07fc9303e0d8",
+    "name": "Roc Mugnier",
+    "type": "chair_lift"
+  },
+  {
+    "id": "73d282dc38a763ef9b3b6647cb8aefb52db0fe3a",
+    "name": "Signal",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8d66e16b5e56f5fdd7914b8fe24ba82ecf1b0fe9",
+    "name": "Biollay",
+    "type": "chair_lift"
+  },
+  {
+    "id": "4261bf1ec55e84a6c21448eddc17aeed21734df6",
+    "name": "Pralong",
+    "type": "chair_lift"
+  },
+  {
+    "id": "633a74fa26e2f5333380f1e3d25e621b2681918c",
+    "name": "Castor Pollux",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "ffc3b5169cc6a5e1d6ab54594e007e6ab5885250",
+    "name": "Golf",
+    "type": "chair_lift"
+  },
+  {
+    "id": "357853411a26b9b00cdcc11c77aa2eed41c48b54",
+    "name": "Altiport",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9ab490f24185c4c241629f270700cdd5a508687e",
+    "name": "Altiport",
+    "type": "platter"
+  },
+  {
+    "id": "d3ee3ed36d96f3613b3bfe6fb104673e1878b457",
+    "name": "Jardin Alpin",
+    "type": "gondola"
+  },
+  {
+    "id": "4e5890565a4a27a3d281400cd94c4960d460376d",
+    "name": "TKD Gros Murger",
+    "type": "platter"
+  },
+  {
+    "id": "19dc2ef977b1ae2ff3d25f1ccef2a97f308cba31",
+    "name": "Roc Merlet",
+    "type": "chair_lift"
+  },
+  {
+    "id": "429b94735462a12e35cc3cc9c8fcc48688289eff",
+    "name": "Chapelets",
+    "type": "chair_lift"
+  },
+  {
+    "id": "056a9875fb8dbd6e9712d419b6a82494d97c4c8e",
+    "name": "Ariondaz",
+    "type": "gondola"
+  },
+  {
+    "id": "8b859be57620c845f3f1e36611f892bdd015af4f",
+    "name": "Croisette",
+    "type": "gondola"
+  },
+  {
+    "id": "7f14bc3feb5556418a66cfb552642a7b09f0ffda",
+    "name": "Olympic",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3a56a9ee2e478c39b100609e3961cb9534a5ab2e",
+    "name": "Legends",
+    "type": "chair_lift"
+  },
+  {
+    "id": "06a55fb6297a3e53b5c93b9d9a12a166335a19a6",
+    "name": "Arpasson",
+    "type": "platter"
+  },
+  {
+    "id": "84c0ac9d7150cfbecb3b2ac362ac0ddd1571b459",
+    "name": "Dent de Burgin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8ff7051a841b4f66f1d9fcd62a5a40405ee7080b",
+    "name": "Adret",
+    "type": "chair_lift"
+  },
+  {
+    "id": "5b8fff72942ae5fd7f8d75475f671ce1ba7799c2",
+    "name": "Saulire Express 1",
+    "type": "gondola"
+  },
+  {
+    "id": "c1cfe0e7fe7808cc945700ea77a5c32106bfdece",
+    "name": "Châtelet",
+    "type": "chair_lift"
+  },
+  {
+    "id": "ac94427ac8fe260e8783870188af002fefff8b73",
+    "name": "Grangettes",
+    "type": "gondola"
+  },
+  {
+    "id": "68a87ab465feadafbd11f5f8b6969180a69ad693",
+    "name": "Petite Bosse",
+    "type": "platter"
+  },
+  {
+    "id": "d0f6119dda649ad2ba30a8d507786ee33a5607b0",
+    "name": "Plantrey",
+    "type": "chair_lift"
+  },
+  {
+    "id": "1821d3fecff7cebb5598740bde3115ada665ec10",
+    "name": "Tovets",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a81a5a20ace826620f3384d13fa3e0df85af0edb",
+    "name": "Stade",
+    "type": "platter"
+  },
+  {
+    "id": "0a6295394d83f14e3c447fe002bf0ffacb773c6e",
+    "name": "Plan de l'Eau",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b3198267fed085f6a3f780ffb46af3243f48fb12",
+    "name": "Morel",
+    "type": "chair_lift"
+  },
+  {
+    "id": "dab63e1ad9c8606e53f88a5d3e85be81459c0989",
+    "name": "Stade Tania",
+    "type": "platter"
+  },
+  {
+    "id": "08634ee4eccb70de22f9ef0922cb288cb1007c57",
+    "name": "Roc de Tougne",
+    "type": "chair_lift"
+  },
+  {
+    "id": "0caea2cfa8cd6fb26cafbb12009ed5988bdd48d4",
+    "name": "TSD6 Tougnète 2",
+    "type": "chair_lift"
+  },
+  {
+    "id": "315db0deb787a719298c94b8242a88f7f76e429e",
+    "name": "Olympe 2",
+    "type": "gondola"
+  },
+  {
+    "id": "2d7d66f57ad7b7c2e22bc213c1baf9a6d3c5ec17",
+    "name": "Sunny Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "5d3856d207e292ef1aca6b471f04bb6c7d7205fa",
+    "name": "Reberty",
+    "type": "chair_lift"
+  },
+  {
+    "id": "07a527c36190a94cda8398279cb15cf8a82c3e0c",
+    "name": "Granges",
+    "type": "platter"
+  },
+  {
+    "id": "84f6e283407a3738ad01f744699dcaeb8ca20148",
+    "name": "Teppes",
+    "type": "platter"
+  },
+  {
+    "id": "6af88b211e94d262b82be4edd382becdee55ec94",
+    "name": "Mures Rouges",
+    "type": "chair_lift"
+  },
+  {
+    "id": "06869df19459043b8b37b8ad587b2b3ec73e10c0",
+    "name": "Brelin",
+    "type": "funicular"
+  },
+  {
+    "id": "e5116e4c29f860f492bd1a49e7246191c40adeee",
+    "name": "Preyerand",
+    "type": "cable_car"
+  },
+  {
+    "id": "a5f2ffbfd9d46932a919045e785d1a44a0cf1bfc",
+    "name": "Aigle",
+    "type": "platter"
+  },
+  {
+    "id": "5a17806da9be47d95e549cd801bc8a243182ea95",
+    "name": "Village",
+    "type": "platter"
+  },
+  {
+    "id": "bf0a61816ecfb5db9d6dcd58b9a400c59cf65d2d",
+    "name": "Saulire",
+    "type": "cable_car"
+  },
+  {
+    "id": "dbcb8ecf3953432f90512a1c4d20a3027a731eea",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "7a5afb174bbb59d025792290609d0ce614b634f7",
+    "name": "Verdons",
+    "type": "gondola"
+  },
+  {
+    "id": "1760a610c3a5506bd2f4dd8f6b229f18f761dd80",
+    "name": "Plans",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "128ad3a080b7d7d918e8f07fffc8c11fa80d3c4d",
+    "name": "Musaraigne",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "59be20e86e16d0486a0f43178fbb6b5f3446ef9f",
+    "name": "Campagnols",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "2184211cf6fb96b0f20dff8e40762becca3462b2",
+    "name": "Chalets",
+    "type": "gondola"
+  },
+  {
+    "id": "47b03d077ee73d8a35562181ed760653dada3ff0",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "eb1a199c06b50b98eb21f9d6e87e2f9f62d15fa1",
+    "name": "Doron",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "4a44a06e9a3c4b6e937091a513df7f5d648ec5f8",
+    "name": "Loze B",
+    "type": "drag_lift"
+  },
+  {
+    "id": "22e2de52d19d7015aec9d64325e3f527a4f1c9b9",
+    "name": "Epicea",
+    "type": "platter"
+  },
+  {
+    "id": "73e3885b0e82c7ca226664a90d904cf02e6a57d6",
+    "name": "Jardin d'Enfants",
+    "type": "gondola"
+  },
+  {
+    "id": "52208d81104870626ccf00890acd251779024358",
+    "name": "",
+    "type": "rope_tow"
+  },
+  {
+    "id": "9f8e263fb4a90a8f6949b3b2667bf81394d5aaf7",
+    "name": "Côtes",
+    "type": "platter"
+  },
+  {
+    "id": "408c76bec2e139d85aa3bebe2d5110c8c28c595c",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "4fb668f6e0f9eca6614bac17042a3a553ee017e4",
+    "name": "Étoiles",
+    "type": "platter"
+  },
+  {
+    "id": "7d9944447a556fd06da7693dd4c9b7256e8fb913",
+    "name": "Fontany",
+    "type": "rope_tow"
+  },
+  {
+    "id": "5a7fe4092d66cfa06fb273d86c8f0a61401decf6",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "980c5f08111d90afa5e3cd4de0082ab49227d355",
+    "name": "Jardin d'Enfants",
+    "type": "platter"
+  },
+  {
+    "id": "d7a898f4f2f7052eec835c513fbe26ae0d015f87",
+    "name": "Stade",
+    "type": "platter"
+  },
+  {
+    "id": "3841849a13750f68456d5c92bd2020e4fc086ee4",
+    "name": "Pyramides 1",
+    "type": "platter"
+  },
+  {
+    "id": "7a8f780fad8a1728eb0e384902b3947c193f8faa",
+    "name": "Pyramides 2",
+    "type": "platter"
+  },
+  {
+    "id": "1739b5ebe34a5fb67feed6d43721c08b44b32b2a",
+    "name": "Altiport",
+    "type": "platter"
+  },
+  {
+    "id": "c307ec79ec46b39e2630e2ad7265a7c73861fc9d",
+    "name": "Ferme",
+    "type": "platter"
+  },
+  {
+    "id": "ca8e6d3cc5bea1876723736922030e6e5a8e771d",
+    "name": "Mickey",
+    "type": "platter"
+  },
+  {
+    "id": "50bbe14f9819f12ab18ecca8b6c6b84ac6a0c76a",
+    "name": "Belvédère",
+    "type": "platter"
+  },
+  {
+    "id": "adefcfd9a1b2651599283e194c4be862013f3d46",
+    "name": "Preyerand",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "23e151cbf60ea40464dc48da453e11ee52a67345",
+    "name": "Cospillot",
+    "type": "platter"
+  },
+  {
+    "id": "ebe609f806c9c44fa46213060ee61327d1e8bbbb",
+    "name": "Roys",
+    "type": "platter"
+  },
+  {
+    "id": "7ca3cedbb76f590a25ec0de360a339526562b9e8",
+    "name": "Bellecôte",
+    "type": "platter"
+  },
+  {
+    "id": "82cbc07b4ba4c0b17fcca2f25861804d5eebbc82",
+    "name": "Côte Brune",
+    "type": "gondola"
+  },
+  {
+    "id": "752e30114fd610adcca042ae2d9517fa7f2ccbf0",
+    "name": "Thorens",
+    "type": "cable_car"
+  },
+  {
+    "id": "2e97fccd2dc026901df8f2117d09292495a5fe20",
+    "name": "Saulire Express 2",
+    "type": "gondola"
+  },
+  {
+    "id": "d0992994b4f19e2788e6b72a188b304e787125e5",
+    "name": "Loze A",
+    "type": "drag_lift"
+  },
+  {
+    "id": "f0642d2981a152ffd748a6d2b8954fd0ee5b9e3b",
+    "name": "Bouc Blanc",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9d673e3e04fea33efe3b997262015ceeff361446",
+    "name": "Petit Moriond",
+    "type": "cable_car"
+  },
+  {
+    "id": "1324f291f67cc53ab2e14c9d10ffea857050632e",
+    "name": "Piou Piou",
+    "type": "platter"
+  },
+  {
+    "id": "fde188e1047068f898d644c2519f1f112c03e1ed",
+    "name": "Plateau 1",
+    "type": "platter"
+  },
+  {
+    "id": "937dbcbfc7fbb2406ac8ace68514c54e661e3c2c",
+    "name": "Plattieres",
+    "type": "gondola"
+  },
+  {
+    "id": "fb1fcc706dbcf82690088d0636ce03807eded82e",
+    "name": "Combes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "6b014f1d7524c6cbe8d82654a7499a1e14e2daff",
+    "name": "Télécorde",
+    "type": "rope_tow"
+  },
+  {
+    "id": "58e0f9e3c09b0a99673ce4695d23ed3ac205745a",
+    "name": "Forêt",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9e691294c023d35f328f3067a648693d18a74bbe",
+    "name": "Funiculaire des Tremplins de Courchevel",
+    "type": "funicular"
+  },
+  {
+    "id": "7788634f484db3ca5a0f1ff6dd8aa4be46f19c06",
+    "name": "Bettex",
+    "type": "chair_lift"
+  },
+  {
+    "id": "4a4aaad441f7a1f5a2c19ac48367dc00cfcd8dea",
+    "name": "Arolles",
+    "type": "platter"
+  },
+  {
+    "id": "3f7ad9ff00bd3a88bc06b1f3b3a1400ec7067c92",
+    "name": "Lac Blanc",
+    "type": "chair_lift"
+  },
+  {
+    "id": "f54a0fdfa726437e7935617753478e9df574f76a",
+    "name": "Cherferie",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3f916f74d7d46fb98bb9c57bfc7baa6de9a4881f",
+    "name": "Table verte",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "498dcc8ea03fe644b47bb611c461f4e0ac51aa6d",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "9746497544ae2771713dd9dc298b7740b883a0cc",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "2318e9f378dae2ccd58c8f73552a5beb54c604d7",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "004e3f0819939de340236bd5fcffd6c025171d2f",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "80a61d7576c5ce13df01bd8ccdb7097dac2b90df",
+    "name": "Funitel Péclet",
+    "type": "gondola"
+  },
+  {
+    "id": "37b4890f447d0a8d727de6a0abae4d85d8bc982f",
+    "name": "Grandes Combes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "f0e23097bbe0591123a9abb8ded3754a23b82600",
+    "name": "Praz",
+    "type": "gondola"
+  },
+  {
+    "id": "e96d07ae143f5b56491de13178b00c8ecaae580b",
+    "name": "Bruyères",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "3669799b77d634a1bac120fc1ca5564b0fd8eb59",
+    "name": "Reberty",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "e8a28db7f0f544bed674bb32f9a04ba2d0050db0",
+    "name": "Pelvoux",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "d9d7c56d5dd129df8314bbcd509e5ef47a3f9489",
+    "name": "Télécabine d'Orelle-Caron",
+    "type": "gondola"
+  },
+  {
+    "id": "4c37a9e92c53634c0130b767b94a03c4f7653da7",
+    "name": "Pointe de la Masse",
+    "type": "gondola"
+  },
+  {
+    "id": "93145d774308d9f2dc078fdbe12cd0fdc981fda1",
+    "name": "Biolley 2",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "d6c1c201739d1b8f4fc67b01e15c69bd1e20e95b",
+    "name": "Biolley 1",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "fdee0deec756acadff54363a15c18f87dfb95f4e",
+    "name": "",
+    "type": "funicular"
+  },
+  {
+    "id": "dee8fb6e0f5ccaa9545960f78442bfd5f65ed914",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "0e562352866c153f71a36789f03ec7789ad546cb",
+    "name": "",
+    "type": "rope_tow"
+  },
+  {
+    "id": "a498b27ed5b2b6bacf42d9006cc06dece83f4fc9",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "1725d1afa56a4d59ad096c2a08e83296a92ec3d4",
+    "name": "Ours Brun",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "b95c1df608dfa1cd0109940af20360636bb53026",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "d3df4cf92bf7cd12341fa8ff6a19cfd95268cf03",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "1486ebe41ff7fe965730e8a42718f1d5959cd723",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "30c489307b39d53e95ff37fca16678d90b366769",
+    "name": "TPS VCS",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "ac9fbf9a68da3b3b40f6d0cf971e54c8275ef6bd",
+    "name": "Télécabine d'Orelle",
+    "type": "gondola"
+  },
+  {
+    "id": "eef3a4ac83259c04e5b18f716008e1f98dc087ad",
+    "name": "Rhodos 2",
+    "type": "gondola"
+  },
+  {
+    "id": "26e4722a71ffab96e20d93ddfbabd7a140c4afdd",
+    "name": "Bruyères 1",
+    "type": "gondola"
+  },
+  {
+    "id": "367eabd22f3d6233d8e0f63838b5157dce79931d",
+    "name": "Olympe 1",
+    "type": "gondola"
+  },
+  {
+    "id": "795b336991459851e091322092571dfb0da0184c",
+    "name": "Olympe 3",
+    "type": "gondola"
+  },
+  {
+    "id": "8305e5479880387459fc43fbeec7dc200e90e50c",
+    "name": "Face Nord",
+    "type": "gondola"
+  },
+  {
+    "id": "46e44583adf54fc69124240ffc84e2d37cc20fe1",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "57c5b40e045ddf9f52cc1d3cd11a57f44a9c9a61",
+    "name": "TCD10 Les 2 Lacs",
+    "type": "gondola"
+  },
+  {
+    "id": "ffd3e045ee61421eca7dae8deca6bfc1571b2831",
+    "name": "Marmottons",
+    "type": "chair_lift"
+  },
+  {
+    "id": "56d786894fce9200b2e8d5831ea18250875d5e92",
+    "name": "",
+    "type": "magic_carpet"
+  }
+]

--- a/lumiplan-maps/data/les-3-vallees-runs.json
+++ b/lumiplan-maps/data/les-3-vallees-runs.json
@@ -1,0 +1,7087 @@
+[
+  {
+    "id": "113f5658dcb41d9b6795f0446a42b66b4e132282",
+    "name": "Stade de Slalom",
+    "type": ""
+  },
+  {
+    "id": "38bbf76a4673879952d49374fac545858ccd2fc3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6d3fcfb4678fdd6aefdbd5d8369229d31bebdcaf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bb6a68dbf69903d163c120ab1767728d4709698e",
+    "name": "Tête Ronde",
+    "type": "easy"
+  },
+  {
+    "id": "48451e132fff2daa33449745ce44ac8f13468472",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "da36fca04211b839287b9f8c4fe5ffa98da06fef",
+    "name": "Coraïa",
+    "type": "intermediate"
+  },
+  {
+    "id": "f8d6a5cd27a82eb84fb89cf40d8610c75905244e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ae7353522ff245428f5366d72a61b4f5bc1fad13",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "3b2a696ef1a4c12c768fea49b53b3e01d2351a7e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "25664f1e5a6931f4643ceec462d21a47d9b521ba",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4fa2269feda6fa0a5c293da503ee623bcf401f82",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "81bdd3016f158b45f75301d04b4bd9af1c0f0dff",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0d450b6ea69418a20cd4bf3bb59959503f4e2481",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b4503ab9a25168e60b19daa85e9de782c1badcba",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ba8b46339eb95a1f778691c9bb642ad22ab0e885",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "754af2128611597ffdbc2b338bd2f8609e9024ed",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a958da619d8fe6f5372a327749409abad881caff",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "f2dd8a82c15cd3d3088273c084cb5fa3596ea845",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5de66db4b26f51592a61bb1cf389bdf9d9058088",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1924398e836067f3e18d847f1fecf60288579555",
+    "name": "Col de l'Audzin",
+    "type": "intermediate"
+  },
+  {
+    "id": "bab299385036265e19088e08220616146834a5f1",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1e9569ba70289d708b7d933107393e94fa232510",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "fa47c5ec6a1e1df1486a0d4c8fd1b7a86a3f0527",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "743dadffde56a9e6add77bf71198baece1589dac",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "045e0c9e7ed9859300fb2e913eca9efad434718f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "08b199bb6c1fce3d9a8510a2630b829ffb41bb30",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e67fe22d92c723590b9d04ecc1efdf1f2f593386",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "02b8613448644747e8d75227bd5b32286c068829",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b93ba569d0f40762c65f085383f595eb369dfbc3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5f8764d19858c064870f638bff563785422a444e",
+    "name": "Pluviomètre",
+    "type": "easy"
+  },
+  {
+    "id": "97d5efb90367e3445453739d417a01fa4a5bc5d2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "75228cbbcc10c71545bb6cb5473f33a970e79e2c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3687ccd99f0994122b2b30a291f57ac99df91361",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6c1db8018e29a4ce60210a42b727eb941fbf4876",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "830b1bca1d81f79176bffdd532b546ff82026e2a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "641452469109110b9b8349f69e2095025c6d9eb7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e0041ba36e4695bbb7f33d49d6212b15e00d2727",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e1c927fcca66aedfd483ccc7ef7f388a0ef0d928",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6a589eca7055ab0451bb7252562acc43b85555f1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "35437fdfedd6b25226a9d74d2aff1fea963a6a12",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "912dc1193ec852c1dc01d7b89617fc50137a281c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b2bfe461b2d8d9b281f5d3b1f2616bc6c1acb8b0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d67de5c9c2744458a62e91784e25209754cb50c5",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "2cc300d9dea448d3885c3fa7dc55e6d1aa5d03e9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "34e41935aa01aefcd52a3f5e3b84e475776a4f4b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8545b72e08936161712c537f35f7d7c3fac1b427",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1a4e2e0eaf4190c8b3e783bc1e73e54df07893ac",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "883156e24d752b1724b6c616313b220c7d824397",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "eb81cd83cef86de784a67d2fa001775d9210554c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "729f7ac7287b9577032bfc7a7811b9808369164e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fc1c9866e7d2a8aee9409de271af2ffea601f570",
+    "name": "Boardercross",
+    "type": ""
+  },
+  {
+    "id": "0a1a7e591355e003dcb26d30e8ed5fd0c94015ba",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "56b8de9390b092d010fb6035f4751b68c2139a3d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e38df21de7614fd28fdfdca0337b60339c281edc",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "94eec2efd44db1c7a28c7388e930f9b88d19611b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "94d7c34b3c0c36acec3a0b3df6ebfb4f927d0a76",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "853e40ae08a7b640627960f67eaf94f651237c3c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dc77f61f8ff8a3c6327b81024bda6251ec0f5f75",
+    "name": "Stade Yannick Richard",
+    "type": "advanced"
+  },
+  {
+    "id": "88b2138f63fd974adffe1d5f17a89f4cdbe49fd2",
+    "name": "Béranger",
+    "type": "intermediate"
+  },
+  {
+    "id": "5f17d51dadb4b62c7bea8d7aeab940423ff15979",
+    "name": "Lac Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "4a578363b3b6ee5e22cc89a23e2ae3c162797db6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cccfb052c65377752ef78fcc5c8fa26a431cfc10",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b02522b649bdf001dc11a194c531f2389c413d25",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ff1bc3f89f4c38878f5d82e20a257b1baa996fd8",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "e62eada6df62a7001c43fb2c7ad00503907d334a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "dd2fe3bda4d8dafc204cc1af4a4c07c10c1eb0fe",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "04cf190c932ca78cc74284e59d35124569c49fb0",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "7e92cc152c458861346e8caee6d89bae711d818a",
+    "name": "4 Vents",
+    "type": "intermediate"
+  },
+  {
+    "id": "c096e7adf7bcb5378b487939e7ef065f5900926b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1088c117dd1c5aa31d66578b6daa9998d96186fc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d47f6ee7c6b2c81220d87b8dbf97c20a8200a231",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "90afdd6ce50c51acddcd0596300e96fca09f2037",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "37543b64892a62f6537d4f583e1349798aa3a610",
+    "name": "Fréderic Covili",
+    "type": "intermediate"
+  },
+  {
+    "id": "7102c5cbbc36bab837d00b65dc964863ac129d15",
+    "name": "Mont de la Chambre",
+    "type": "easy"
+  },
+  {
+    "id": "70fb38b399ae42120daa0fd989a6e20866de2b25",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4363cb397426003843c28b7cfc6e35a1d7a61c8c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "83c80ddf08527856b3ac9fb5e354e1d6da62e245",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "adf1962a07c8845b06054decd04eafa491b0ed23",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dfe81fa8237dc1fbec527a26bacc3b3b10f47198",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3263799190b94bd37d62c40b96f78eda6a3ac3d7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "45a3dcb77e7be8f9ee392ce55f77a941b623ea36",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8d28077447c71d6d26009e0910dd7e4a220e5cd7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cbd965bf59d7b977f045e1c014c6ac7bf9b7963f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "64fea677ba95c551f94b9c1528f7ec4da3b5adf8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "885d60851fcc0d7a6d4909fef5185aaa75d05081",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "80aee5d1292a3ce2042544e106451eaada4a9d6d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d08952400d8b6e1650e155b882bdbed92faf3cb7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "78774bd9297b138485f05d38958607bd2fbfe08e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "873b37d329ab3d850e74c6bc88fa2b44aae87072",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2d22292dd79ae6fb9313e0f8688c0b95adc5e79c",
+    "name": "Bettex",
+    "type": "easy"
+  },
+  {
+    "id": "23373bdffff849270d3920206719d68500e81882",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "52b551948ce501c86613597480e2a9216508cb4f",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5e7f4e8716ba7e51cb6dda24bae5eeb421cc508e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "705d3ab536717a1d2e8eb157f96342289c15b4e6",
+    "name": "BK Park",
+    "type": ""
+  },
+  {
+    "id": "dd1f743bf0ddd5284a7d21daef47631349444363",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ba7ff54294642c72561b3404184cc93d54dfc350",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "47502c2e1bd496009dfc5383f315644a8e9dac99",
+    "name": "VT Park",
+    "type": ""
+  },
+  {
+    "id": "2ed8a52c42e00840fde3899f897b5a60f1f6c969",
+    "name": "Espace ESF",
+    "type": "novice"
+  },
+  {
+    "id": "8e2bae3ffbb4e47671d2cbc83d3b824db7895158",
+    "name": "Mauriennaise",
+    "type": "intermediate"
+  },
+  {
+    "id": "ad102326ae72cf002612340839f8ec377b480e4d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dfe85fab3833f7ce752dc73f23483f0a0d373480",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f28427197dfcb04786293e1bba66ac0ec51cc504",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "73ecd157fa20abcdde93f7e7f80bd405193e0723",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b41c93604369d5157c8a396f37acc697224caa47",
+    "name": "BK Park",
+    "type": ""
+  },
+  {
+    "id": "cbe4f77c9f8e0f46524cd53a688b1c9220e3f46f",
+    "name": "Espace ESF",
+    "type": "novice"
+  },
+  {
+    "id": "bf5c8b8bf6de46a0b798e55531a096de3fa5ba06",
+    "name": "Adrien Théaux",
+    "type": "intermediate"
+  },
+  {
+    "id": "ce64ae0ea452419e210a91820765ee8748732937",
+    "name": "Family Park",
+    "type": ""
+  },
+  {
+    "id": "2aaa4c22fc057af21b11246a702da43f65e1f2f9",
+    "name": "Moon Park",
+    "type": ""
+  },
+  {
+    "id": "797a0927a231e85c22c9f41aa2cd39a7f8e8695b",
+    "name": "Club Piou-Piou Chaudanne",
+    "type": ""
+  },
+  {
+    "id": "cc4f41c7e89fa58474aae917163e3cd6584e06f3",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "7d35696d754ea11c8fdec275eca7e9099bafcf72",
+    "name": "Stade de Slalom Emile Allais",
+    "type": ""
+  },
+  {
+    "id": "eb3706d4f08cfcc2a3265ef17327b24f2ab36fa4",
+    "name": "Dalles",
+    "type": "novice"
+  },
+  {
+    "id": "17a822f0bfc8681aae0f9458f9b30e7f02f24e57",
+    "name": "Combe de la Saulire",
+    "type": "intermediate"
+  },
+  {
+    "id": "abc13b6a054901af360ad95293265df4158e7bf5",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7c3fedb5da5ee4d525c27972aa6b6d179351fd4e",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "921a4e3d2bb4fa45cb880b8c225097602a8e1cc7",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "660a04d359a17e60a745ab1a9865194c724a740a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "266c59224d197530a640f9b5058eca058b76be94",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "68482fab4d9fcf3e5e736b6157863f8c2404d389",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fcf73f7e4cdb6220fbaf6f2bba6a82e0a994bb58",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "0f6b60461cc0907d37a3218d21644b4eb0714103",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "046a0e1238be44858780294c51f06c5c9dbe72a1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8d75eac1025d46ee9707a206503a6147067c4494",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ad933385eeab8c1dfd020f0c19433c12e392be8e",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "1d634033aea0ad2025d512360127558207d42f22",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "75afe5fad50fdb65973f679b74f7302b5fbb6c4f",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "be6414d925b09919561232ec02a8db945628c281",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "80b23582d6578ba11467c177ad922294cd893e65",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "edeb66176ea102bd2ecab0920c1f7c8e912ffa0d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5715bf4abe6d3eb98c9eb80bf8d0eaf8f82af797",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "798c606769574e72e01132d3ab28507f3fd62a76",
+    "name": "Couloir Tournier",
+    "type": "advanced"
+  },
+  {
+    "id": "c214643a4ecf0b1abcd0e916dc029eb20da56e1f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c51860ef1b4c82ef2cb45c47747622f6f344cd7a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ef568aa8b1a0e5d3dcdae3b8225a536a88db77e0",
+    "name": "Natural Canyon",
+    "type": ""
+  },
+  {
+    "id": "c0ef02a4f71b03c085e799077fff844ef8ab6630",
+    "name": "Snake Park",
+    "type": ""
+  },
+  {
+    "id": "01aa355063f0eb69c55a3dad9215acb345c686a6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fba8ba1a5e4eba2ae4c1ad6f548cfa95ec56e05b",
+    "name": "Courchevel Aventure",
+    "type": ""
+  },
+  {
+    "id": "d783805437ba383b0473b440d1ab25239dbbfd9e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "77b0f7101d5651d5f3e3168002b3aa9a221f09de",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "90ecb7c709b6c33db1e266b7d167e61e37409e2f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6f3932dee68fa5aa4ba63f2b4f7c53bd96eaa07e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "42c6e7187ec9703f65335ef4b2abd1bc30274085",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ece4d463a59dddaab992ff08c4b9b3863371d377",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "dd83124995729d509fc85c4287fbb33b8c7c7bb6",
+    "name": "Dalles",
+    "type": "easy"
+  },
+  {
+    "id": "9cd0c0900bff8c76fda33e5ff3f862e178ea30eb",
+    "name": "Fun Slope",
+    "type": ""
+  },
+  {
+    "id": "4eb4933c29788ebb8a82d7e64d56390f49e56a14",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "27c3dcd51a845f871fb897345453303cbda5caaa",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7f7d791f404b05e6a34ad363d76d7038a6ae71f0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "e2b8fd01276229e697fb5435c189834b0f7d40b6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "58c7a5475ebae832537ccf0cc4a8f71661d0cbfb",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "0aadd7a116292343f4c49ea0e0bbbb80f219e731",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "2a8c0f8f5f9e9322d230057218cce4b45bebf699",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ec2488d29db98db7b73f00edf485046fa22140a6",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "0c64259bbeae447a4f635336176369112a445672",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "bb8f058f1a4e2ab393ce83dc3c670c5a3592f7fa",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7663a993c85be45d43f139e85055db444e82930d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a91800e7f724d122ad89a88847680094b1e079e5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8c90ffc9c9d3e1fa89783aef91b4839d56f0529d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9e6b8f7bf91104dc147d833d3c8b492a1a871e0d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "172511d87f66994d8ad4cbb9092dc29b94fbca1e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a08a6257664479e84675c0569d1cf03208c3a01b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "31b17a1fa4dce0c9e9d56a887b42cacdc1525d0f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d60e15b4aca504a874e8ec8c394e907cc71a06d9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3761690500fa4fac6ecc0da067294ef1d68d5abb",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7bc7fb74ec32ffef2708da87fd57daf4e547c46e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "02de22c8bb7b36351ba85df2b6180268e9cbd9f7",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "22691767b438a01f78af0ca241d8bc4bb15d6a69",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d71d99513e328653ed5e91578cf1c778572143ce",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "e9f0fb21125ed46298db4e2c86b8d2e752c5ef40",
+    "name": "Roc de Fer",
+    "type": "easy"
+  },
+  {
+    "id": "438c33cfcb957c286e984abbfc198e495713b28c",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "20ab86194de8318af985d01301a6cb611b2ab631",
+    "name": "Longet",
+    "type": "intermediate"
+  },
+  {
+    "id": "93b1e2be5814785ac944b05611722cb39691cace",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "05a70328061258aef8f4d26593a012b765f17b8c",
+    "name": "Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "e004c887d015d50ac5dc4e259aaacc18b7351a20",
+    "name": "Mur Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "35a3529e5c6d5fc4eeeecf4454a142135dc5f4ee",
+    "name": "Les Enverses",
+    "type": "easy"
+  },
+  {
+    "id": "ccbe2e4a88301ce239ae70c006e5ac47c54c0dc7",
+    "name": "Rocher Noir",
+    "type": "advanced"
+  },
+  {
+    "id": "349cd99b0bf2ba7c88355130026cbe1da1ecac8c",
+    "name": "Rocher Noir",
+    "type": "advanced"
+  },
+  {
+    "id": "3b70f6b79b9790628b0d4eb166d7c54e3d029950",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "ec09facde67e768e55be4564201f41b4dce9dc12",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "8ac1d1553b1e5f3ba2397bf63920b60d2c354273",
+    "name": "Crêtes",
+    "type": "intermediate"
+  },
+  {
+    "id": "38f9e770c09e749cda55ec393dba052e6123e973",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "73ae2023caf2a841808cb56da64178a9c5bf8852",
+    "name": "Rochers",
+    "type": "intermediate"
+  },
+  {
+    "id": "396d2e52dadc5c1ef911ca66f8378fde48884b7b",
+    "name": "Boulevard de la Tête",
+    "type": "easy"
+  },
+  {
+    "id": "f73142df573bd53c757f0c0a83458a220d9f264f",
+    "name": "Dame Blanche",
+    "type": "advanced"
+  },
+  {
+    "id": "8fd19281a23808d16a045825c7a6464233953bee",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "6f33f531045fb539d6aead5a9142978ac720e145",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "06124a41307f7ba6ed9dc6ddad79c99c6140a2d1",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "a4aa2fbc01e99b4c33f32a679c2fd200a025dbb4",
+    "name": "Friendly Natural Park",
+    "type": "easy"
+  },
+  {
+    "id": "34aaa448bd8bdce2e0b63f0122bb116215f204d7",
+    "name": "Violette",
+    "type": "novice"
+  },
+  {
+    "id": "21b2aeb26bdba7e6b572c41aeb2f01115fed8292",
+    "name": "Montagnette",
+    "type": "novice"
+  },
+  {
+    "id": "1b6a10252e23dd869f6ca5e9e23e6c195c23070a",
+    "name": "Les grandes Combes",
+    "type": "intermediate"
+  },
+  {
+    "id": "ee77f41882a57901ebccafb9f72cba4372718eb0",
+    "name": "Gros Tougne",
+    "type": "easy"
+  },
+  {
+    "id": "9c3c528666a102b653b68de96dfe5c514f644a0e",
+    "name": "Boulevard des Girauds",
+    "type": "easy"
+  },
+  {
+    "id": "6d58d2fe75adc77921495f0e8692a122e8a4091f",
+    "name": "Allée",
+    "type": "easy"
+  },
+  {
+    "id": "e34ad92bf5e1dad92e537994e5113205a4f5ea1e",
+    "name": "Allée",
+    "type": "easy"
+  },
+  {
+    "id": "bc1bc3bc7e12032c4a690177739f24e7ddc3f8ef",
+    "name": "David Douillet Haut",
+    "type": "intermediate"
+  },
+  {
+    "id": "e002adc0c9aba5110c87bb8b616af91be3037d6a",
+    "name": "Paturages",
+    "type": "easy"
+  },
+  {
+    "id": "1d4f7d7c3c6b68031c85204f79e2606592b3323c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9e69b9fa23c7e832d7352b67cb782fe24e5ad52e",
+    "name": "Combes",
+    "type": "intermediate"
+  },
+  {
+    "id": "fd9925214c22c94a7274b08296bf895322c00a52",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "de33bc5dfb3af37def3393cbc73e9e1bb3dc2c60",
+    "name": "Lac des Combes",
+    "type": "easy"
+  },
+  {
+    "id": "9f3d7fb8985edfbb6a5056d1d96d427171dfaa08",
+    "name": "Côte Brulée",
+    "type": "easy"
+  },
+  {
+    "id": "5c624072e80cff5d7b1dd282eb6c2d150226919e",
+    "name": "Côte Brulée",
+    "type": "easy"
+  },
+  {
+    "id": "ac8ed95cd05e41365d22407bc7686c3ab181c30c",
+    "name": "Lac Noir",
+    "type": "advanced"
+  },
+  {
+    "id": "6e651879ec944eb045d67941f8538ae53102bccc",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "cba57138fa56e4b8e05b40bf255841aaa68dd22f",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "20f0fa71623fef24e571959da2835809aeeac42d",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "6f580dc6f01c2d7a8133706efade585be0788a24",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "cad3119985d83490e03d6a958424d558f2e699b2",
+    "name": "Boulevard Gury",
+    "type": "easy"
+  },
+  {
+    "id": "e5a2e72879f2b2e0a485762355912ad0ddbe32ac",
+    "name": "David Douillet Bas",
+    "type": "intermediate"
+  },
+  {
+    "id": "7385d356287485e99caa80c7d56c20b656d249e3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "00f4835f2035911d72acf638da2bacd8e7f2dc6a",
+    "name": "Pylones",
+    "type": "advanced"
+  },
+  {
+    "id": "755c5bf20004af20ff7502d4b84808d71d56537e",
+    "name": "Léo Lacroix",
+    "type": "advanced"
+  },
+  {
+    "id": "19075126a6e6f7cfeb6ce1721bc4e3bdef7ad3d4",
+    "name": "Léo Lacroix",
+    "type": "advanced"
+  },
+  {
+    "id": "5dc30ae84a8b983eef736b2df846cc96ef05bb5b",
+    "name": "Aiglon",
+    "type": "intermediate"
+  },
+  {
+    "id": "e324f73a44db8ead04300443650066fe0b24d98f",
+    "name": "Boulevard de la Lance",
+    "type": "intermediate"
+  },
+  {
+    "id": "d4baa7d51f427ad17ab41fdf8de5f00d3c98ef39",
+    "name": "Boulevard de la Lance",
+    "type": "intermediate"
+  },
+  {
+    "id": "c682c8ffdd73ae61a226ddb1c6d87383e181d64d",
+    "name": "Les Plans",
+    "type": "easy"
+  },
+  {
+    "id": "1c0f67f4a25edbeeeecdea3096a7b70c27ad1d5d",
+    "name": "Gaston",
+    "type": "easy"
+  },
+  {
+    "id": "ebbb3a66438f1e15edb3709fea27e666fc522442",
+    "name": "Boulevard du France",
+    "type": "easy"
+  },
+  {
+    "id": "81927e273627e4a21ea2b9d28613ac345022e3f0",
+    "name": "Boulevard du France",
+    "type": "easy"
+  },
+  {
+    "id": "d3c5c59b428657c448b76a8c49b10cc82a6e2953",
+    "name": "Mouflon",
+    "type": "intermediate"
+  },
+  {
+    "id": "91793a3c41b4deb1a5c48a47da5141ce6df2fbb9",
+    "name": "Boulevard de la Becca",
+    "type": "easy"
+  },
+  {
+    "id": "f9cadf89f0d4dad51d9c2ddaf7707edc05f991cf",
+    "name": "Boulevard de la Becca",
+    "type": "easy"
+  },
+  {
+    "id": "533b2c581ce06362f3840f92d352a04e785d173c",
+    "name": "Pelozet",
+    "type": "easy"
+  },
+  {
+    "id": "14f9b53dd2da367a5fe24ac1acee6ead2d7983fb",
+    "name": "Planes",
+    "type": "intermediate"
+  },
+  {
+    "id": "61adc3ee7e620e2bcb495c09e2beafb2e8e46879",
+    "name": "Boulevard Cumin",
+    "type": "easy"
+  },
+  {
+    "id": "99d1bd529aea0bc4c5877a5203009c57f8292424",
+    "name": "Boulevard de la Masse",
+    "type": "novice"
+  },
+  {
+    "id": "aa90c84de9e5e248886cb8903c870b6b6713add7",
+    "name": "Boyes",
+    "type": "easy"
+  },
+  {
+    "id": "497ebaad0c461ae7383a9a9e9cd1c223d73d0e18",
+    "name": "Fontanettes",
+    "type": "novice"
+  },
+  {
+    "id": "d46831b913a60bb9c6a03aeb36954fa764979ad8",
+    "name": "Lou",
+    "type": "easy"
+  },
+  {
+    "id": "a1c332d5cf5bae030f7642987f79dd91c207d8ec",
+    "name": "Lou",
+    "type": "easy"
+  },
+  {
+    "id": "6b8b8eb6b1c9d4330b32fdc8282b8600ffc160eb",
+    "name": "Boulevard Cumin",
+    "type": "easy"
+  },
+  {
+    "id": "a2c52133c738860a5e8789a7d95cbbf57ce13aa3",
+    "name": "Bruyères",
+    "type": "easy"
+  },
+  {
+    "id": "1ec21eaa4f32578daee9f92217ca32a96844832f",
+    "name": "Chasse",
+    "type": "intermediate"
+  },
+  {
+    "id": "f578edce959350ceed0ad78f6601336a8f42f03f",
+    "name": "Plan du Bouquet",
+    "type": "easy"
+  },
+  {
+    "id": "0156893b047f1199c3ffb01f943bdb6677bcb6e2",
+    "name": "Traversée de Montaulever",
+    "type": "easy"
+  },
+  {
+    "id": "7b54c9375ab0152a792491de1e39b29e1f1b478e",
+    "name": "Mont de la Chambre",
+    "type": "easy"
+  },
+  {
+    "id": "afe0d92e3417157a5cbbdbc0f52eedf4269d66c2",
+    "name": "Alpage",
+    "type": "intermediate"
+  },
+  {
+    "id": "08632657de19c5f981001d992f0e854fd04b177b",
+    "name": "Biolley",
+    "type": "easy"
+  },
+  {
+    "id": "baadff6a92c1184fcdc590dcf7905e284c2438e1",
+    "name": "Loy",
+    "type": "easy"
+  },
+  {
+    "id": "cd651ccfa72772cf86b04f5e63eb4a2da5196b7d",
+    "name": "Loy",
+    "type": "easy"
+  },
+  {
+    "id": "98de6b1424f5e05ee631f26f9718c1c08d079d27",
+    "name": "Village",
+    "type": "easy"
+  },
+  {
+    "id": "7ea5df1d463930f6964553b9db25b49461af46a8",
+    "name": "Verdet",
+    "type": "easy"
+  },
+  {
+    "id": "dcbd4820f28b3d596bb81f98572e54b29f1cd5ad",
+    "name": "Jérusalem",
+    "type": "easy"
+  },
+  {
+    "id": "2739ffb8e316516059de9799fb8de854d6fdd22e",
+    "name": "Jérusalem",
+    "type": "easy"
+  },
+  {
+    "id": "6df533ad8cd5488a351eecb94ecf50fc0b493379",
+    "name": "Pramint",
+    "type": "intermediate"
+  },
+  {
+    "id": "3c4f71ad75e7e3ef6b7f2232b047000e42f5826b",
+    "name": "Evons",
+    "type": "intermediate"
+  },
+  {
+    "id": "ef4c207a1aaf37548ca4a707bc971a083149b5c7",
+    "name": "Gros Tougne",
+    "type": "easy"
+  },
+  {
+    "id": "d6a9114459583e6f81501e6e093bb70201211830",
+    "name": "Béranger",
+    "type": "intermediate"
+  },
+  {
+    "id": "a870d1d99473a4509c63288346f5c0ff3690100b",
+    "name": "Tête Ronde",
+    "type": "easy"
+  },
+  {
+    "id": "f1f7134a29ed77983fd2e3b4e34f12ec28b202fb",
+    "name": "Boulevard du Doron",
+    "type": "novice"
+  },
+  {
+    "id": "000aac65781748d5275de36cb0d7bee423be3229",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5e18dec7fb0fd528386a1bb9c5e9aa1349bfd9d6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1af4acbffa45b710c3c67a92fef5fc7df9aec262",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c4b2c5741e593a1388d8ded7e86f96863f1016a5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b784fadd3424e17db54130ba5cc33ad6a1f62321",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4ab3b78c289c4b7f9613ae593c406e6c1116fe69",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e88d35bcfb98525fd5d13b400969a55fa0b0421a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f7e39d1c4c5842f086e82b46b65f5b2c5aedb5fd",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "0dbc03fecaf2ad58469cd2b243a444521c6a8e70",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "757b02e619716382cb4513a6366fcc55b094104f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8246466cdc3dd4ee5a6ed41e473b08a885381970",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "f5f07fa0eb4944da9ea8a7ea1b2766e641fdb721",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c4bc2e7630293b126283c9d1068093bdd6f2a927",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "17503afc06df5cea7ac7752701b7ad29dae504c3",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4258f68f9ee08c0f5109b87795576e8eb12f8de6",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "dc0bb308b8a61c8d7d480310bc4487dc0aa9bd6c",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "7ab2a22fe306217cd4d36023d6aadc8b33d0a618",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "16a7173c5342099bd31f50da5afd3612869602ef",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "43879a04362793b3ec15e6497d9be591e724c7a4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d179100c188bd4a1b2b503367bd3747708c24242",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7e1fdc5c3d8271c49aa6b9d37e81d7a1acea0d67",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "77825122ee7e37e0d60aff3ac0e672b4ec30fac5",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "77237fee6af76ea77efc9beb0480de8aac36b205",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "7fb1eefd8dd21351d7b6e6633e1cc7ba53c9e3fd",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "3229b50ebe24f8c5dda2bf9b2800b8ed0696aa53",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "780e44e341b9fa6223c1caaaddc9a8dacab38156",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a6c580287e7c8157c41932742ef85919d8b7d8e9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "96f572d6695c4dfdeab2f994a661a3c2d93119d8",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "153ac378ee798e26963976e8bb9a3a0ba22aadb6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ba17575d7a21c3da0b1282bf7133afb450bf7aab",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "080106241da2ae1d32238f8d102e058bef3d9347",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fb1c0d221b1d35ea4362b1f4651d810cdf317302",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "07b2969db814d9735a6f3331315cd6f4a52a28b2",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "bd917bff3c73ccf0062e3805fb567d4da97dd5d3",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "78410cdd18eacbcb75139155ddc2dbfcb0cbeeec",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f380b6fb1f8157f27ba3a1d81153d624ca6a9782",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7aa7f40419326b4468d69f25c4bcc7fe35ed2e20",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ad75bd118184c73c256d87a63ff01a71c3d21695",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6f95766460b8af4a3d6f65f51264a81cc794ffe9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "beafe7ab0cc8b72dfc7cc8dd0503b05ed7550a00",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9b4ab65c98c71bd61431eb3215523f6bd3184d27",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d3300955e38108d364f343bf439d854c1099e297",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7a068d87c585a5f7d2122857e291ba8969fadaa9",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d40a09704dc8894bc63558b0c28918e03c26a3a0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "27a3147e30fc6fdd98dd9e0292f656b60abc56b8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9a681d7f591d90a3557bf9e84412c02e735e1d03",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cbab07fec1a88cf2dca5bf65d1f6fef2bfc15e05",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8483d766d78a346f2df5cf656556607372a418c6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7288d3e6a51c5769001d6f61453241a93f455183",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "08e84266b4d52cd02272a84c2e2f10795bd6eeaa",
+    "name": "Adrien Théaux",
+    "type": "intermediate"
+  },
+  {
+    "id": "e29497fa570adfd2952c13b238cf3fa57e673086",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ce5c00acfc9042e9ec2ea35bac40419c83e57d03",
+    "name": "Corniche",
+    "type": "easy"
+  },
+  {
+    "id": "a98cf26110c4a7c0bdfde31b2c7be6ad43931a33",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "75138d1527bd1b3d5aba8b52bf6030d2ddf57edf",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "07e21faba69cba66a3028e6b32d6bedf9fff69da",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "677448b17d1118d2c011a65716252d33793c5a69",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c78108ba695abb9b08855fba104b76ee44bb4c83",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c91de71d721d07dc81cf75695902febeecd0a4bf",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "217055650a55ddcddfc23482d78e2761efc70289",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "9fda5d1657935623a6cdea41ef178802b9cca722",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "0f25d5bf11a45fc448cb5704476fa3653d6625b8",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8df8cbf83a2b6ab1964d3d225da8c6dc9cdd9e88",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7377a91eb7dbab2b099b1fe54906424ff14a05b5",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f4c518a3b0c10d7275dece9d33972f9b4baa0cff",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "bc23e3be20354a4231eceb6724bb5de6341b4f0c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c162a5f6cf6cbd4eb3e472e96f77538605504e4e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5406676dd3776f6b545674c60a1c8fdced1a7013",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b1cf59f13b5f293a3274d72e2bd6f5920001180b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4a8245887746335ba92647382d8446f80ae41b8e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "66de10bf8cd26fefcf6dd10e228706d217c0ae14",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6b416d57b89e1e97d3a10f2aee536bdba0575055",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9200d905ed2850025ccbacc4b7cec4669418c1d8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "03ac830ae35f46b6932d7236174debf98e05942c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "89bb2f6274ad51e4e99b7dc151fd445b2c037163",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2448f991858707422b9906965e5bc0aa5a0a018c",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "05c6dabdd438503078f3ed7ba39d6b949942dc66",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "928d66421cbe6e0688738d49c411a4b06265bd4b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "960831f397f96cb25afd16bd569b3fe8f2e42d8e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3452101e9a97ef1c22406555c989603f1af33b6e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "17901b20b9bbeca0c4808e3ce63f2bc526cc3f35",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "094cbb5692d5dd849dce0529b2614f24d6d118b9",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "43ef33ca017248ee1d484f92f812ad6cdf01c833",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "65e247a228156dcb4496b4454a550b67b7bcebd7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b8a282fb85fafdf9140ed1eaa217d866bb628862",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3e14b006979699c90b6bfa69b06ffdb9dc997ca4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3b4add9a99e898bc84484b7dbe08de93d06e155c",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ecb1463546e86a66dd1056e4de2b8d6c85f60de1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b3b46b806d3425076df6cd6dc95fa0870fd5d21b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cabc4d1078cb37afbf9a75c573f5d3bbc892ecf7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e6ce98018efdb8f0c91d655216626e6b002500e5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fb1f524ea34eaf07e1f921537f01fefebddc8c1d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "356178968f2028701402b66f8ca3cd27f890a5a6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c39cc302bd85534cfc4fe657031e3ca7deb2ca3e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3e01ef34588f6668180c5bb122853165e7e7e9e0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a45249e9b0faf0924f9347927303ea095870c1e5",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0b908261c3887468d1174b701759350742ec66f0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "da59d9bd99f6afc5ea7fcd1c194fe0e0f144b3eb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "572ada7d3035e8c7d90a12a5a118664190b90810",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1b336f27b8d1cb8f8449547baa71a0a68f9449c1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "24543fc87727e12b95e1b0859e6eeb428f561585",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d09500c6c6ab54049e9837ca177bd661fc8953f1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8b50540486cccf13b9731688673d45332544a28a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5ebb9126619df5ba785e09dbdc55eecba0191950",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fc00a04f7598ccb10f41fb18d3ebdc1a96e97621",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8ad9916fcf4c1d18de77a6c6affdd503a0f374a6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "02363c856ec04a5cc5e9da16906b7845250b7095",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dea88c101bd5304b8924a24a50a02cf769126fe1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f2b77d08873af35ae4d734e7b73dca69206d6d6d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d357b82875b57148708cb78e15bc781b90502e93",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "eeb16f959bb80d41c9715d9c9865315cdb8edb34",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f1fa5d5bdec661e95cd5cdcada7ccb9919c1a883",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6c0accab6d3f082777e50b7f1438c85b4dbda43a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "175ce63f9c791315bd5c65f8fa6b894b386d98d9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "24e702b71e3f06864ee86e767be2bcbd8fdabab9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f337418a4575b5da15364028caa98676a8384c48",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2ac57977aaf9bcda465800dcbd08d59c7d416255",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "330e6855efba306d2592d171598e14eda62709e4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e64d28604e41b88f7c4f733efa8594b8b25dd6e6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8483e19825888208900a36c6fb98d472b68362b1",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "448bebc30496f39f596444a5be6fa8dcc8984c50",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "944222fd9e9e2305e6fa7883d2be0da125f3f106",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "3050cf5e0b32c1800d13245d215f11b42b87e3b0",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "e6ddb61868a041c0af609b41f267055ec2986141",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "3f08018dad5ddfe7c641eacbd29df14e6cc063d0",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "70d724150922c806fc11918c7805290e2c214f06",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "65ac9202675a29627b0c3414e1a3745b50ef07ae",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "9281a2226b9da3792e712637b2cb211ccd9a1e22",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "84685664e8a58292335e92b26660cc3989053b8b",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "e23407b2d1856783e73dc9620ee521f021f1091d",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "9c4985f81bbd258717accb08d8f6f6d5027f7a72",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "c2804af529190c4516f7de81251ddcb45f76df89",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "a1394fb4b1d3ecc2a9014316c3d66b5eeab8cc82",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "1ea44be75c1d1f4da96ce64eafeaf4225449f09a",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "9737b576d7a716dd6c4a1c88bd4db8b0238f35be",
+    "name": "Rassemblement cours de ski - Courchevel Village",
+    "type": "novice"
+  },
+  {
+    "id": "ecc4d57733f7bfe3acd64f60ee6514e1cad424b6",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "0133c11290069167665a51f6e07c9676c0407a8b",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "ada379d3a031e2427ba6a56f123faab6dd55c227",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "9bc631e0ba3a8fbf8c977a816f61369b7ab91117",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "23bf1d482d43cc85d07d56520e7843d54913ef4d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "686b171a01c90ef1025b119553482151eaaf8a61",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1c104320d36455147254b482bdf2dee3b391e00f",
+    "name": "Jean Blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "ced699ee20488247c7f0b7de08c8df923d895d5b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1f3d616fb57d3e6347a5f3adfc569f8795e09167",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "97a3e07c8ac29884e51604ab0369c5a906e4edb0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "84b299c9933376b838ecfee9ad4664742aa9c195",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a5e145f1a5dff5ade9f17f3de60e12eb5ca7e6d5",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7a9111eab855a250c75adfd769a0cd3c1cda8122",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "346ed4dabfb204a1f285c9cd88da96411fdf9ca5",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "65c776a4d827dad12e2342589f45bea4520e17c3",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "52c0aae69b42da173a7e61f600fd7f076839c4bb",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "4d5c80a6e8756405b0e7f326e22d03c206f14fc9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "f76fad05770dff59efd991d4e85e7fc799890886",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "9e99f12b31dcc41c1f4e4c6202eae04090876adb",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "4cf95f64eca046c15362953d6fd7b381fec5dff1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "db6e7dae368bfa3ff58db2c542e85c86aa3b8b8b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6e7feb9fa9f08186250d0be7d9e713a0a772fe20",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b8eccfdf9116cf41306498d9c58f068a1bf1b5ee",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "deb4fcbd81d7bba982738525d5bdc3a5924877fb",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ccb1ff49347ffdbe096c890f223bc88600be1b86",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "47d1d2ffcd5d1bea503f8a968ff8c75a093c7b89",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "aa93bfa38567b805e50741a88e293419c5f157f9",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "e5e3fa81f5b4aa26bded5631a34920a3d1a4c501",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "94f26d1d5b920dd7328826331fd21361058a2e31",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "1f4c13c96b59c051568ac9e05dd6938ecc844dc5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3a2fa7c0667fe4780429a20928cbdc6f0c7c8abe",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "c02851d210ab303e26b0b67719e6557a78c74f44",
+    "name": "Gélinotte",
+    "type": "easy"
+  },
+  {
+    "id": "1b8e691531285c91e949d18af5468d2d7e599e53",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a9931220d941dbfbaf0d633b1bd21396facd6038",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "434c0375aa45b135299f744170fad604d76e14a9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "3e290482d58830eb12a3c1462e92dcc379f722ff",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "04659e44f5222d13891d4c6d534d625034a064ff",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5eabf0970dd17048164f242b512759bbd1d5cf4c",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "ec2e3809f41cb55cf56df7ab6e7918d186f19365",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6591d30e6830cfc522ede49ba8e8b687d08cf8b3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "83d4cfdb9a618a3d47844ea49302b1a9f8ab808e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7cf988da0ae917e399144f87826ff9a6d4864c7e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6f09dbed712d5673eaf645ca429a880668f62051",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0f30309c5b024a0f31322a5fd4ffed949ce5a00b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4eed765f7eeaa2533bac663db01b9d3d2901ae5a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c6b83eded9f8695a39d99ce581ef8e793f2b4783",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b4e295fc3cabd10a38d1b5c61be87ea44cc08d6d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d3d07599ed1d7fe81726a8df1818893c8849112a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1d48d440e711b8b6f3a13b118d886c0b1b22b413",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1d928be129d28d51704e4760a71d223ddad564f5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c7039f30da52c09d4eca4829e8635793eb201a34",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "44193c5011ef2afc1e76547e589e5cac87f30acb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d77d46ee760eb061373ea1962b6157987d0f55fa",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9e7f778574ca80d267c72fa4236b505f5a3fe583",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4381fad8e7231159df989e716de9594967adec80",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8d3bddebe357fe052eae3cc3a605db75488e445e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "eba36968a8c983c577e379d80481ef9890c1cffe",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "255bcadc3679a05d0feb2547e2717eeb6d5f61a7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1e6935596f54fe7dd3f80bcd1bf7947f6465e1ca",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c3f030573321d85fbcdc34883e33460610bff482",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "30d7fcd7182ddb964240ad452fdc7646b98c7570",
+    "name": "Rassemblement cours de ski",
+    "type": "novice"
+  },
+  {
+    "id": "3cb1ad373f27f732c6929373a0308a5bd6755666",
+    "name": "Trolles",
+    "type": "intermediate"
+  },
+  {
+    "id": "11c1c4b56a9731f7f16e6ee4ed3050443c8d53c6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "20abc4a37a22335f03a8f544eadf1576a2212bcf",
+    "name": "Preyerand",
+    "type": "easy"
+  },
+  {
+    "id": "ef123698b8d6c1e25012ac30ff994d2aa2ec24dc",
+    "name": "Marcassin",
+    "type": "intermediate"
+  },
+  {
+    "id": "f69e8233ee21ebd5cf774781669c45af1b1f2977",
+    "name": "Gélinotte",
+    "type": "easy"
+  },
+  {
+    "id": "f318031573bc753722c462376e7be01db7a72123",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "79ca4ec4ecb0a64b2267b76d1e86c5d329bac0e4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "15a650ef5c18056ef9a733b5b356a89c626ef662",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ab295795068f49a8e5016914f95e1d98f3ae54fe",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "36c80c3960bfac63cb41fa742fcb10eec5633e14",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "0fe5bb0d0ba11a020fae0ba7489878951a7954fa",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "67f6e03154869fe5eb6c518a837c6d93eaf985c2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9439d2fd833af8c3aeb76bc4ea2c456c3b809678",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "abf61547f891a5c037c95f34846900bb2dc6236e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "474407a5b777f95bb7b702ea5f5edd047710c2a8",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c7af8930e5e4fd6b9843023b61f609831b35a3ba",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9ee6f6dcd372499867016ae7d05c24af370bf6cc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e3d62e72087e6fdaccda738d95ed98e02c327d0c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "95509cd192cd160209e9fe47bf48cddc3652affb",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "0f7cc954c148694f07cf65c97db67c0d95bdaf08",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d915d8162199e6c40d88d9be67b68e6cd18c3fe7",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "96d083f79ff2de2231803633f65f47ec575c02e7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6d309d12f9eae5fe5e1201c97512804e81929feb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1ef4837cc7fd49592b96bcf5834ebe372d19af0b",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "03542ed6d69c7b660d5ccd120d3e7551fcca5398",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9918e2e9bf93094c0ebbcf4c861d13ab74233205",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "ecf5eb2d08f98e75358dd1aea32cf904da845f0c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "48c4f9cbda48a2ff68eb6226cc8125baed9120dc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3d41cf3e5a9e06dbc9f0ed52bee479a892f5d713",
+    "name": "Open Park",
+    "type": ""
+  },
+  {
+    "id": "85d008818f023e9fbef2794b401cd13c1a20c455",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "4b31ccfdbed5b9c491cd955ac1b1ab652747d478",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3dc014f07d31807fa7c8e3e8678f41aaa0ded701",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "aaabd67136c788042a66ccafd90435da1d0d9b01",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "78eee992f2fc5210a2642a1706c1d92d5e8ab131",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "015dde4901a913831ba30faf076ef343c5fffe83",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ce10fc4db1b9c085af5a234f5b748045cbaa7fcf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c1083e8eafc8773179df293922af75d848136c04",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "54916b612f6accf3456c501ce0a2964d8b93455e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b11c763ae79869cb21b665827a04d717a7deb632",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "219ad22f908231e997a1e89ca86d89cf1a8c52d1",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "3fc64ddb96029659cdf6d51b4291e9b97109a875",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "b8a61474d85a2eb69167238a3311de2bf58131bb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5ff50497d1d79608b2e6b315003fef1f012cb946",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "152915c525110c9396c801a8d31dea7a88fc5611",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "a3b0d4318d876e3026a45836e7fc773c0119b8c0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "f49262e482ffbdaf1c5fabe45f9cc3322d36e8f4",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c607f1aa726fa9efe562ded4847508410ce90811",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a9f9517dd7ee112adffb78b706f64ccaddc1aa4d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5c7290845a1ae66136c134744dba0a332da0fc86",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "237f21ddb00108cee39f2ae6d90f1d8402d4a728",
+    "name": "Western Ski Park",
+    "type": "novice"
+  },
+  {
+    "id": "edecaaba4926f17433b48d270c74b6821ec6e305",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "40cdf3441835a473c57211dc1604f496d09e74c8",
+    "name": "Carabosse",
+    "type": ""
+  },
+  {
+    "id": "0a094db6db582916fcd8a89a59ab99d9d8b631ac",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "62ba6029fa7afd40674d18eccac564e6f484b2fe",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "fe7a3600302c7fd635cc4196cb16447c27d237bb",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4249d4228a5c90704b4bf6c526fea94d2a29f47b",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "fa4f3340f90bbd78a924c5c9e4aa15bd424e5599",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0ab9303701e8709132f43b3c9d70b0a5015e9f7e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1ae090c3f976fb856dacc749f523c43bc370bfa0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "e6ddc19506808fe92257d794d645dc5465ac6963",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "60a32211d9b28f11afd8669d2b1a25b843039497",
+    "name": "Les Menuires - St-Martin-de-Belleville, Au Fil du Doron",
+    "type": "easy"
+  },
+  {
+    "id": "ae2bfb7dab24b91dbb04a57123a3651bf3f46f8a",
+    "name": "Les Menuires - St-Martin-de-Belleville, Au Fil du Doron",
+    "type": "easy"
+  },
+  {
+    "id": "44f68cc0a8fc82dab5b03bd04db6dba5805e2e64",
+    "name": "Les Menuires - St-Martin-de-Belleville, Au Fil du Doron, Pont du Barrage",
+    "type": "easy"
+  },
+  {
+    "id": "fbe21194344cd18d334f12920a0d96d8f628dc0d",
+    "name": "Les Menuires - St-Martin-de-Belleville, Au Fil du Doron",
+    "type": "easy"
+  },
+  {
+    "id": "e9f73ed2eb3a027df9dbc1bf42d73623a53fdc10",
+    "name": "Les Menuires - St-Martin-de-Belleville, Au Fil du Doron, Preyerand",
+    "type": "easy"
+  },
+  {
+    "id": "39dbfc0a4cf4f4f56d3a2ccdb30cf1c67f7cc780",
+    "name": "Boucle de Mottaret",
+    "type": "novice"
+  },
+  {
+    "id": "dab6f6b965470915fd54835631a0677cf5be35ce",
+    "name": "Boucle de Mottaret",
+    "type": "novice"
+  },
+  {
+    "id": "2bc477bca1392d678e113ea6c351e7ec850f9701",
+    "name": "Boucle de Mottaret",
+    "type": "novice"
+  },
+  {
+    "id": "caaf6ace054fc84734289c5427f8323d8d0a2567",
+    "name": "Boucle de Mottaret",
+    "type": "novice"
+  },
+  {
+    "id": "22198c798a288ac8875293b6c212409306004277",
+    "name": "Boucle de Mottaret",
+    "type": "novice"
+  },
+  {
+    "id": "96cbd7eb05ab554e65e0eb3d91e9a6775912147f",
+    "name": "Boucle de Mottaret",
+    "type": "novice"
+  },
+  {
+    "id": "3c89fd994b9182e72323cab6fd6a27937caa3fc2",
+    "name": "Boucle de Mottaret",
+    "type": "easy"
+  },
+  {
+    "id": "3c231c6ff8817f35c80a427831f5c746dd6948fc",
+    "name": "Boucle de Mottaret",
+    "type": "easy"
+  },
+  {
+    "id": "5b2ed994a580d1fb64ec0e0cab4fd07f76624f34",
+    "name": "Boucle de Mottaret",
+    "type": "easy"
+  },
+  {
+    "id": "1a3295bc1f4c7976fd2ab06f4938b6237bdd3f54",
+    "name": "Le Fontany - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "0f165623897325b54e14a2bf96e1e4098994f1de",
+    "name": "Le Fontany - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "8d23f45be57321544681ddd140e90caca80cc7f0",
+    "name": "Le Fontany - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "22dd15ab0d909bd958059c8e824d356c5f2b3c1e",
+    "name": "Le Fontany - Méribel Altiport, Le Plantin - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "753c2dffb8163082b724d6ed0a0c29792c11cdd6",
+    "name": "Le Fontany - Méribel Altiport, Méribel Altiport - Courchevel 1850, Méribel Altiport - Courchevel La Tania, Le Plantin - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "e6ee92ffd00cd14e09c5b81bf9d9b4a0bbe30b34",
+    "name": "Le Fontany - Méribel Altiport, Méribel Altiport - Courchevel 1850, Méribel Altiport - Courchevel La Tania, Le Plantin - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "7e6c4d8a6ff39807bb97459b1e2cf1ff4eb68c4c",
+    "name": "Méribel Altiport - Courchevel 1850",
+    "type": "intermediate"
+  },
+  {
+    "id": "9e04e5e42e0ab55ede2806359652f859e87499b6",
+    "name": "Méribel Altiport - Courchevel 1850, Méribel Altiport - Courchevel La Tania",
+    "type": "intermediate"
+  },
+  {
+    "id": "86c9695eea855ab8cf97615279b478a6704b56b5",
+    "name": "Méribel Altiport - Courchevel 1850, Courchevel 1850 - La Tania, Le Bouc Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "b3977e227a1e08f7f42115aa9249d5f401ee5f7b",
+    "name": "Méribel Altiport - Courchevel 1850, Courchevel 1850 - La Tania",
+    "type": "intermediate"
+  },
+  {
+    "id": "d55600f0b5acc58c3ea02b2669061dba0fbf02a4",
+    "name": "Méribel Altiport - Courchevel 1850, Le Bouc Blanc, Courchevel 1850 - La Tania",
+    "type": "easy"
+  },
+  {
+    "id": "4ed19d63dc19649e4ad0877a8ace7dc2f4ff5605",
+    "name": "Méribel Altiport - Courchevel 1850, Le Bouc Blanc, Courchevel 1850 - La Tania, Plantrey",
+    "type": "novice"
+  },
+  {
+    "id": "f88079d7b696c0f2f13b5bd9fb387f08eb5c257d",
+    "name": "Méribel Altiport - Courchevel 1850, Le Bouc Blanc, Courchevel 1850 - La Tania",
+    "type": "easy"
+  },
+  {
+    "id": "7efe03d521ba51f0befdc05ec65c6d109173efa4",
+    "name": "Méribel Altiport - Courchevel 1850, Le Bouc Blanc, Courchevel 1850 - La Tania, Plantrey",
+    "type": "novice"
+  },
+  {
+    "id": "f6c1a80415772240d21d8adef29243b800aea610",
+    "name": "Méribel Altiport - Courchevel 1850, Le Bouc Blanc, Courchevel 1850 - La Tania",
+    "type": "easy"
+  },
+  {
+    "id": "4aca55c973ac36291a1c8ffc9f05483141b874be",
+    "name": "Méribel Altiport - Courchevel 1850, Méribel Altiport - Courchevel La Tania, Le Plantin - Méribel Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "0fa9087aa33fd22029a515b9fb842a644d0eae56",
+    "name": "Méribel Altiport - Courchevel 1850, Méribel Altiport - Courchevel La Tania, Le Plantin - Méribel Altiport",
+    "type": "novice"
+  },
+  {
+    "id": "f81f6286a72e805a638beab117ce2622b5465097",
+    "name": "Méribel Altiport - Courchevel 1850, Méribel Altiport - Courchevel La Tania, Le Plantin - Méribel Altiport",
+    "type": "intermediate"
+  },
+  {
+    "id": "c8e43dd0d66836a44e2d1b0ed7d3ba4b9794e652",
+    "name": "Méribel Altiport - Courchevel La Tania, Courchevel 1850 - La Tania, Le Bouc Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "b1a1fab3bb4f0de30d0d90b0b36d1a6ea25d69dc",
+    "name": "Méribel Altiport - Courchevel La Tania, Courchevel 1850 - La Tania, Le Bouc Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "45c66fffd0d459805a1a37ba914d2769d4ee2752",
+    "name": "Le Plantin - Méribel Altiport",
+    "type": "intermediate"
+  },
+  {
+    "id": "a1f82000a99b8deed4813f54105e230c16f26537",
+    "name": "Le Plantin - Méribel Altiport",
+    "type": "intermediate"
+  },
+  {
+    "id": "36d7d835b10476d3076c2edf186cc9b557f3cd71",
+    "name": "Le Plantin - Méribel Altiport",
+    "type": "intermediate"
+  },
+  {
+    "id": "13e77da0553af1d202e50d211cc02e6dc19e65ec",
+    "name": "L’Altiport - Méribel Altiport",
+    "type": "novice"
+  },
+  {
+    "id": "2a492d20f2c22627d6ce7ce54dfd18bc69469cb8",
+    "name": "Téton",
+    "type": "advanced"
+  },
+  {
+    "id": "d2381829c1de1d22b8cfc1705585a544c1290713",
+    "name": "Téton, Route du Col de la Fenêtre",
+    "type": "advanced"
+  },
+  {
+    "id": "73fe2e3c594ff8dd0aa670ae1e6858e5626c3445",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "9c12503316c629fd34835ebe823f633ba22de481",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "0e4eb354ad7c54691cf10823fa227024107a2ff7",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "7b1bf69c901fb12e1073fe90b6036f518ce38315",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "c5b260581aefc17f141e73c65d7674a2892bfc49",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "8c7bafddbe1bba6bbae733837765510aabc8da45",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "33f368f2147115959a53af948ce2712c7590f958",
+    "name": "Vincent Jay, Pont du Colonel",
+    "type": "easy"
+  },
+  {
+    "id": "e5790e67b480e43972aac7682559b37190ea1d9f",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "354e61aacc3c5776ce45b8e19422081d27781825",
+    "name": "Vincent Jay, Les Roseaux, Le plan de l'eau",
+    "type": "novice"
+  },
+  {
+    "id": "a077864db32f9f354d6b9bf1666a05f9018eecd3",
+    "name": "Vincent Jay, Les Roseaux",
+    "type": "novice"
+  },
+  {
+    "id": "bc05c3e3688a96ff63f781d70b3efa933be064ec",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "98ef5c0107c53ac5240c74c97283a93701ab81a7",
+    "name": "Vincent Jay, Pont des Bruyères",
+    "type": "easy"
+  },
+  {
+    "id": "13dbc7d2cfa55e37caedaca2caf631c43adbb0de",
+    "name": "Vincent Jay",
+    "type": "easy"
+  },
+  {
+    "id": "31ab1522c81db176d6dace81b7e2690786e0dde4",
+    "name": "Les Roseaux",
+    "type": "novice"
+  },
+  {
+    "id": "72014d2cca907047bcf92540a62b370970d17abd",
+    "name": "Les Roseaux, Le plan de l'eau",
+    "type": "novice"
+  },
+  {
+    "id": "551ba64b9e25c1a5e63de36b49c6f58716f8f882",
+    "name": "Au Fil du Doron, Preyerand, Plan de l'Eau",
+    "type": "easy"
+  },
+  {
+    "id": "d5f9f85bba50c1380b82878fd2219ea31d9f63a0",
+    "name": "Au Fil du Doron, Preyerand",
+    "type": "easy"
+  },
+  {
+    "id": "d13956dd947f1fa268b76c83f5fcf133bcd27e0f",
+    "name": "Au Fil du Doron",
+    "type": "intermediate"
+  },
+  {
+    "id": "26bbda71fc2da037133db98425433f61a26d4e7b",
+    "name": "Preyerand",
+    "type": "easy"
+  },
+  {
+    "id": "3c6c3d4a778bb13fc00b9b2b24d04df99d2d0284",
+    "name": "Preyerand",
+    "type": "easy"
+  },
+  {
+    "id": "ef06e7a098ea2a00b6241e44792146161c92bee1",
+    "name": "Boulevard Goitschel",
+    "type": "easy"
+  },
+  {
+    "id": "912e8a1236fbb45629dd96f1b601d7c5b593fc5e",
+    "name": "Goitschel",
+    "type": "advanced"
+  },
+  {
+    "id": "8afa388eb7aadcd7f036247cce2d5e80d8e32f6f",
+    "name": "Moraine",
+    "type": "easy"
+  },
+  {
+    "id": "6ada1fe2b6946f854cde845019f78f0bb10bf4fb",
+    "name": "Cristaux",
+    "type": "advanced"
+  },
+  {
+    "id": "0c6b229f82d8b4c65b6d9c5babde355f48742f26",
+    "name": "Combe de Rosaël",
+    "type": "advanced"
+  },
+  {
+    "id": "eb857674f2069ff6010951225b0805909be0c935",
+    "name": "Mouflon",
+    "type": "intermediate"
+  },
+  {
+    "id": "76e915db9118c53b6e87de3cd6d188fb79d5f251",
+    "name": "Bouvreuil bleu",
+    "type": "easy"
+  },
+  {
+    "id": "edbc59ff48c5e63d1d1d70abbedd41aaf97327cd",
+    "name": "Campagnol",
+    "type": "advanced"
+  },
+  {
+    "id": "e335888e03e81d11011dc9dd47474cc2646b21c0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "04ec77d70bf85d5bc257a43ab210d9e6bfcd811c",
+    "name": "Grand Lac",
+    "type": "easy"
+  },
+  {
+    "id": "9bb51f3885b1932de7f825bc541c94cec43ce994",
+    "name": "Lac de la Chambre",
+    "type": "easy"
+  },
+  {
+    "id": "3e749976e4fe42040c6bb22e1ba821ed08c103fe",
+    "name": "3 Marches",
+    "type": "easy"
+  },
+  {
+    "id": "319d464b17d386e04b0bb5f48eadb83e388d6bd4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8a6165ec8ce73f572e504fa86067a15c8919adc3",
+    "name": "Gentiane",
+    "type": "novice"
+  },
+  {
+    "id": "1841068a3096e585f54dceb9acd62f5c769df22a",
+    "name": "Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "0484d838a0d79225fe7c859912a4384e39bd9d2a",
+    "name": "Combe du Vallon",
+    "type": "intermediate"
+  },
+  {
+    "id": "f8b504cf58e9643370192bc078ff603cb80efbc9",
+    "name": "2 Combes",
+    "type": "novice"
+  },
+  {
+    "id": "c595b3fbc8c6081262d0bcface8e10173a81b5fc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b8e97723898a1115b8c0b8f34c1c86e4c799e1f5",
+    "name": "Pluviomètre",
+    "type": "easy"
+  },
+  {
+    "id": "0432ade3d5da7176ae858d7d3df63a199a384dfe",
+    "name": "Jean Pachod",
+    "type": "intermediate"
+  },
+  {
+    "id": "128eca6e9871f4caa373f52ea6a7076194a9088d",
+    "name": "Creux",
+    "type": "easy"
+  },
+  {
+    "id": "2e5fa1c3f7673117485299bada3e6dcf1f9ffc59",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6baa26c80a4ee6dc199869a22e0db6b5f9ef27e7",
+    "name": "Truite",
+    "type": "novice"
+  },
+  {
+    "id": "7110c24cbc26f6ce46f29a60bb7ae29b689414c8",
+    "name": "Perdrix",
+    "type": "novice"
+  },
+  {
+    "id": "86c1cf138d634557b31db32c85f4569e8b9c3258",
+    "name": "Lac Bleu",
+    "type": "easy"
+  },
+  {
+    "id": "45796ff3593b4bc567c2ceed0a58b60031d6a4b7",
+    "name": "Biollay",
+    "type": "easy"
+  },
+  {
+    "id": "5841780b3e4393c0809c71e2ac46860c32c8e08d",
+    "name": "Boulevard du France",
+    "type": "easy"
+  },
+  {
+    "id": "fad050d8cf5a89b957d804536418bdc80702a3ca",
+    "name": "Longet",
+    "type": "intermediate"
+  },
+  {
+    "id": "1a5cc420458f8a4ba7cf0f39ec3962a2b40ca737",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e1fc65e9000928aff8f58c98e3c3d794145a3410",
+    "name": "Tête Ronde",
+    "type": "easy"
+  },
+  {
+    "id": "c4f9a495b49f79a9f65287320231d58b6f19512a",
+    "name": "Niverolles",
+    "type": "easy"
+  },
+  {
+    "id": "bf86cb2e48d16e3eff165662f9b07e8bc2dca35a",
+    "name": "Variante",
+    "type": "intermediate"
+  },
+  {
+    "id": "66f3c288a48ca51fc97fac98b8262fe898b1faf3",
+    "name": "Fond",
+    "type": "easy"
+  },
+  {
+    "id": "fbd9b6783b34549bc618eceaf865c5239dca0fd0",
+    "name": "Biolley",
+    "type": "easy"
+  },
+  {
+    "id": "ea13d9aadfc6f05b229a52aff635c491eaf21740",
+    "name": "Gros Tougne",
+    "type": "easy"
+  },
+  {
+    "id": "6b14eea4c8e823b97dfcff41988722cfed5d7317",
+    "name": "Crêtes",
+    "type": "easy"
+  },
+  {
+    "id": "fa0f2c452193fa494e32da880cd451056d71d450",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d7595383d2d0008149e4f985927755c9edaa60a4",
+    "name": "Chardons",
+    "type": "intermediate"
+  },
+  {
+    "id": "c851bf6286892382be513b0fe23b93ab1b13848a",
+    "name": "Blaireau",
+    "type": "intermediate"
+  },
+  {
+    "id": "a90a5eab334efa3ad24e041f287c02094149085d",
+    "name": "Grive",
+    "type": "easy"
+  },
+  {
+    "id": "2c2863b2df6538ffe82287c4b15ff3561ee4d3f4",
+    "name": "Dou des Lanches",
+    "type": "advanced"
+  },
+  {
+    "id": "6221ae8c8418187d32f4be1cf8a338216827dcba",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "99548bd39b789403facf188cc93c9ae15a7711c0",
+    "name": "Ariondaz",
+    "type": "easy"
+  },
+  {
+    "id": "48548ba83c7a13dba864876035f073bf674648b2",
+    "name": "Marmottes",
+    "type": "intermediate"
+  },
+  {
+    "id": "b9f20d9afedee67849bf70d32603ec1e2f64f0f3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3fff426cfc7131e0e15a2eeb3ab0222cee777dc3",
+    "name": "Plateau",
+    "type": "easy"
+  },
+  {
+    "id": "19acb213855b25a5d750e96252d560929bc92567",
+    "name": "Haute Combe",
+    "type": "intermediate"
+  },
+  {
+    "id": "aef83b4b86635dfc8fd2648f1fc0118258b3468c",
+    "name": "Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "75f49c7cbc0c51cf4055c0a86882c30e27e74d5f",
+    "name": "Médaille",
+    "type": "intermediate"
+  },
+  {
+    "id": "eb080e3c1ff3e809fd5019ed05f08277e02012d5",
+    "name": "Plein Sud",
+    "type": "easy"
+  },
+  {
+    "id": "81e11b8c9ca594bff0f5afe8a72b8286397a44d2",
+    "name": "La Val Tho",
+    "type": "easy"
+  },
+  {
+    "id": "728eb360e677d89886247d88f0f83f8b480c10d8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2e1384faad15d5db30658f223bc256e54b5cbbb3",
+    "name": "Lapin",
+    "type": "easy"
+  },
+  {
+    "id": "0d136108ae47f01c15d92ed04fb25372006fbc3d",
+    "name": "Peyron",
+    "type": "easy"
+  },
+  {
+    "id": "b9fa54f56c8a9b2c0eeb472e1eeb7c33e4e36416",
+    "name": "Génépi",
+    "type": "easy"
+  },
+  {
+    "id": "1c4d82efd2ee4c05cfde353f55628c14eac50547",
+    "name": "Portette",
+    "type": "intermediate"
+  },
+  {
+    "id": "9e13a7b5e2a8e5e728c7a1c33ff95271bc945c8e",
+    "name": "Rochers",
+    "type": "intermediate"
+  },
+  {
+    "id": "4877f274f0ad5a24dba7296421d5ac009aef442c",
+    "name": "Les Enverses",
+    "type": "easy"
+  },
+  {
+    "id": "e295e1fee4fad60521bfad7e5c0efb50b3571787",
+    "name": "4 Vents",
+    "type": "intermediate"
+  },
+  {
+    "id": "8d9661de4aefb76d7e8dd4f6b7f4b9dfd22d21e0",
+    "name": "Pramint",
+    "type": "intermediate"
+  },
+  {
+    "id": "430ba4fcfcb61896d8c2306503be925a50ca581f",
+    "name": "Choucas",
+    "type": "easy"
+  },
+  {
+    "id": "44056e6cc1d33528a9b2282d5c5f641c55b210cd",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "05059e9726459a526ba088004d9b982d28238dd8",
+    "name": "Face",
+    "type": "advanced"
+  },
+  {
+    "id": "33549e2454e9bbab2fa639471fc57d83d784e313",
+    "name": "Rossignol",
+    "type": "easy"
+  },
+  {
+    "id": "d01dc5e0fce52b160914e968cb1c4801f84d3ff1",
+    "name": "Sittelle",
+    "type": "easy"
+  },
+  {
+    "id": "358e096130722dc416199623230fd2fcf008c6ab",
+    "name": "Roc Merlet",
+    "type": "intermediate"
+  },
+  {
+    "id": "2a7f2779f0f13403745087034c03207532253926",
+    "name": "Bel Air",
+    "type": "intermediate"
+  },
+  {
+    "id": "e0a97116a9ec37fe66dbe95c5a6801dc55c30539",
+    "name": "Menuires",
+    "type": "easy"
+  },
+  {
+    "id": "5a8e7b947edaa619fe03e2bce9326a9fa8fdfa33",
+    "name": "Trolles",
+    "type": "intermediate"
+  },
+  {
+    "id": "728bbbc492436b9acf6757a219f06399f65a40ca",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1e42982586c07b6b6c7ed03a68d4075ae305cbb7",
+    "name": "Petites Bosses",
+    "type": "novice"
+  },
+  {
+    "id": "65eb934a06c377c36043bc43b0b8e3e81c51119e",
+    "name": "Grandes Bosses",
+    "type": "intermediate"
+  },
+  {
+    "id": "f6bc75fd4188d82d23a067fa3f4aa2967cc49272",
+    "name": "Verdons",
+    "type": "novice"
+  },
+  {
+    "id": "9e6cc86111cc859a9f96b16b5599bca8ab53633a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fa31ca6fd72507873cc60f1643028769a63c652b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6ba3d07606e07f7a4f98f871946b40d72a6fb48a",
+    "name": "Martre",
+    "type": "easy"
+  },
+  {
+    "id": "ac098237e8bc00c793ea0a413cb90130a2c7dab9",
+    "name": "Chenus",
+    "type": "intermediate"
+  },
+  {
+    "id": "1fcf5d00979d8a1a8f807efebc91ef3864f36154",
+    "name": "David Douillet Haut",
+    "type": "intermediate"
+  },
+  {
+    "id": "95123c514c6faaa4fe2959c9600fcd82277bf044",
+    "name": "Rocher Noir",
+    "type": "advanced"
+  },
+  {
+    "id": "b2ea1153909a1e1f06aa6af3ac993d4822c2aba5",
+    "name": "Paturages",
+    "type": "easy"
+  },
+  {
+    "id": "c802fec1804b1c82df8091b9f86539354dd4050a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a7c4000d8e41745392a0c2fe3032b176a139ce39",
+    "name": "Niverolle",
+    "type": "intermediate"
+  },
+  {
+    "id": "c0555db8b08739e7d030fe41428074dd61e489fd",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e9ea0ee68c0a097fa343c731c2ca00f57f64319f",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "efabca023a633b32427d01dd086f1667c321d003",
+    "name": "Moretta Blanche",
+    "type": "intermediate"
+  },
+  {
+    "id": "91e1b817ac6c6532667734783bc1187214d4ebf9",
+    "name": "Plan Fontaine",
+    "type": "novice"
+  },
+  {
+    "id": "07a3fac3f12d6f9a4e0cc33684aac0f83c54858a",
+    "name": "Plan Fontaine, Murettes",
+    "type": "novice"
+  },
+  {
+    "id": "8d6eaaa9d87d638fc318aaae00c589d16e74cd60",
+    "name": "Plan Fontaine",
+    "type": "novice"
+  },
+  {
+    "id": "2ba01af3317ec3235af908f8b989f6db00ede557",
+    "name": "Signal",
+    "type": "easy"
+  },
+  {
+    "id": "b0bed351c6943eb5acd3db593b5117002afb535f",
+    "name": "Turcs",
+    "type": "advanced"
+  },
+  {
+    "id": "043680fab11830e235fffd5d5096b461d2f0140d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "52db67debf9c4d23708f242cfe67899253a46424",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0cbd1fe7d4115daa2ef7029c3494f02e4ec1fe62",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d0b8dfa487bf16eae4c9d8b1c3df03d7e1456f95",
+    "name": "Peyron",
+    "type": "easy"
+  },
+  {
+    "id": "0f670efec4f91d259e1c8104015f81a4c1bb1055",
+    "name": "Falaise",
+    "type": "intermediate"
+  },
+  {
+    "id": "be206fa40b4ba933bfffd30e02c51568760a3826",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "42f89d99ea05a3c6f49ba72b5ffb18a49c154b13",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "981c4c94f61409d7392e3d820f1049e80cab0d41",
+    "name": "Lac des Combes",
+    "type": "easy"
+  },
+  {
+    "id": "d9e8446fe0b340a1f0266bcbf4612979c6d25fbf",
+    "name": "Allée",
+    "type": "easy"
+  },
+  {
+    "id": "7ca922b83a3cc1f98106f624734e731db09b9400",
+    "name": "Boulevard",
+    "type": "intermediate"
+  },
+  {
+    "id": "0ccf110b207d749decd35d643617ffd9bee64e99",
+    "name": "Côte Brulée",
+    "type": "easy"
+  },
+  {
+    "id": "a4e0adea4308d40323b8f204a37cc712eb357c8b",
+    "name": "Boulevard de la Becca",
+    "type": "easy"
+  },
+  {
+    "id": "b5dad396e49ed5c8b2c5904dabed33bbdedee0da",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "70ccd899f03976cb76b1ca9c88dedbae36f8eed4",
+    "name": "Peyron",
+    "type": "easy"
+  },
+  {
+    "id": "352dd64ff4490fd89866ed38b8cf54e855f2132e",
+    "name": "Dame Blanche",
+    "type": "advanced"
+  },
+  {
+    "id": "2e55e266210717737b2894721e9136a39a1e403f",
+    "name": "Boulevard de la Masse",
+    "type": "novice"
+  },
+  {
+    "id": "ce5f1d41adbe029bc95de5c5c2962aee7882f2e2",
+    "name": "Chapelets",
+    "type": "intermediate"
+  },
+  {
+    "id": "20af107ee3e0af34c40a34f78551094ee876f8f9",
+    "name": "Hulotte",
+    "type": "easy"
+  },
+  {
+    "id": "a79c4b8dde403fea589a1eb22514ad12bed4667e",
+    "name": "Pouillard",
+    "type": "intermediate"
+  },
+  {
+    "id": "90a9273a67ab1a47977e799c0076f640e1241ee6",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a33492dddf3940fda2198ff04b132d269c9c79d0",
+    "name": "Renard",
+    "type": "intermediate"
+  },
+  {
+    "id": "295f51a096c396022d4d6058e89c9fc9523ba4f9",
+    "name": "Blanchot",
+    "type": "novice"
+  },
+  {
+    "id": "40c5f34759216741d16ef71042cc2a2720459178",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "00950c025659df3016f1577116f7d504aff01a65",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "01d4be797aeb6e58c84fc7a933d9fb72e05ce5d0",
+    "name": "Rama",
+    "type": "easy"
+  },
+  {
+    "id": "6c01ce484880bc2398c918a922c06869cd912f20",
+    "name": "Roc Mugnier",
+    "type": "intermediate"
+  },
+  {
+    "id": "bcdce8f10e15814dfa4c944760b4aac469ed0727",
+    "name": "Cospillot",
+    "type": "easy"
+  },
+  {
+    "id": "4d76c4bc8d014fccd1999da3ed92cf92cc586370",
+    "name": "Bosses",
+    "type": "expert"
+  },
+  {
+    "id": "2c7ad915de0cb91caf69685b64548b2b3c9f71d8",
+    "name": "Jérusalem",
+    "type": "easy"
+  },
+  {
+    "id": "701f98d21831e6ac61ae4d9fadb0979fc12c365d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "53a93db5c38bb3b0044fa08fed237515ffba7249",
+    "name": "Bouchet",
+    "type": "intermediate"
+  },
+  {
+    "id": "978f1801e3504902afe27c074011eb2d2029fff4",
+    "name": "Gentianes",
+    "type": "easy"
+  },
+  {
+    "id": "a2cbe56df2aad95d4d58fe6a6e92bacb14833e18",
+    "name": "Boulevard du Téléphérique",
+    "type": "easy"
+  },
+  {
+    "id": "e7eaf6578b9ca0d35f56d4482deba126e966449c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "17de70ae89d759fcd26a233d99034e20f88beebd",
+    "name": "Rhodos",
+    "type": "intermediate"
+  },
+  {
+    "id": "f0ef8e84740de2233505292cd6e3639843bd7021",
+    "name": "Linotte",
+    "type": "easy"
+  },
+  {
+    "id": "f6bf4b82b8b2917aaace96183b4bf38751a568d8",
+    "name": "Hermine",
+    "type": "easy"
+  },
+  {
+    "id": "8cb2ec81d5938de5bff1859579b0ea49b431eb64",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "7a1e439ca6741f20cb68c3a03756eff9ab743c17",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a0ea0492f3713f79aa42533b6f08c9c8913f81db",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "1d1bfc25b1e8eb9232b12a4237b8d2eeaf4fe30a",
+    "name": "Sanglier",
+    "type": "advanced"
+  },
+  {
+    "id": "5e7f025918f09ad7cca04e61496ccfaf7fe18bb4",
+    "name": "Becca",
+    "type": "intermediate"
+  },
+  {
+    "id": "52a0703e00b4fb9e7586c0b3287615fd660f507b",
+    "name": "Boyes",
+    "type": "easy"
+  },
+  {
+    "id": "b9a5708a7968b035c03012ce589062f403501505",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "60e6f7cffa40b7a952d8c077f06d5c0c69ef484f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "be399ce7871873958bc3debd471f50e258419c6b",
+    "name": "Boulevard de la Lance",
+    "type": "intermediate"
+  },
+  {
+    "id": "ea574152d831acfb832e451bbc195e84f5e3640b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "828501e083ff9092b98a30db2df0f0930f3dd63f",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "0c08ad947c6bb46264c0f8417a4ee40d52f6a1ae",
+    "name": "Allamands",
+    "type": "intermediate"
+  },
+  {
+    "id": "1a65f40e3a4b52fe5a20eed3d585df8881e8b783",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "068c600c33b2a6169171911dc6400cd7e86e70c2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6bd596de0f01a6217a326d74278a834f416f291d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "18ed0ec44575e3df2dd09b92c72c7058b57fef8e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "74a5cd9408e2e861f891c846e5f471c56c717790",
+    "name": "Escargot",
+    "type": "novice"
+  },
+  {
+    "id": "e1ef551ed0953bb5a896fd530fcd38d2fb79b968",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "89b27cc237a60dca9cb912b4bf58b6e0dcfd4106",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "df4f066ee0042dd8a003469f202b5c1bc7099cb8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9dd3f880bd75bf361321f81a91586979d55f37f2",
+    "name": "Combe de la Saulire",
+    "type": "intermediate"
+  },
+  {
+    "id": "6ac7b0b585312036bfcd81ac62a63f4b0acf0396",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e5272efeba10e1d2a4cd213ddc533172087793e0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b28ba1a7610649689ccb0ee17b99dd10f96f4429",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2457ab88baaaad750fae11b309c56a84db6d2a12",
+    "name": "Ours",
+    "type": "easy"
+  },
+  {
+    "id": "a71cfc925d0f90ade835a4fb566c7cbf106d8ae4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "de86dd57456809cf89667544e6deeced4ab89c7d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e3c114025c8733f69410e8c622104ea0f7908e96",
+    "name": "Violette",
+    "type": "novice"
+  },
+  {
+    "id": "0b089ddd7dbd152315676c79c1c8f8bb625447a1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "870ccdb8cb3388d5b534dda24e5e1f465e152192",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c6e1900c60a97134eb71a2b4efb7722550325323",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6af80365c4f3a86b2a28e1417f35ffbf6c371c3a",
+    "name": "Cairn",
+    "type": "easy"
+  },
+  {
+    "id": "3b1c4b176d7ebba120043595b7aeace91f64abeb",
+    "name": "Pluviomètre",
+    "type": "easy"
+  },
+  {
+    "id": "04e80680922cb8c4d37b0fbbd6496fbc039ac5bc",
+    "name": "Mur Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "003398c4e1b5370d105ece3dd1ce0cfbfa63f4af",
+    "name": "Fontanettes",
+    "type": "novice"
+  },
+  {
+    "id": "0eba8e4505ff2c20e4ef373b0577faa516139b86",
+    "name": "Aiglon",
+    "type": "intermediate"
+  },
+  {
+    "id": "f64741fbb25f57dee062cf172b5b0e5cd72fdde7",
+    "name": "Bartavelle",
+    "type": "advanced"
+  },
+  {
+    "id": "afc86ce0305492d6c061076bdddb04f9d0a25b10",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e6cad0d3809d326ddea9dd32b0e2eea6ceafb2c1",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "66d43d96862a8d1be47477805113cd55425998d5",
+    "name": "Marcassin",
+    "type": "intermediate"
+  },
+  {
+    "id": "d2cf99baacc36f81ae7a78a2244539935a0ec34b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3660851681654bd3855038d15db69e5396194e81",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "79f5a1c6a6007005f44242464529ef9feedcda61",
+    "name": "Montagnes Russes",
+    "type": "easy"
+  },
+  {
+    "id": "c66b9ac342a31cbd9d60d2035576d26e2cd7d951",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2ca724ba9599808b2c89227161cc65fec657c3be",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fa5a292acf45f362e38684821e2dff41903519b8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e036c5e70e90704d09d7df3d15a764727b100bd9",
+    "name": "Verdet",
+    "type": "easy"
+  },
+  {
+    "id": "52e061fa03e3800ed953712dfaa1371ab945e1ee",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b2dccfd17e9708978cd62b3d06f288ff545683de",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "91be571ebbe240154f1e9df5ab785cd1b4d27134",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ca3d3517c50e788f9aee0958391f733498f0945c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "fa330c655f70217366a4bf04eff4027a9f42c688",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5b805bcd19db3c9feb5268353101b336977423ed",
+    "name": "Boulevard Cumin",
+    "type": "easy"
+  },
+  {
+    "id": "3d20457171c04c11dc8e8c7c2fb174b119e52e1d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fa3523282a8b64365feda066ffb8c1077379b0c2",
+    "name": "Ours",
+    "type": "easy"
+  },
+  {
+    "id": "7395f3bfa4a5b1f4ddd0de6c12a3fd09ec87055e",
+    "name": "Voie de la Boucle",
+    "type": "easy"
+  },
+  {
+    "id": "63828d74c8817c072ae335f64843d9a2026d232a",
+    "name": "Plein Sud",
+    "type": "easy"
+  },
+  {
+    "id": "dd75686f15f2443cf69ac1e8bd45c6f7672c3616",
+    "name": "Biollay-Verdons",
+    "type": "easy"
+  },
+  {
+    "id": "119d2451115060b917a0802bfd8e1236f8ea6cc1",
+    "name": "Piste M",
+    "type": "advanced"
+  },
+  {
+    "id": "6e495857ccc580530823622c76e348783e5d8d72",
+    "name": "Mures Rouges",
+    "type": "easy"
+  },
+  {
+    "id": "6bfa0ba06fd737eff9e6b9df8a9f351ad1f96b49",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b101ec53268db7902415eb0272bf75659e7e9329",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ef9dfa0173a532d34d281f5988885d1545e3c473",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fabb213108ba106c6a753242ba1689a4d4f18f11",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "28b796f85d8cbd45daf0c545699a9df01f5461f7",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "5326e22d48caf1f13c736c6b91d773825517bc1a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "2186bc365d21d25e67ac53426522a04fcfdcaace",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bb2eda0d462b06a90770cef74ff78b585df6367a",
+    "name": "Marmotte",
+    "type": "easy"
+  },
+  {
+    "id": "313ec18a80593504d3a043ca2266ce87c3990b2d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d3852c97d9a9d069371ebf4a4634c74e92657942",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "49c0da00479c6f245e3cd7d2e72b31a4d6c62f67",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "585d6b976bc68c96e79426ab19e066f27fae6276",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a88f9e47986cd75eca9af99c198598ff88109676",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "87c433c36090d045443b7b951cffd556462c4e4b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bc6aef03fbfe9a09e228d6199ddb9dc05570d5ec",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "814337745cf08503cde6f35080315f07f2eb9692",
+    "name": "Rochers",
+    "type": "intermediate"
+  },
+  {
+    "id": "1b69dd64c4f4237fe080193e72355f70fbb01e2c",
+    "name": "Marquis",
+    "type": "easy"
+  },
+  {
+    "id": "f9b2b088138742c0678c085b81b4106466cb2515",
+    "name": "Bouvreuil rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "4cd0538025a5bb722c2b92b2dde94258f6c96084",
+    "name": "Piste des Inuits",
+    "type": "novice"
+  },
+  {
+    "id": "a647ae257a6eea03b865de68e09014d13c7161e6",
+    "name": "Rhodos",
+    "type": "novice"
+  },
+  {
+    "id": "2a8884d02bc19dbf98516067c7534b0a441c301c",
+    "name": "Boulevard de la Loze",
+    "type": "easy"
+  },
+  {
+    "id": "338b01568ac81451c0c0a317c1836eb755b59d37",
+    "name": "Tovets",
+    "type": "easy"
+  },
+  {
+    "id": "b5ae776c8147f490814fcc940f55c064fcf958e7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0380313560f0f1debda994e1dd39baf9b8982dc1",
+    "name": "Blanchot",
+    "type": "easy"
+  },
+  {
+    "id": "3d10787be9b7b3b0a03a55d180eb6a8ed035b3aa",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6d60993e5970d2f68a49ae36676f3970977720fd",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "405086b7909c38c389047e439c871733c48588a7",
+    "name": "Pylones",
+    "type": "advanced"
+  },
+  {
+    "id": "a7870853921cdb51c83a3d7da3ad486e8afd6bca",
+    "name": "Pylones",
+    "type": "advanced"
+  },
+  {
+    "id": "db7c59fa0bce780b98aed324e8a73b9aee44d755",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9eb1e17441dd7dbf221b4bcc664c189f7bda5ab7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5444762c5b88d49a1c08b717155e39dc6e512470",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5600b14765226f54dd8bbd3e45160252a323f7f3",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "d39193e55b986d086095831cc93000148b07f3e8",
+    "name": "Col de la Loze",
+    "type": "easy"
+  },
+  {
+    "id": "736a92f116d8f54d96d1d39bf8420da84faa0467",
+    "name": "Preyerand",
+    "type": "easy"
+  },
+  {
+    "id": "45a37492e19312c8e50c4fe1cf6ef2f79ea82138",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "69910a5c1eef0e07f0b4a8c0e9c9f088d4fffbf3",
+    "name": "Bettex",
+    "type": "easy"
+  },
+  {
+    "id": "9a8b96f4f44f68539d3297bd0f8f3fdf76088c31",
+    "name": "BK Park",
+    "type": "easy"
+  },
+  {
+    "id": "58e89bc64788a067d6c6d88f2afbc8d3ebf52554",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e9df1bbaa3c96ddf4361b0b558341899db79481b",
+    "name": "Écureuil",
+    "type": "advanced"
+  },
+  {
+    "id": "c916967ff9faa09b2413098600787ebbc3a0fe30",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "7b0569380a88dbcaab10abfdd2a2aa3aa588b105",
+    "name": "Roches Grises",
+    "type": "intermediate"
+  },
+  {
+    "id": "3488a0ae2865de785802cb99804e1ea0f4ff6b0e",
+    "name": "Freeride Lab",
+    "type": "advanced"
+  },
+  {
+    "id": "d7f55790f5f52cecd6824f7c1df2298c7da669d2",
+    "name": "Boulevard du Lac",
+    "type": "easy"
+  },
+  {
+    "id": "3788cbc3402ed1fc7fffef74c583f02632c098fa",
+    "name": "Plans",
+    "type": "easy"
+  },
+  {
+    "id": "2f36c22bbab173bb7e602a10a8a53179c42bcd47",
+    "name": "Little Himalaya",
+    "type": "novice"
+  },
+  {
+    "id": "f7b888e4fa8e1b50c02c4188933622f80dfcc055",
+    "name": "Dahu",
+    "type": "intermediate"
+  },
+  {
+    "id": "c948644e0351b617ffae674334402e3f8a575a00",
+    "name": "Coqs",
+    "type": "intermediate"
+  },
+  {
+    "id": "bfb26252fc01fb299bcfc3462e6a553eab37ef5b",
+    "name": "Stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "223f5933ed00730b5e6dd06aca76a266fda05e05",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c42b8810ab45a19ddc558e404de7c276989525c7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ef1355624021dff86857a0b37331fd913522f592",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6b4ce2047eaa9b7165acda16bdd225fcab40024d",
+    "name": "Petits Creux",
+    "type": "easy"
+  },
+  {
+    "id": "0821b5a260c36730f006a50cf04b33631d0a2d45",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c04c84d5762b2107867bc117d2a0e0dd444b97fb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3363a6d662d3e88cdf58440e9d7bdcb83738404a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b132e19162d40022351aacbbb45ae512fc82f157",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9637864990b3c240a91e47f5262c492154da1ea4",
+    "name": "Bouvreuil bleu",
+    "type": "easy"
+  },
+  {
+    "id": "96c5ea505d1c0788dc38d6d99dc2129cfa5ba4bc",
+    "name": "Gaston",
+    "type": "easy"
+  },
+  {
+    "id": "f64ea4b4dbec2cc9189ae8745360c73d835e5e70",
+    "name": "Combe de la Saulire",
+    "type": "intermediate"
+  },
+  {
+    "id": "d899bf3762733b4a00468db599bde388dba73703",
+    "name": "Alpage",
+    "type": "intermediate"
+  },
+  {
+    "id": "f4f72d35bcac94d4f3bc68661081dc97bb336181",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "914f9b593c09ee30cf7419fb07d37842dfec507e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ea6b7b413b8f508973b94bc017ea88a62be39e30",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3cff83bb25e63d543e24b723df9069fbb9f61c80",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c44e7d487658f7e50dcec14c00e8984248381960",
+    "name": "Suisses",
+    "type": "advanced"
+  },
+  {
+    "id": "32fe7567e07c8cfe61b69464c4fc67a287109bcf",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ad83e4548fb1d9aed0a536f758bcf07cb6f452dc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cb0081b3c418872342f6c28f271bad98dfd30387",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "e8645ce4bd40c276a6392fff42fa3ef466617a25",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ab82a142cc5aa431c6e8ec211d71039fc64ab523",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "32b2cdf175ee03453a7fba54ba25ac361b98c04b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4d4460a522eca48f33449301b0f63e02f3d99ffd",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fc6593882df47757da4332c6b966cea95dedc232",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0c22eafd2811cdb512ed09641a1a7c504ef8b7a7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5c737dcda9b1b456027a9f24f3de8ac00068e50f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5325b64778e3f723bf20c1ca875f045cb662c315",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cdd1bf0528cde90d8ca515769cdd84f4fd62333a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "2110cc4813b5e831b2b52a3082243791447467c1",
+    "name": "Loy",
+    "type": "easy"
+  },
+  {
+    "id": "c5448030e5d55ac19d025fc364bc2ec7d548af04",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "68a3aee79436ded858ffefab17ca65a03d567cad",
+    "name": "Sainte-Agathe",
+    "type": "easy"
+  },
+  {
+    "id": "65c085bedd11e1f5288ccd20701e2de8851a5efa",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f9710deaa957c5b8d40e090bbb457d11c0fbb8c9",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9669703bd6af815f410e11cd3f4c85b8d1db3be5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c4ce8f3b0502e953a40641b546106440216fb118",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7be07da48f3704bd01a46c0cb2dd801632f69057",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "568f88c5c840fb604a4c0347e22797072ef73e59",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e175be38c168d85780154d8b66cc1ce0fcd30c65",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "14abd9853244ac47ec01bd11c793495c79a1aced",
+    "name": "Fouine",
+    "type": "intermediate"
+  },
+  {
+    "id": "1f0083b93e605b8c095b09f20bd7d0942c640886",
+    "name": "Pelozet",
+    "type": "easy"
+  },
+  {
+    "id": "bb1604c4a45b8a91b2d0d3ed1c386660fdab6a9c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6c051df75cf6938fd34cfea271785a7086a2d7cf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f391e89a53cb5a3c5842c20d340f6d76df0950b8",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "980defdeaa65af76f6cf24296348858439e24cf3",
+    "name": "Alpage",
+    "type": "intermediate"
+  },
+  {
+    "id": "ecc61a5755baaed2a2a8e46b054690d1ba42f524",
+    "name": "Chamois",
+    "type": "easy"
+  },
+  {
+    "id": "14ae23aee387764214961397ebd387f7f9a3f7f7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e7c219f208216e540a92c97950b4f22cc3792abb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e4d65099dea49d43635e98ee431f5ef4c1cd690f",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "573f0a70954c67d3cbcb2fd2cd614a99eb2d1d50",
+    "name": "Plein Sud",
+    "type": "easy"
+  },
+  {
+    "id": "9ee59be298c9392ba9a0e8a00a033b57288f67cd",
+    "name": "Musaraigne",
+    "type": "novice"
+  },
+  {
+    "id": "98f900ac6f8ba0989fb285c02d7d9c9c90cf7df6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a410b1f660d2c4d26dee47550ca7f1f3fa134b97",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f410f2da023088f071c996579c98d09a5259fd78",
+    "name": "Éterlou",
+    "type": "easy"
+  },
+  {
+    "id": "f6267dd80c1377c24a002e1cf126fed4e50deb2a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "492f76fb87d2dce0354e41bd16df58fcb7de5737",
+    "name": "Mauriennaise",
+    "type": "intermediate"
+  },
+  {
+    "id": "468c0fcad966f17d2f9c97391a0a635e032bf670",
+    "name": "Combe de Thorens",
+    "type": "novice"
+  },
+  {
+    "id": "37149d24ac8cf3b049f8997372f8d754c008585c",
+    "name": "Lagopede",
+    "type": "easy"
+  },
+  {
+    "id": "627168c76642f9feea93a29dee995c5d0203b634",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d5f58f2e2f24eb9c1ed4f734b8fe7509084c617a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7837e7709d3bb3efb8428fe9b1bc2b9b16c7fc62",
+    "name": "Roc'n'Bob",
+    "type": ""
+  },
+  {
+    "id": "3f266daadbdd9aff5eb6367628a1472c09cb62ae",
+    "name": "Teppes",
+    "type": "intermediate"
+  },
+  {
+    "id": "d3d5bb25d2f7dd82f53d10f8d003e5d122c7278e",
+    "name": "David Douillet Bas",
+    "type": "intermediate"
+  },
+  {
+    "id": "7758e72c306f4bc60578ded7cffbe7c20cd787c1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "22ffd3f73e098f572e4b281e0f833bee3b1a431c",
+    "name": "Retour Sud",
+    "type": "easy"
+  },
+  {
+    "id": "7f77f2e0a25200ca4a0dc6bea37f9a68c936f789",
+    "name": "Voie Lactée",
+    "type": "novice"
+  },
+  {
+    "id": "ac5b711116d8ff305fff53691662f1e94e2ad22a",
+    "name": "Col de l'Audzin",
+    "type": "intermediate"
+  },
+  {
+    "id": "c7ca163eb881f3d186a5467f6f5be8a102a4f1d5",
+    "name": "Béranger",
+    "type": "novice"
+  },
+  {
+    "id": "6a91921f8a9d06d3aabe1971012890295cc436bf",
+    "name": "Plan de l'Eau",
+    "type": "intermediate"
+  },
+  {
+    "id": "68b897ab63188db6464743139ca8ff693f2b5a50",
+    "name": "Christine",
+    "type": "intermediate"
+  },
+  {
+    "id": "824d717f328523edf857323cc4716d75dedd2cfa",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4b1402443df48dc02dce910aad0cea476abcacbc",
+    "name": "Stade Yannick Richard",
+    "type": "advanced"
+  },
+  {
+    "id": "ad346c3d6b6fb254c61d135138d37c2570955909",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "d14fa1f9aa6919452a01d5e51b47057d715db711",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3f04e24319784f7e9f3042c6d6e1de7871a9088c",
+    "name": "Cosmojet",
+    "type": ""
+  },
+  {
+    "id": "0172c18fad00330f918a3262d3bf5992eb36656d",
+    "name": "Roc",
+    "type": "novice"
+  },
+  {
+    "id": "d2b68b349f044266d86d1e24e643bb447b39a3bc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2c3c31a8e15ca1e012d7ec81bdf91888f2162734",
+    "name": "Truite",
+    "type": "novice"
+  },
+  {
+    "id": "70b9ca5cb6edab65a742140f4a91d8d185568845",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e73625c859ba69d31274f4567be419199ecd8226",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "cbd470fd6473b19cbf6f5d547abf99abe53f1a3a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e9b8fdff785f935b6ccb56fb12b98511fbe008f2",
+    "name": "Déviation 1550",
+    "type": "intermediate"
+  },
+  {
+    "id": "00440816de84dff21be76b1bacdf16a7b56157aa",
+    "name": "Plantrey",
+    "type": "novice"
+  },
+  {
+    "id": "cdd4918a33be1cc9a19963f85efadb1dc65f6be2",
+    "name": "Loze Est",
+    "type": "novice"
+  },
+  {
+    "id": "b71bd4e471eabe40e792f5a3d01299c9330a6418",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4c54552f930092bd500a9d87d9c416b52bee1176",
+    "name": "Arolles",
+    "type": "easy"
+  },
+  {
+    "id": "e5dcc68a4fdd258b58b138f25e158138e21270e6",
+    "name": "Boulevard des Amoureux",
+    "type": "intermediate"
+  },
+  {
+    "id": "6b77a7a4eef6a8ac8808d4e66f73ddcaa5d5bd17",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9985d111b88dc924d1931876ea284d81d03b2cf2",
+    "name": "Folyères",
+    "type": "easy"
+  },
+  {
+    "id": "a60522e9fbc90dd9ef0a30f5ab7ed4b6f05287ec",
+    "name": "Pic Bleu",
+    "type": "easy"
+  },
+  {
+    "id": "b34dfaf08317d4b0930baebd946f43a394ebea99",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dc94f149a9456545e97fdfe11813d3d44a91cd4a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8312097eb0c80e4983397af5fafbe7d14c3aa831",
+    "name": "Geai",
+    "type": "easy"
+  },
+  {
+    "id": "97c9d254c94952a999b991f0422bae2b7704d374",
+    "name": "Renardeau",
+    "type": "easy"
+  },
+  {
+    "id": "4d34e67e685600ea9b0bab43c1903339106bb571",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1d8d44dd4e99016258c714dcbb67c9673d9dc704",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "879ea2812e25ccdd1694e0a3826656e348b89f1e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bd7b78ac01f31ee02c1976ad3f48357a62d366c7",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "b1cf55fa5c9d1ef53df02c3407b5aaa7b5b78a1d",
+    "name": "Espace Junior",
+    "type": "novice"
+  },
+  {
+    "id": "cc5fc5d392db98a799e2ae18db9179c996a1addb",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "994d1c8c7e8cf523a47e1440f085bbbde496898f",
+    "name": "Petit Dou",
+    "type": "intermediate"
+  },
+  {
+    "id": "48c1223771e0e2c6f758fc1bace1c54f5fbaced8",
+    "name": "Stade Epicea",
+    "type": "intermediate"
+  },
+  {
+    "id": "0523a7c5dc58fd60a1fe04f4ec6f70e0b6d296ee",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "efd673d208d1b90bde5d2a1bcb76400fe86d3fbb",
+    "name": "Loze",
+    "type": "intermediate"
+  },
+  {
+    "id": "bcf7ac1bda77d076a6fa0985f84b3642a6fa45fd",
+    "name": "Loze, Loze Est",
+    "type": "novice"
+  },
+  {
+    "id": "f0e48665f165fa9a6c0ae8c79ceda1372ea1fc8e",
+    "name": "Loze",
+    "type": "intermediate"
+  },
+  {
+    "id": "84c3ca55ddcbe138ae467979678e6e425d361d42",
+    "name": "Coq",
+    "type": "intermediate"
+  },
+  {
+    "id": "4eb65be3c1c2d6d0188a1c5b38e75d609362a942",
+    "name": "Jantzen",
+    "type": "intermediate"
+  },
+  {
+    "id": "97acc6c5453d6bb32e49ded2af3af5e9b5c7d727",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4b24f713f6de099d782f5fae51aa49f66d9397ea",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fd8cdb14336d8aeb21e1f2f639da1e6a27462381",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "16c848bc1b1459018b2247e34af9a9418153ae4f",
+    "name": "Mur",
+    "type": "advanced"
+  },
+  {
+    "id": "8d832bb576d13452bc517cd32c5d87ebb78dd06c",
+    "name": "Renards",
+    "type": "novice"
+  },
+  {
+    "id": "6f941ebdc2b4c0a4060ce9976a6730fa2020c76c",
+    "name": "Pralong",
+    "type": "easy"
+  },
+  {
+    "id": "440d1ee7c8313278985dd211851c6582bf3e1e27",
+    "name": "Super Pralong",
+    "type": "easy"
+  },
+  {
+    "id": "4815762ab8f3f157ffbe78f7a0dae5307ece020e",
+    "name": "Marquetty",
+    "type": "intermediate"
+  },
+  {
+    "id": "ad7176bd8468e7b80f744cc04d78e7d819ad4025",
+    "name": "Praméruel",
+    "type": "easy"
+  },
+  {
+    "id": "a256c9088b2f32c8eab41db45d62b2606335d054",
+    "name": "Chanrossa",
+    "type": "advanced"
+  },
+  {
+    "id": "986b1b4abee0285fcdf5de573ada8793d2c66927",
+    "name": "Chemin Vizelle-Combe de la Saulire",
+    "type": "intermediate"
+  },
+  {
+    "id": "d15adf11172a30b4fb8b278c27521b9f332399e2",
+    "name": "Combe de la Saulire",
+    "type": "intermediate"
+  },
+  {
+    "id": "805471147b2b50c6816dae741b947409094aa086",
+    "name": "Combe des Pylônes",
+    "type": "advanced"
+  },
+  {
+    "id": "c5ea3bb9e2f4d70bb2134d46ad85a648a7203f31",
+    "name": "Tétras",
+    "type": "advanced"
+  },
+  {
+    "id": "9f0dd201726307bcd370c802760ee41eec4d9a48",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "3eb49b64b52b9d7767ac57715fc084ca19285d96",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "21d43b0850aec6a76f584af0ca79a0eb6d9d1224",
+    "name": "Folyères",
+    "type": "easy"
+  },
+  {
+    "id": "a6dec1429b4815d89181a75e18d278fa532c7cbe",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ea1a2f083308565020ee237e6a5605389d248cbb",
+    "name": "Plan Fontaine",
+    "type": "novice"
+  },
+  {
+    "id": "781f058305cd09be59808591ad836e915f2af352",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3c28dd48530adbe7f6366555783e7a4eb7a4d88d",
+    "name": "Troïka",
+    "type": "easy"
+  },
+  {
+    "id": "d1f348f65eaa9928a1cd6ac0e8df72010ff52c67",
+    "name": "Bouc Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "b6abfc2cf37ef8df9100652e592becb086e60f03",
+    "name": "Bouc Blanc",
+    "type": "freeride"
+  },
+  {
+    "id": "9735d8f2961210c5191c994a59056a35b5967902",
+    "name": "Bouc Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "b0d870994927a38a135e2b1583bded15f4057405",
+    "name": "Forêt",
+    "type": "novice"
+  },
+  {
+    "id": "86d92e42683d68c147913e9dded3af7345d6e014",
+    "name": "Forêt",
+    "type": "novice"
+  },
+  {
+    "id": "a69cb1760029ef095de4721fcd24c54432fb5b82",
+    "name": "Arolles",
+    "type": "advanced"
+  },
+  {
+    "id": "7ec21decfa05511c6587f127cf8884e9e96b0906",
+    "name": "Lanches",
+    "type": "intermediate"
+  },
+  {
+    "id": "f2e7400c87b94d773cd858d1e53c7e2a50c9225d",
+    "name": "Loze Est",
+    "type": "novice"
+  },
+  {
+    "id": "9da4e9d7112bcf6b0308c5ac071e4776259135fc",
+    "name": "Loze Est",
+    "type": "novice"
+  },
+  {
+    "id": "298a004a4c9da263906aa9f859f107d839630119",
+    "name": "Plan Fontaine",
+    "type": "novice"
+  },
+  {
+    "id": "f69822971d5956bf4bc7cc3593ffb106c08890c4",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a2326576bdc47f67596fd8f5933f2808035585dc",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "2cab6ae3f0ecfe111ebc00c71d83dc7c7811365f",
+    "name": "Boulevard Boismint",
+    "type": "intermediate"
+  },
+  {
+    "id": "fd283505969561c9f7646d3d97ab26026e557c1a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "175c67dfa3a040dc2ff9fcd9b720d2fdbfa802d7",
+    "name": "Boismint",
+    "type": "intermediate"
+  },
+  {
+    "id": "0ec63263dd946f95c621998d100b465743c8ed13",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5cbf62247fd836806be801a3b7cc4c0ef53f47e6",
+    "name": "Fréderic Covili",
+    "type": "intermediate"
+  },
+  {
+    "id": "e44e2e53754097f4977f5a25477e4df0ae91dbf2",
+    "name": "Lac Noir",
+    "type": "advanced"
+  },
+  {
+    "id": "35d685da57fc5fe2b39d3c45a09ff9ee931c110f",
+    "name": "Longet",
+    "type": "intermediate"
+  },
+  {
+    "id": "c4d115d3d1f54da3bcb183a2ea74c0475620f6c3",
+    "name": "Chemin des Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "62ec09d29db82e5447f82a9f64c3e1eaec37b997",
+    "name": "Léo Lacroix",
+    "type": "advanced"
+  },
+  {
+    "id": "e629a6cd0aadf4681e41bfde08bbadc7084e4270",
+    "name": "Léo Lacroix",
+    "type": "advanced"
+  },
+  {
+    "id": "758d57be2ea6a73f58a9d44ee87fecaa5c927ba9",
+    "name": "Plan du Bouquet",
+    "type": "easy"
+  },
+  {
+    "id": "f10fad6794aa08aac1cb33274560d6cfa91165d6",
+    "name": "Mont de la Chambre",
+    "type": "easy"
+  },
+  {
+    "id": "33076d7f83d1231a2c74b99ab4c750684b930ed2",
+    "name": "Traversée de Montaulever",
+    "type": "easy"
+  },
+  {
+    "id": "f09c8da92b022cb80b7098cdc39641db27ccda40",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "0f97ef46ec9cef8503ba11c87a727bea6be0d4fe",
+    "name": "Dalles",
+    "type": "easy"
+  },
+  {
+    "id": "8cff4f632132addfcf86eb224e9d39ed73456a62",
+    "name": "Easy way",
+    "type": "novice"
+  },
+  {
+    "id": "f5063f2b7d754e62f0ea5976ce3964ce5553c399",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e3198c0f02c083d5171065c41cc8cc2cc8a4f705",
+    "name": "Combe du Laitelet",
+    "type": "intermediate"
+  },
+  {
+    "id": "dd68e1288eb04617471613381b0b58ac93b06026",
+    "name": "Evons",
+    "type": "intermediate"
+  },
+  {
+    "id": "988a3bde1c2d76f239a96a9b61f2439c1145f55e",
+    "name": "Faon",
+    "type": "easy"
+  },
+  {
+    "id": "73f6ff22c23b8d77e9bd7041d0e6abf766a798f9",
+    "name": "Faon",
+    "type": "easy"
+  },
+  {
+    "id": "4a16a28c88beee3553aabb13573e16e899808910",
+    "name": "Combe de Tougnète",
+    "type": "intermediate"
+  },
+  {
+    "id": "b0fe7ab0287979e8017fb30210fb9ad97d8248fa",
+    "name": "Bosses",
+    "type": "advanced"
+  },
+  {
+    "id": "12fa38f8ab62342e7b665cfc36f45ad6dce4eddc",
+    "name": "Buse",
+    "type": "intermediate"
+  },
+  {
+    "id": "27efad2e3ee3360cb3995a7162261f824ee1b758",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "db64542c42006fb6e3717415c3c8297a8b66121f",
+    "name": "Blaireau",
+    "type": "intermediate"
+  },
+  {
+    "id": "1bda4867d8de972e86a1b851fa37441d0a16b093",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "b863bd2f21b14e88234c1d785e0106dd1158baf5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b0f50edf13bee4faa54e34b3db16e45d0a91f27b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "22026bf2a31ebc9f8c6a6b08bd6ffdb6302d9a25",
+    "name": "Jérusalem",
+    "type": "easy"
+  },
+  {
+    "id": "10df3cbe8175ce73b4eb1d76f74a363483ebb890",
+    "name": "Roc de Fer",
+    "type": "easy"
+  },
+  {
+    "id": "b7e6ae80d93da207868455a05518574026f9d433",
+    "name": "Éterlou",
+    "type": "intermediate"
+  },
+  {
+    "id": "69aa4c4441ff046962cead6a3ed4ddae4dc37155",
+    "name": "Boulevard des Girauds",
+    "type": "easy"
+  },
+  {
+    "id": "797af2aef7289181ab70598bc74b8c95f1723a5f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ac9b6b5175293d3d49afeabbafb07a027e988116",
+    "name": "Julie",
+    "type": "intermediate"
+  },
+  {
+    "id": "1d5f3fd44ca8711f44ac70814267a636876f69f1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "59c6e60c69f235af26f01e4ecd1f71b17d2af205",
+    "name": "Roc'n'Bob",
+    "type": "novice"
+  },
+  {
+    "id": "f46d8b43201db04c50de174fd0446ff7d0c18d14",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f381e1fdc586ec914d3b708a8369883df3bd8890",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4355fa35f2765b5810147aa3f93277a0af6a3843",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "96122a1d744f271a81edc93c8f6979c90e76bd1a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "e8f4d296cc4b71e90f252adc3cfa9cc0e5ce9112",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "611f9dd56a4634640822d58bd58586206cd0218d",
+    "name": "Plan du Lac",
+    "type": "intermediate"
+  },
+  {
+    "id": "f76062f624944eb88865c8b92493b0d96d435f47",
+    "name": "Marmottons",
+    "type": "intermediate"
+  },
+  {
+    "id": "f126c504801c9b8fe10268c96ff488fecd98c2e3",
+    "name": "Cave des Creux",
+    "type": "intermediate"
+  },
+  {
+    "id": "e551260c69b5e0bf710b761ac05940ec20c12f31",
+    "name": "Lac Ariondaz",
+    "type": "easy"
+  },
+  {
+    "id": "d477de31b3cd21c0e20eda3f18cb960e26617558",
+    "name": "Pyramides",
+    "type": "easy"
+  },
+  {
+    "id": "a5fbddb02be123a0176acd985db4b101e45dcb82",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "67e3ad3a9a21c2aa08df077f7cc239d49f9fbf4c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "58bb51ff19e9478424247680050c78391598d1f2",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "620587d6a65f4261f59bc1ea4d07974063cbaab6",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6d23d24b9ce3cc635df815e043c2c842282fb902",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d5d4f5973c1ab67cadcd6c9053860521aaff4541",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d9cfc41257e1d7f970ff34cc24f8d9889e9ccb3a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cce0926d153e6ba2a2f311afe4f2f62529b4c0f2",
+    "name": "Granges",
+    "type": "easy"
+  },
+  {
+    "id": "ff6c2ba9d2bd0e87883937264426521696e7c7cf",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c952e42bbc6c00a16089a7182b69748ebb1332d1",
+    "name": "Chemin des Girauds",
+    "type": ""
+  },
+  {
+    "id": "d772f263e73fa8913916ad1cf8474f946f6ed464",
+    "name": "Chardonneret",
+    "type": "easy"
+  },
+  {
+    "id": "ffa19377a6b6f3d72f1331e9254b4906165fc4d7",
+    "name": "Campagnols",
+    "type": "novice"
+  },
+  {
+    "id": "cb15cc0a8a94c751ec7a131f79cf5e558c458f5a",
+    "name": "Vires",
+    "type": "intermediate"
+  },
+  {
+    "id": "5ec117d1707d95c6b6e4eae13e4befada7dfdbe9",
+    "name": "Flocon",
+    "type": "novice"
+  },
+  {
+    "id": "f0977119f633fb35879b12356ef1db5cd26501a4",
+    "name": "",
+    "type": "freeride"
+  },
+  {
+    "id": "04ec136065b5cf4a00a353745d389a1139a07674",
+    "name": "Ardoises",
+    "type": "intermediate"
+  },
+  {
+    "id": "5853179092256f0bdd9c5d5e9e912c43c7bd8218",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "536d5de649734f79af1c8c27480d9f3daa5ca7cb",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "271cee3142c047ff9f4087397096f78991b8064d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "30afaebebffa4d911a02f4673753f0aba7392795",
+    "name": "Tétras",
+    "type": "easy"
+  },
+  {
+    "id": "784367786628320881eef623cb96e97bb623261a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "77f7d3631a24e6f47862cff157703925b04495d0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f1a7fd6cc94984bd9280dcaa2872563a49df0741",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bccde41087787f9fa5bec4dfbb9c2b5e9128a51e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "f26557aa8037a52f4ad6ab68d47994e8bb233f26",
+    "name": "Mauduit",
+    "type": "intermediate"
+  },
+  {
+    "id": "93289a0275f116c5db4ecb4b11d696c5f1046c55",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b7b3358421683e0fb5b169ec98cf5ec540962e27",
+    "name": "Biche",
+    "type": "easy"
+  },
+  {
+    "id": "d928eb612e3745a4665ab3676a08cd04c4075716",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "225dd431f9a0007a956e32462a1dc0b771611ace",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "03ede5c86f5fe07a12ed882d13ac53aec16e3628",
+    "name": "Anémones",
+    "type": "easy"
+  },
+  {
+    "id": "2270799e4d763082bcbc5ca4dca41e53979e6230",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "70af10c4e4cc8956b6104b78534ebb9b40a2c4c7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "dc8a712240720159591facf8db0df8d680ccce74",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2a8dac268b7fe2d5f20b164889c8cb25c88ff9fa",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ed1226a6156321987e336c0b7de48d35529fce8c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f13a9c7dc5ba222c07f7d88cf11688ac5f3535f5",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5545e71d792d920ec19ea4312c2e151c2e5e820d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3a1bb6ff2287d19a2c299b5bab31ba5361e40bda",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "80cc485501e53f1a465041da2e5f370ad60decd8",
+    "name": "Pralong",
+    "type": "novice"
+  },
+  {
+    "id": "dd8da3ccc35b335ebf85f208ae99c96315822b33",
+    "name": "Gentianes",
+    "type": "easy"
+  },
+  {
+    "id": "1b3c109d007eda6a24ff261c3ddf7e6e841f7812",
+    "name": "Gravelles",
+    "type": "easy"
+  },
+  {
+    "id": "10419973f38b752851f429fe44b6d36660eeea36",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "213f04a08389ebf5ce05915cdcdf6f325467dbe1",
+    "name": "Indiens",
+    "type": "easy"
+  },
+  {
+    "id": "989e783e6b2ff6ebfef11596fa70cbc3fdd968d1",
+    "name": "Plan Mugnier",
+    "type": "easy"
+  },
+  {
+    "id": "dd5a9d3ed76db83c71b7393ad85b394960276ad0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ff2d518f4b860d3ce84318b1278a51e8ae9ece1c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "abb02546df66d20b0b2b106412ffb86168780cbe",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "d55c33758681df3710f2eb9348d343459342cd5e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "09a9d89f46f9570ceffda61b8203f5c4924c5ede",
+    "name": "Grande Rosière",
+    "type": "advanced"
+  },
+  {
+    "id": "3ce97eca202a7262f96573fd81b11b3635ab515e",
+    "name": "Combe du Laitelet",
+    "type": "intermediate"
+  },
+  {
+    "id": "47cfa3873ce9aa50897b983b73b4636b12a0d527",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0c9fdbaea7ec9b5eaa35b0e1f00303a115e67d73",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1ce07871455946c386f62070354c3d6c6bbcddfb",
+    "name": "Dou du Midi",
+    "type": "intermediate"
+  },
+  {
+    "id": "58b3402bab0546099597c5a17d9b3740bc727392",
+    "name": "Jean Blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "f0f9c074f06ff8de87cf5c96a8ac5db4e4bcebbd",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c8c98d72b88796ab9d28784521cb46c15af8c27b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "bb532c88bda1cc37a978a1d064b0134145a15b01",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7dea740a161400455d48b655bf505b955a1311be",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ef51253ac0097fb7d2955d83db788f9e5c490c7b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6f64695d66135c9c76db83c08cadf7606d0c27f8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b8e4cf0326f6e2daa3c460ea8fe921ae8986531a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "87b9da0b95dffe9a280c7cf5824e833846428067",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a2b724225a7c1025dd5a8a31123fe9609ec585ac",
+    "name": "Boulevard de la Tête",
+    "type": "easy"
+  },
+  {
+    "id": "f6e55142158a27a5852ca075e70abc274dcee92f",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "87174988a846ea854aa57d1f665f6d290194c56f",
+    "name": "Combes",
+    "type": "intermediate"
+  },
+  {
+    "id": "f776e71e568bde10a0ecb0ccd5b83650cfc8f5ab",
+    "name": "Cascades",
+    "type": "advanced"
+  },
+  {
+    "id": "61d5e073363574db1c012f2aa66e6af7533a6a9c",
+    "name": "Boulevard Gury",
+    "type": "easy"
+  },
+  {
+    "id": "904db5c89ed577d09c3b996998560f2758ee511a",
+    "name": "Bellecôte",
+    "type": "novice"
+  },
+  {
+    "id": "89441a41e87c65696e5b7a80ab54309d31f186d2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7a10d7a8a5c7206c4dd647121b56da4cdbb35107",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3a7781f9c2d5832f333b5c8e7d5589834d963b53",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "19988b7aaeec60b8ad352ef3857b16ca3fa1b799",
+    "name": "Mauriennaise",
+    "type": "intermediate"
+  },
+  {
+    "id": "e05c9297350997b29a3ce7d37d851f21dabeadb3",
+    "name": "Telephone",
+    "type": "advanced"
+  },
+  {
+    "id": "b861b13571e176a237379b295bf405551b9ca7c0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8ae6287d27cb8b996e73d848fe267c16972c3064",
+    "name": "Telephone",
+    "type": "advanced"
+  },
+  {
+    "id": "22b8757b22b76c877b6aa2b6111a61e34ead87e8",
+    "name": "Chemin Vizelle-Combe Saulire",
+    "type": "intermediate"
+  },
+  {
+    "id": "698a41aee56f92217eaa004f7ce872e782d343a7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "356692229d3a21b197f05fc940bf09f793ccbed7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b84dbc99743a546fc368f65df6dd448466282cb0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a9dcf684d469687d9755ecd59cd048d5de8c94f6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2b27faa3ff7f8ab1db6e467b896ff86cae8bd8a8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "742620a602f43feb6469727e4ed1256d7b26fb13",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cb8be3b533942fbcfcbcc9cb7b10674443055d9b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "598b657510c60286502d9e77d4a3e261760124b2",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3ae35dd0f03ba914b794bb547bc8deaa7380599b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "83b0a42246376d51f863e9b337579d3393ad7ea9",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "4291eb2ca852d69a35d68fbac133c645d9fa42b7",
+    "name": "Provères",
+    "type": "easy"
+  },
+  {
+    "id": "33196e35189f96c56ecc00a5d359e18f3f1ef938",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "96b651e79feb057d2c61564fc4f62817337e66bd",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4bc0216b83b589a677cf59a97c0da566af0948d7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "987d9ce6913bf276840e2cf0f2a403f72c002c1a",
+    "name": "Grangettes",
+    "type": "easy"
+  },
+  {
+    "id": "307db9958b743ce65fbc593edf05a9ee8a6ee058",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "81597ee882626def7e84b3a0fd6db8d9ae5b8c0e",
+    "name": "Brigues",
+    "type": "intermediate"
+  },
+  {
+    "id": "f27574ac59e26e9de12778b7d7af10c7b254b091",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ccddd6f92fc4bba48822c9151e3d6b9a1382fc04",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cdc0e0df59ee133cbb7e432d60391db8b71140cd",
+    "name": "Bellecôte-Pralong",
+    "type": "novice"
+  },
+  {
+    "id": "03a28383824a19c25ab099eb9361972a0d88df2d",
+    "name": "Alouette",
+    "type": "intermediate"
+  },
+  {
+    "id": "41b7f2a0a64f2c1fecf308d2674a976bd25e667b",
+    "name": "Venturon",
+    "type": "intermediate"
+  },
+  {
+    "id": "e8df8511bf8448d6186ef0e0a562ea99405c4733",
+    "name": "Béranger",
+    "type": "intermediate"
+  },
+  {
+    "id": "b6f9af81a7edb14dc3fabc24561b805c3005d9b5",
+    "name": "Lac Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "21a74c32a8404fe334cfd28e5ce19225e03eacfe",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "c2a5bf7eae88429074325a9ed025cbc3518c508f",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f829673ef23a7974f54a7823c5228d3c775aed8e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cf19715cf937be3febb181bf14eae53b3fc9b70b",
+    "name": "Chocard",
+    "type": "easy"
+  },
+  {
+    "id": "3f00840f39ea4c2c8be821ed5452087204e750f7",
+    "name": "Asters",
+    "type": "intermediate"
+  },
+  {
+    "id": "d5ce53fea2a394234bd87a8880e19354d3151e19",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2285f0d987cdbc0c599ff40b9e2afeb4626d492e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8030eeac2b0b4ef413e86bf15dfc8fe156d1cb32",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1e9b894da1d9002af59da9df6c2410f020fd9f1c",
+    "name": "Les Grandes Combes",
+    "type": "intermediate"
+  },
+  {
+    "id": "3777e65491827837dd641a290ba45faef27255ca",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9991eb2cc3922cc1453d733d60914cfdf5b36174",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d4c5cf51e49b876c7d4cfcbebc0c1de95a01987e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cf2282f240cebddc04319c640451586d3c2573b8",
+    "name": "Chocard",
+    "type": "easy"
+  },
+  {
+    "id": "cccdb555fdbca51d29352fa798da61020317f71d",
+    "name": "Villages",
+    "type": "intermediate"
+  },
+  {
+    "id": "c70b85e0472c319a1ea634e00aae4b3e29e9c1b1",
+    "name": "Doron",
+    "type": "easy"
+  },
+  {
+    "id": "c0b63b6a06decd4eeea0d3f6b948aa228201b675",
+    "name": "Bettex",
+    "type": "easy"
+  },
+  {
+    "id": "01d6d3face8f247ae3167aee76ec13b972e8dac0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "22d4f9cb05aeb4d21b760f8112daa80bd9c79941",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "66d60086a8932979a1c9a50149bb982fb8d2c0c0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e9df252bb98e6575d64c333062a273ddb5321608",
+    "name": "Lapin",
+    "type": "easy"
+  },
+  {
+    "id": "66e1131dc689da599799d68d83deb89930319192",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "95734f6d747b6f1b0ee0b6dfc106854298b89bd9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5107e322d9374cef03a7f174cb4067104c0e2587",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "11aede2f12aa72d6c1ab07f7838d440d20b1924b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6bd696dc1980e1943cc9791978f073df099410fb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6e5b6218a097211563acd6a8faa024bf1ab22d0e",
+    "name": "Pelozet",
+    "type": "easy"
+  },
+  {
+    "id": "73b48015fca13fc37fedf1028d85e78fd78d879d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1257e0fb97b5d0cea2bd4d16024f8ea0c5306150",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4c4f49bd88c09b610acc048b8d6514247a89ca5f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ac60aa6a96ee46fdd985ce4c035f59ef9fc824e8",
+    "name": "Lapin",
+    "type": "easy"
+  },
+  {
+    "id": "b4a25ccfa68be0d11a7920cef8c050ee8045ff1f",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "4c6038b8c876fa9e30f16cb524903f31ae961893",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "69f2e0eccf94f649e6ad9fab8899eb2513a5eaa0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8fac5bd2e08404f6dde36ab4e33812e86e96bfbb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7b0d323f11f9db74edd3ed634b5ad4a60e21e859",
+    "name": "Access UCPA",
+    "type": "easy"
+  },
+  {
+    "id": "af90c5327a93c4d0aab29ed15b5c15c01b0c44e8",
+    "name": "Grand Couloir",
+    "type": "advanced"
+  },
+  {
+    "id": "f73086b55fcae7472a063281c53a68d38cfe0906",
+    "name": "Loze Ouest",
+    "type": "novice"
+  },
+  {
+    "id": "937dbf4c013925c354b99f5ad387e1c08c8708cd",
+    "name": "Enverses",
+    "type": "easy"
+  },
+  {
+    "id": "7371439227bd55958ce062d243af8b8224ba60d4",
+    "name": "Les Enverses",
+    "type": "easy"
+  },
+  {
+    "id": "d159c0f01ef6481ff73a9d56411ed641479f1de4",
+    "name": "Les Enverses",
+    "type": "easy"
+  },
+  {
+    "id": "8d9a9e7d4787883ea5b9171507e5a5a5d81da370",
+    "name": "Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "74ae7123a90cb26d97b223b3a0eb392211444bf2",
+    "name": "Roc'n'Bob",
+    "type": ""
+  },
+  {
+    "id": "a264a88f92adb5dea9d556f2f6a71aac4fb2fa19",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "cd54669dd1f35c4815e767505c3392a9b11ac7e3",
+    "name": "Couloir Emile Allais",
+    "type": "freeride"
+  },
+  {
+    "id": "bdf127c81a97b122b8db02437803149768f3ee07",
+    "name": "Couloir sous les Cables",
+    "type": "freeride"
+  },
+  {
+    "id": "6707db33bf0fba7154009329d66d9ab0529120ba",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "63dc293e3718582f9a29959e907dc618af6a077e",
+    "name": "Col de l'Audzin",
+    "type": "intermediate"
+  },
+  {
+    "id": "a4f6ccbc40c73c575f1d4403e2bdebc3021e3a32",
+    "name": "Couloir Tournier",
+    "type": "advanced"
+  },
+  {
+    "id": "ba7631a8e13c61ad0e8ed0cf6159e2c07688cf90",
+    "name": "Traversée Deux Lacs",
+    "type": "novice"
+  },
+  {
+    "id": "277c8863375fdac6ca4bb265b3f5f9fe6e95d8d1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e7bfabfdc1a7f9dafa4ff42a91520b94ff27c42a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a9e77f3991902c7211272d3375dd1500331a2278",
+    "name": "Les Plans",
+    "type": "easy"
+  },
+  {
+    "id": "5a65c66d935f978228da21b738797f7e1a5aea5a",
+    "name": "Boulevard du France",
+    "type": "easy"
+  },
+  {
+    "id": "042ff05421e7449fb13644356fd5095a0aba84fc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b755beaf0e336dbd7cd85241851bcfc2708fffe4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d9f5b2be4962cde13359b14b66abea47ee9689f4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "02aca9b03b574ad9ffa08a30230cb7c12d2ed7d4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a1c95e38e742c644a0046300a1badabef114811e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9f22e9ef5e73aed2321a99845d40370a39b2e8a7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "999178293000c9af923fb28d36652f9d83df778b",
+    "name": "Gélinotte",
+    "type": "easy"
+  },
+  {
+    "id": "02b8c71b4d45792dc7846ca1a13c97067690c75a",
+    "name": "Petit Moriond",
+    "type": "easy"
+  },
+  {
+    "id": "228828f703affb996ed40a0186f6b29151b4bb53",
+    "name": "Praline",
+    "type": "novice"
+  },
+  {
+    "id": "1e373df4bd87f0fd59bc8b3e9e057f3e2a847a17",
+    "name": "Praline, Belvedere",
+    "type": "novice"
+  },
+  {
+    "id": "485c9292fc89e73a141f2d7fb08dbc3faa941049",
+    "name": "Praline",
+    "type": "novice"
+  },
+  {
+    "id": "ef7eafcf918cdd9b85e19353fc1c52fc76a9ddcd",
+    "name": "Praline, Belvedere",
+    "type": "novice"
+  },
+  {
+    "id": "4299d99c7fbded9c18936f92b8f3b375de41c055",
+    "name": "Praline",
+    "type": "novice"
+  },
+  {
+    "id": "c8099946c3eb960e8410b21e07686cf9b52720c3",
+    "name": "Boix-Vives",
+    "type": "intermediate"
+  },
+  {
+    "id": "28de0782bbe3dac9dd01747c12bd3202f20ba0aa",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1586b55d3422b5872639db76a95d20176a3327c2",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ee8408fb7608c27cb7211b7b6b423bc3723fb7d6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "30a49673e73354cc05f178f694dc741e35ddac49",
+    "name": "Piou Piou",
+    "type": "novice"
+  },
+  {
+    "id": "8323a277ae5135f6401af08210d0a5fd09f77aab",
+    "name": "Praline",
+    "type": "novice"
+  },
+  {
+    "id": "4f2b4d8f7eebb27ca01e5080c97b89ed6327e4b3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0dad60ef1b4065c32e702e2a359961361252ce95",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c397407984410618f509febc07476c3b08362eef",
+    "name": "Belvedere",
+    "type": "novice"
+  },
+  {
+    "id": "e13f27939436424c39b74e6482f56ab76d1d4c11",
+    "name": "Chamois",
+    "type": "intermediate"
+  },
+  {
+    "id": "3188e3b7a36e15f92e79a12d475b2315f4cc82a6",
+    "name": "Fun Park",
+    "type": ""
+  },
+  {
+    "id": "8b30a209ab93483b8f4523b8927ca88540344acb",
+    "name": "Snake Park",
+    "type": "novice"
+  },
+  {
+    "id": "6dccec7a7198d13513eba1c2f148325b0c84c7bf",
+    "name": "Sources",
+    "type": "easy"
+  },
+  {
+    "id": "1f77ddfbc176f74dbc77ce430aee6a769eac03d6",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "381c3def003b9e25bdbd327cee7b4cbe85cd53c4",
+    "name": "Stade Courchevel 1850",
+    "type": "advanced"
+  },
+  {
+    "id": "f3fad93b519c5a5d11b459812111189362c85f40",
+    "name": "Altipôle",
+    "type": "intermediate"
+  },
+  {
+    "id": "68d1dd5609d4431acc3fa9a4f1f25402b2454597",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "679b7b68feb64ef3bf73be1a1546083ac05c2d58",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "4d3999e9cdf42b11a2688694510e0229e0ec4575",
+    "name": "Jardin Alpin",
+    "type": "novice"
+  },
+  {
+    "id": "80a3c5d69f79a95a8f2b3bcaa569bc7b96e15e9f",
+    "name": "Belvedere-Granges",
+    "type": "novice"
+  },
+  {
+    "id": "d24e428cf82b474b3cf2f28a3db1a184fbf3e57a",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "d772f1ca3031bdee0b07f51d1e0094cabeedfc37",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8746583726de4d4b8137be0c079fbd82d4ffdfce",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d0159de8e69c73b7dad726f7383b52c0f3a3f4f6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3fdbc84c05a3dde5baa886ad2f99629f86aea2a7",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "6f2b62881d8721ee61df0e1e1002d91eebdfb51d",
+    "name": "Lièvre",
+    "type": "easy"
+  },
+  {
+    "id": "f25ed22431ba6044bda52813b2fb8e2c5a2fe364",
+    "name": "Perdrix",
+    "type": "novice"
+  },
+  {
+    "id": "ed50a99b1d2dedc066f8963c447fd5d7ab2ba341",
+    "name": "Village",
+    "type": "easy"
+  },
+  {
+    "id": "2e967d8c72999f1ce46615015cf210d3d2e6f7b4",
+    "name": "Boulevard de la Loy",
+    "type": "easy"
+  },
+  {
+    "id": "d8e772d50aa662554dc7b899bda1ddeb8eac4a5d",
+    "name": "Park City",
+    "type": "intermediate"
+  },
+  {
+    "id": "04ae464d0196a1979a5aff3bc15cb7c8b6eb8b7b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "98c89f1e43787ba01365519be7e1a41e7d6c3565",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "08b0c4421bb78ab417b27a179e7bcccf2fa565aa",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fb62d98b10bc6c6f895f7484dd2df01bd868a3c3",
+    "name": "Park City",
+    "type": "intermediate"
+  },
+  {
+    "id": "13c1af2bf18b11eb6ec1e095877b202a9723303f",
+    "name": "Roc Merlet",
+    "type": "intermediate"
+  },
+  {
+    "id": "4f0863798634d5149f3f7791ec8779fdee7a5e60",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8758df7f27c78c1143418c2b0b53375770ab02ed",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f08192cc349eece35ecee04fe3bcac72d4daa67e",
+    "name": "Jardin d'Enfants",
+    "type": "novice"
+  },
+  {
+    "id": "8ee5ed2bc61290c9f2eb9e61be4b5bccc7d80723",
+    "name": "Jardin d'Enfants",
+    "type": "novice"
+  },
+  {
+    "id": "e3c68c5f02fbbb559f193f5ef72c03db5736d773",
+    "name": "Piste des animaux",
+    "type": "novice"
+  },
+  {
+    "id": "f3b157581b537575a36f1649d336a81a52261e58",
+    "name": "Plantrey",
+    "type": "novice"
+  },
+  {
+    "id": "fc143759f56461a9199652103b325fa180462cae",
+    "name": "Plantrey",
+    "type": "novice"
+  },
+  {
+    "id": "bc172a543ea68e3d0f26ba38f464bc685eb11cd7",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "78037b5e72fc293674c8caf0c97829e3c9415218",
+    "name": "Folyères",
+    "type": "easy"
+  },
+  {
+    "id": "79b914462721aaaf915375517219be66497dd690",
+    "name": "Chabichou",
+    "type": "easy"
+  },
+  {
+    "id": "f6139c27f8381d2ede3881792dfc422cbc6c905e",
+    "name": "Saint-Bon",
+    "type": "intermediate"
+  },
+  {
+    "id": "fd2e7739433cc858cb78ba1c3bb82466c9a698b5",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "006282e712cf2997133683bb477efc9653d2de46",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "c01f268dd2e6f77a663e1c8c0eb0bcaeed6157d0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "67f6953668a0e5eda2662532d586025391f09846",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "26ef79bf136daf4c6abb6887b5bbe71b9734d67a",
+    "name": "Access UCPA",
+    "type": "easy"
+  },
+  {
+    "id": "272283aa63235eda4363a48b4c74ad421440b153",
+    "name": "Accès UCPA, Access UCPA",
+    "type": "novice"
+  },
+  {
+    "id": "435d274ec8a02b64fdadc0ac795973952bbbcd28",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6565f0ee34cff01ced2371fbde3b2155e6110f1b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bcc705b248464f6fe50ae455cefb7e7f97f02467",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7d27c59682e11ea0772e5ee105bcb6082ad17864",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "15cd1be36dd3a560a8c515f3e03f6e92345ce47c",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "35d173780a1346cad52dd0eb9f4adc0985b5563c",
+    "name": "Coqs",
+    "type": "intermediate"
+  },
+  {
+    "id": "79e803097aaaa5365e3058e1242c42be9ec4a1fb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fbb9ceae93abead695c7d293d467674c25bafb96",
+    "name": "Lory",
+    "type": "easy"
+  },
+  {
+    "id": "fecdf92a4e56ceea19008ebfc2099524e736d2ce",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5ebaa686f7a81ed08377636e2cacd13264366325",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "47e027b23528d0548c5bedf75732320b6012274f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f5f8e8710df6d186acd5b19445f10c82a438f51e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "4771b0cfeccf34d5d4b6ddafdba21f7ecfffa19b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3c23052973580c654cf2dafde49412e872de8f7b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "991b7594d483a65e498b27521bcd56bd76998efa",
+    "name": "Boulevard des Coqs",
+    "type": "intermediate"
+  },
+  {
+    "id": "ee1bced7805530551300d512d565c1b19b1260f1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "dd44076cd63a405da2e91cfacfabb709329db0b2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5cdfe60166cf9951d8bde106b38bab2e0ea82652",
+    "name": "Chasse",
+    "type": "intermediate"
+  },
+  {
+    "id": "2ae74986f34bd693a66d223eb560a681abc05525",
+    "name": "Montagnette",
+    "type": "novice"
+  },
+  {
+    "id": "ebe095ea3661bc16616874cdd7976a43f6eb24c1",
+    "name": "Plan de l'Eau",
+    "type": "intermediate"
+  },
+  {
+    "id": "06e2590a420041be41530694cf434b7f219a235b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "20038981de7863722bdb4bc842b32be972c95fac",
+    "name": "Altiport",
+    "type": "easy"
+  },
+  {
+    "id": "e33e73b7ebab07594efd8d51840f6ff293b14a9a",
+    "name": "Adrien Théaux",
+    "type": "intermediate"
+  },
+  {
+    "id": "cefb77bc206e87417369a306118a98e0b9a38d41",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "32879c7c6ef895f7db17bf01e57df54d7b8cc641",
+    "name": "Croissant",
+    "type": "intermediate"
+  },
+  {
+    "id": "b464c4e97f9964b4e9d3104f0f0d8ae9e898daee",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "2472dd4d67997d735113bd4d37f4a3cb2d4abd4a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cf1e0863d54b7d65304393a326d072803e13302b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5bab5ab7d4c42084fcd2d4258a034dd06642effa",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "45080627d3faec5a150fbccff7fcd193a28e1942",
+    "name": "Corniche",
+    "type": "easy"
+  },
+  {
+    "id": "1869c103f26dc121a6bdc1acb21a19f981450ed1",
+    "name": "Croix d'Antide",
+    "type": "novice"
+  },
+  {
+    "id": "3b7b400ac5846d43e897c8612675fa2a2b24295d",
+    "name": "Lac de la Chambre",
+    "type": "intermediate"
+  },
+  {
+    "id": "3f171ef5f39b116b0891aa686e7ac932e6a991e4",
+    "name": "Cherferie",
+    "type": "intermediate"
+  },
+  {
+    "id": "2ad5102f400d8072eed3782d4d809ef91005ae2e",
+    "name": "Liberty Ride La Riondaz",
+    "type": "advanced"
+  },
+  {
+    "id": "2025ce9a9b128a09a45fcefc729f53e73f3a1cb8",
+    "name": "Jn'Bee",
+    "type": "easy"
+  },
+  {
+    "id": "5a8ded9d52cf7e343655470de174dbd059abfbed",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "83cc46aeabdf41aa2a51f64f6861937ddf8dc24e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "3055b1da6a1afa35b1b04040acebc7d238390486",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ed0a8feaf764dc14f24b12d877bd6c57fd2bb191",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "cf4b6c6e736d0a0294dc6449a4c988453ba18d94",
+    "name": "Masse",
+    "type": "advanced"
+  },
+  {
+    "id": "7bfff6ca2ffcd29b536ed6ac802196b81032298e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "52f148ff281b6ad00c54fa842f759457e4249252",
+    "name": "Rhodos",
+    "type": "novice"
+  },
+  {
+    "id": "37efca20765ead0883fbb583f330bf580e10f205",
+    "name": "Armoise",
+    "type": "advanced"
+  },
+  {
+    "id": "7c4f3529c3d85e3ac941b0f35ee15fa81eb9a19a",
+    "name": "Folyères",
+    "type": "easy"
+  },
+  {
+    "id": "d1db7b72666135bf9f9755ff03d83ff5a653fa62",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1e39eb55290be85408c18e9b6e89d2ac49964c80",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1d1108fb13e153632ce0e83582af89f80d9c5554",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ff2993c8aa0cd96b616fb159da744246bd383918",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0c24b12a20920177dbbc86ae3d35349ab7ae785e",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "6f16e831a70ebe29b31e4e8527738a00c9d35736",
+    "name": "Verdons",
+    "type": "novice"
+  },
+  {
+    "id": "412b4f213c7c3a9c99cdc1e9021cdadeac3502c6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "56f9804fb828916ec1c2143d05441e5aa8a14c41",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8be011bbb207e6bb5f68820ef9a2c44bd2903fa6",
+    "name": "Murettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "22c535b0989a1053f0afcf3366c561a6f636812d",
+    "name": "Murettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "007d28074efd19753d3088959fba87b5c68e13ca",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b496e8540beb6966d1b8e33421bef84f02c6ee3c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e19a29103f5e7a095f3184ce6a91bf0bce971a87",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ae69fba88c5e6eb3dbc17dd266470caae1002211",
+    "name": "Voie de la Boucle",
+    "type": "easy"
+  },
+  {
+    "id": "335729a82434bea52c88528738b4edd56105f4a9",
+    "name": "Voie de la Boucle",
+    "type": "easy"
+  },
+  {
+    "id": "403ea60d2a13b715743eda8f4f487c11ddd832a0",
+    "name": "Combe de Caron",
+    "type": "advanced"
+  },
+  {
+    "id": "76e95c65755f7c37d89150f2d20ab009478a16d7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b9095f20a6e069b7f006af3715f7aad1071ecc71",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "027e003639468ac25df180a4bbdb024df002dc71",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e9a7edf02b3c553e4d16846d4bdcdee5654f35f7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "45bd03876fa983dc3f3a78c5bb5c299c40787f7a",
+    "name": "Longet",
+    "type": "intermediate"
+  },
+  {
+    "id": "567070041f00dc1084542ec0fde60b40d89ec981",
+    "name": "Crêtes",
+    "type": "intermediate"
+  },
+  {
+    "id": "ff38339273678c64e311ae3304b6bd17f3123fa4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "121443f4793c720e2cb86a8ac6e62830a1a69468",
+    "name": "Plan du Vah",
+    "type": "intermediate"
+  },
+  {
+    "id": "26ca940b2cd5fc8dbb7dbc0b10d48f7c494b5fa6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "86370f9036a6d1d040e58e3e9e035aab815691b3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8edb22b0c78721e0066f09bd6c8883aba8ff7c0a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cbfc70435f8b09f631e595936267acea42b069f5",
+    "name": "Bruyères",
+    "type": "easy"
+  },
+  {
+    "id": "0733574d59f64d49fbdf06a7f0e3852d10b9bd62",
+    "name": "Alpage",
+    "type": "easy"
+  },
+  {
+    "id": "ad58a81dd185880e91073aec1eee2fe4e1e825ed",
+    "name": "Boulevard des Echauds",
+    "type": "easy"
+  },
+  {
+    "id": "b5be20fbf054c985c1cd0657125ba83aba1e98af",
+    "name": "Montagnette",
+    "type": ""
+  },
+  {
+    "id": "8eda8dace2d5235875cab01c7923d53ea1ccef7e",
+    "name": "Bleue",
+    "type": "easy"
+  },
+  {
+    "id": "8ced865820e140b2778100b42fbca118ed399e86",
+    "name": "Friendly Natural Park",
+    "type": "easy"
+  },
+  {
+    "id": "d31a20e6f4d995afb506f379c73c434e9d36c5ea",
+    "name": "Cèpes",
+    "type": "easy"
+  },
+  {
+    "id": "193bb1e61ca626ea78ca214958827b346d5cab8e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8e5cb3167101504cd851f46a916acc516524415c",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "efb49d4909716fde4cecf86f4ad6e09ccf5b2645",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bac1af31e69801815c8a8be135e4364943de1ee3",
+    "name": "Daguet",
+    "type": "intermediate"
+  },
+  {
+    "id": "1045d06c6f4f583d1d02e51824fe612f61200c08",
+    "name": "Gypaète",
+    "type": "intermediate"
+  },
+  {
+    "id": "2ed43e1857e341d384b5bd1713702b831247c950",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2f566fa603d70efcd8c9d5256f15c5c0d81f8269",
+    "name": "Little Himalaya",
+    "type": "novice"
+  },
+  {
+    "id": "04330a33a784604e0fb6bcb03ea299f76c983cb0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "1cec5ceaa5cb21ee190f19fec6cbeddfbc8f3f8c",
+    "name": "Grandes Combes",
+    "type": "easy"
+  },
+  {
+    "id": "087b8d6f81108e3e17586bcd077957fb616110d0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7a6400963756d4d2d61fe059fcff22a55c006544",
+    "name": "Bouc-Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "e0c74e26b77908683ae7bf8a09cf6fffa31ccb32",
+    "name": "L'Éclipse",
+    "type": "advanced"
+  },
+  {
+    "id": "131c7f70c6404907dbe16756016e5b90a412ce89",
+    "name": "Pralong-Suisses",
+    "type": "easy"
+  },
+  {
+    "id": "9a67fbb9c283f033cb66d7fa3d6bea9078741f9f",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "a6e9011ae72d8409076608851532413238beaa7c",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "5159fffbb397a0a6dd519ca4953962d56e6a8798",
+    "name": "Boulevard Rosaël",
+    "type": "easy"
+  },
+  {
+    "id": "a6c7f1995088b8581255d65e9ccbbe40dfd5787a",
+    "name": "Cime",
+    "type": "intermediate"
+  },
+  {
+    "id": "59cdaf091cf2fffaf8efc056c131e5c989f058f1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "825c7893e68921a8691950793e46763401949b7e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "c5241cc891de9846874637d66a94a7ca676f34d9",
+    "name": "Boulevard du Doron",
+    "type": "novice"
+  },
+  {
+    "id": "58497c18f5e0a4a6b6c126a887f9282288485902",
+    "name": "Boulevard Gury",
+    "type": "easy"
+  },
+  {
+    "id": "85beafd33898a73744dc66b549115e116fc53496",
+    "name": "Planes",
+    "type": "intermediate"
+  },
+  {
+    "id": "69ba6c7cfdd7062152dc9ce6feb75f52e9ae0b17",
+    "name": "Pelozet",
+    "type": "easy"
+  },
+  {
+    "id": "b2ccbac0dde9d7877e5cc39ec616c95923bccdef",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "893570e579ace5f4d4186b7df762bf72a78ffba9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a746075ee26771a30487198ee3f1db538425a09e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "55b8cc50e1c112ae2116c4e496b5cecc1bd04b6d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cb30b561b8d2e57b1f1278338d5df501d684982f",
+    "name": "Boulevard 2 Ours",
+    "type": "intermediate"
+  },
+  {
+    "id": "5a71b9f59202075a75c426d4ef116529def76a1e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c927657dad515fe5094f32ad115658ef2ab74d98",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e31160d54f320b7a35bda94663aee6707f75370e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "22941bc89131e0a620388c95b3339afe1c9cfb13",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0d7f0a7f20cfcf2b67b62fbb6ef76826849bdbc1",
+    "name": "Boulevard Lauzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "8cdaf19ceaa9b962e57cb2aac1d445efab985a94",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b2364bee62b5d19d8723eed5312c8b017b7917dc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4d08eeab7b7d70d39c16bd87cf436284fe90e548",
+    "name": "Easy Way",
+    "type": "easy"
+  },
+  {
+    "id": "3624f2dff44f1b146568236dfcef30ba4c4d7434",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5efbe8b1ac04c6b8da3c1b31b403ac6a52d1cd7f",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "25d97171567aea79a89a591019270d4f9765ff12",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2ab639f83705d5b4d593a9f285d7d6dc3829b334",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b1db3d52125d35c93ed49c130636768b13f4c4ed",
+    "name": "Lanches",
+    "type": "intermediate"
+  },
+  {
+    "id": "619de451896ee5617ad279317d2e8ece5634cd98",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "c3782fce476e2afd97bd4c8edeab24592511ab50",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6bccc6a308c317978fe8f9bb8a341504853f7b95",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "12612393e19299bcf5234d210ea9e6d9453c5540",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d838f5bc2313f5f70a8a2f98db9007b8e3277d35",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f0fa61320b09bd3c26f181a92388db526e013bf3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "749947df7f192e1b5f134abe849276a8642efd29",
+    "name": "Coraïa",
+    "type": "intermediate"
+  },
+  {
+    "id": "42dfdf239de72c8988d6b8ac477f3943eed84485",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "bff38d1eccf7e8574333486185c883ef49f0e775",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "57ee108aedee2f6d4991b96f0c24b62e3c84c33b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4bc445d956a3a7a51642d04927652a3eb6c7688f",
+    "name": "Moriond Racing",
+    "type": ""
+  },
+  {
+    "id": "05daf8f7078ba2adb96f1da9d8b0f70efed17d35",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "dc9622a904f18672b0507a33f693123827b995ac",
+    "name": "La Voie de la boucle",
+    "type": "easy"
+  },
+  {
+    "id": "8614c28684d537ef2260a360a230655e1a28f0b5",
+    "name": "Plein Sud",
+    "type": "easy"
+  },
+  {
+    "id": "7e756fede58f25ffd9f3312a2b231a67dd1bfdec",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "6926e7f19899c15281bbbfec16b02eeea7ab218a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c68102822fb02b9730b2b90f9fe6204f15e36d2b",
+    "name": "Skicross Jean-Fred Chapuis",
+    "type": "intermediate"
+  },
+  {
+    "id": "2f192a92cdb6dc65e6ec4c360fb503548f29cc92",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "114a1639a25cee9b12be2c548ef7776f947971a1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "48795178a7705be296cb0655fbcc82de6a2accbb",
+    "name": "Jockeys",
+    "type": "advanced"
+  },
+  {
+    "id": "e4121a7feb8a26a258811e9d512ac35abe316c0b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6c2f814b3c21ab91285439877e7e4a5a16ec1de8",
+    "name": "Pralong",
+    "type": "novice"
+  },
+  {
+    "id": "c3fc7adc42b2adb46180efbbd7955499f7a14527",
+    "name": "Raffort",
+    "type": "easy"
+  },
+  {
+    "id": "0b5346eed646bbf34dcd36c2af672ab5d57eb716",
+    "name": "Voie de la Boucle",
+    "type": "easy"
+  },
+  {
+    "id": "3dc523838ad2b839afa8b824d23ae4ea684f4098",
+    "name": "Plan-Bouchet",
+    "type": "novice"
+  },
+  {
+    "id": "9c4e2fb5fd4d8623c7ca3e2efaca2c4184cdfb0e",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ed6ac7a10c5b332b3f4aa01953186199abaf6b7e",
+    "name": "Col de l'Audzin",
+    "type": "intermediate"
+  },
+  {
+    "id": "4dab7a3843bb3671274186aaf9ba185c3aabba05",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "974856d57fc2c827578713b01ae6004f930fadfd",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f5f8dbe3fce80604a0019bad9638beb288db3f16",
+    "name": "Provères",
+    "type": "easy"
+  },
+  {
+    "id": "fd4817134298be850629c5e12a5352673ac36282",
+    "name": "Tovets",
+    "type": "easy"
+  },
+  {
+    "id": "d0766735437d4ea5ce60d720935ac94dabed5386",
+    "name": "Lac des Creux",
+    "type": "easy"
+  },
+  {
+    "id": "165973cc538e9b5e9f5d846006e3b1c7c52ac2b4",
+    "name": "Chandon",
+    "type": "intermediate"
+  },
+  {
+    "id": "f3a43853834fe1c6a21fa323022ce179cf544a3d",
+    "name": "Moon Wild",
+    "type": "novice"
+  },
+  {
+    "id": "a84a551e1616ed8e69c54d6117acb4b6dc22d7ca",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "bdc3ae38b2426a9ec61c86ff6fc7bb7e0802937a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b67ad4118e1a4735b510bb9dc8a17df13b7da4e9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "2e49d983f3bff8068b9f27f23d50bf8647886ead",
+    "name": "Easy way",
+    "type": "easy"
+  },
+  {
+    "id": "f0dec33ca00bf0332eb24b4483bdf18a8b3862e3",
+    "name": "Julie",
+    "type": "intermediate"
+  },
+  {
+    "id": "771a098880220647f71ce6a1b67e6c733c26f65d",
+    "name": "Raffort",
+    "type": "easy"
+  },
+  {
+    "id": "d1cf7971acfc3c19af6295b6aa23cc91fe688d0b",
+    "name": "Raffort",
+    "type": "easy"
+  },
+  {
+    "id": "78111f9e286f32c479991031ffd8127952f8dddc",
+    "name": "Raffort",
+    "type": "easy"
+  },
+  {
+    "id": "d72ca2f6a44ac147a474fdfe3035179e9f59f78a",
+    "name": "Villages",
+    "type": "intermediate"
+  },
+  {
+    "id": "9df36e38ace6a340536bfe5fb5f16dbd623e134d",
+    "name": "Tourbière",
+    "type": "novice"
+  },
+  {
+    "id": "6df2949d3f32a2568135f5fb766560f4fda1f3be",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "72b0e52edd2a439f423478547b3dac89e8d21c80",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ab1a54af1d05ee08f9cb591a0d6dfefbfec09455",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5f986a331b36d7404ee207bab29ecd96e598fe05",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5d24149b252ddf67d38137893fdb07bcb7d69e08",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5c5d321e1384ec25cb61934104abe20a315a949d",
+    "name": "Boulevard Cumin",
+    "type": "easy"
+  },
+  {
+    "id": "086aa549d3f37667c5cea19ba9eef99d035e7db5",
+    "name": "Vizelle - Creux",
+    "type": "easy"
+  },
+  {
+    "id": "d7468e54299ac7f76fc7d68816496c335e20a80a",
+    "name": "Variante",
+    "type": "easy"
+  },
+  {
+    "id": "650a6f95ff4fca3123c40cf1ed7cd1c7968fc34a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cf8a7e94558f85eb335e15d76cf9a185f70fc5e5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3c0949ce5ae3c75391ccd8c1b53c7b56b0e67a42",
+    "name": "L'Éclipse",
+    "type": "advanced"
+  },
+  {
+    "id": "5e16ec65e523c869c43f2e32773fe603a64dedc4",
+    "name": "Roc'n'Bob",
+    "type": ""
+  },
+  {
+    "id": "a600d99a0a71a7904484c95782de6c4313301254",
+    "name": "Roc'n'Bob",
+    "type": ""
+  },
+  {
+    "id": "57694ee3db097538ce3876ed11a619ab4243d3fd",
+    "name": "Léo Lacroix",
+    "type": "advanced"
+  },
+  {
+    "id": "ccaed2eafb190949627a6c8162a1f33641a9ff4e",
+    "name": "Face Nord",
+    "type": "easy"
+  },
+  {
+    "id": "e70a3da62145df0511545041228749a6f3d7b265",
+    "name": "Bleuets",
+    "type": "easy"
+  },
+  {
+    "id": "c3e557bf076b8142d346e1b6fdf3e501d80dc011",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ae366306fe5926daab9079fe0d26f2ff3e5ef641",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "c6e8eaeb37024554ff98bceeeb395941a05fc8bc",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0a222638195b4f2ef6c22c7beffe601fc431b484",
+    "name": "Boulevard Rosaël",
+    "type": "easy"
+  },
+  {
+    "id": "728e0a9f5633e896195e24ee99942b02e6bb2417",
+    "name": "Châtelet",
+    "type": "easy"
+  },
+  {
+    "id": "1b6555f916de4d183e959747f69818c8f6ea079b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5e210d13e6f0abf5939c3bda0242fdc64595d514",
+    "name": "Boardercross",
+    "type": "easy"
+  },
+  {
+    "id": "ada1f5d252463bf6a583eab932de92c7088c5a72",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "04432021c329e561f11c46f9dcc3481f6f80ae45",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f08bbdd09404c81464768e2667cf0b222326ed71",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8ca542903c521ef59e56337517646653dbcbd7ed",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5aebfe48c31ec50f706db08f7299a1022e0ebb3d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8e26b135820a6ee281c046a70f233e8a1af5ff67",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7befb73d376f97930de262bafeeb3e7c0fa7993e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6894238a00ef1a43253dfd3fda97bbb4eac21a76",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "79923924bdc99adcdd82e461f6e6439782ddba0b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d5b84d31e7cf3f3b02c53a884692da7cffc48106",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "873e5ee310b1364052ac7eb43432a343cac3026e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "eb824faa349fe3597116c4ae54b6cdecd0198547",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a63d789d34ea88b39be539fc58525162ba25edc5",
+    "name": "Moriond Racing",
+    "type": ""
+  },
+  {
+    "id": "93be22781d4fb175e264e4c7523a87403c948d8c",
+    "name": "Moriond Racing",
+    "type": ""
+  },
+  {
+    "id": "52aece38527d1672127d8e0452e4e36d109ec838",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8c904113d19ed29a29ac20732d2e47e8126bd057",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b9558b83c51e252e026907f98621052583550dd2",
+    "name": "Petit Lac",
+    "type": "easy"
+  },
+  {
+    "id": "dcf3509aa7580947092f03434da280a2ed2af0be",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0a408b0216d5405e1a27526ff139abac4a2f7d62",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9440a3bd60c7f6b2929a88e103d6e3fd616493d4",
+    "name": "Mousserons",
+    "type": "easy"
+  },
+  {
+    "id": "7067b848bfcce30ed92c82c29353e55d74abd4cc",
+    "name": "Bleue",
+    "type": "easy"
+  },
+  {
+    "id": "cf29ceb800e8cf6277b25b7b32c904ab46e02a2d",
+    "name": "Pralinette",
+    "type": "easy"
+  },
+  {
+    "id": "4d2db62ecb93fe8abf734a36bd6ae32e747b6397",
+    "name": "Lou",
+    "type": "easy"
+  }
+]

--- a/lumiplan-maps/data/orcieres-lifts.json
+++ b/lumiplan-maps/data/orcieres-lifts.json
@@ -1,0 +1,132 @@
+[
+  {
+    "id": "aeee81e3ca1bb482ac73c425f9406707a27052fd",
+    "name": "Croze des Hommes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "982aeb2b5d61c6ca647ddd92974c0fe5972f67bb",
+    "name": "Drouvet 1",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "65c545cc3acfa5946e41dfea10a8fe622360733c",
+    "name": "Drouvet 2",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "ec9bfc4a7781197362bc832b3131fe70b136ac8b",
+    "name": "Botte Croze",
+    "type": "drag_lift"
+  },
+  {
+    "id": "8151af9c49cf0248ce2160707982c04ce6d6dd17",
+    "name": "Manrouse",
+    "type": "drag_lift"
+  },
+  {
+    "id": "c8a1bcfe2f20cdf6ca100ec9c38229a3abe7d839",
+    "name": "Meollion 1",
+    "type": "drag_lift"
+  },
+  {
+    "id": "f2b82ea6061fb68806d0911d008775d1bb96b401",
+    "name": "Meollion 2",
+    "type": "drag_lift"
+  },
+  {
+    "id": "1a2f8e919b71b3d0726befc9b63308adef91c98d",
+    "name": "Gnourou",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9bd04871da841c7b82027afbc7df91261176e2cb",
+    "name": "Telemix de Rocherousse",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "ddcdcff1b041af71774bb11583f610b3c857d084",
+    "name": "Rocher",
+    "type": "drag_lift"
+  },
+  {
+    "id": "20ed60d6e0a194b5836e1560d59ef1e4a2e3c68e",
+    "name": "Torrent",
+    "type": "drag_lift"
+  },
+  {
+    "id": "4bd5c4feb5a572543b025fc04efdd8f8c086ef9a",
+    "name": "Snowpark",
+    "type": "drag_lift"
+  },
+  {
+    "id": "e2117d1770a83de1bba573b6f8088a230cb989d8",
+    "name": "Lutins",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "d10797b5b74ad355ec5470bb99b65f4083bc53a9",
+    "name": "Trait d'Union",
+    "type": "drag_lift"
+  },
+  {
+    "id": "846bad6f1c5d674244e09ed429e9a270a8507aef",
+    "name": "Soleil",
+    "type": "chair_lift"
+  },
+  {
+    "id": "afe1c53856a5f7f3860ac5b14f15cb0bf0efd84a",
+    "name": "Charpenet",
+    "type": "drag_lift"
+  },
+  {
+    "id": "3357502ef6b2950e46df9ffecd7ac3490fb65ef8",
+    "name": "Fontainon",
+    "type": "rope_tow"
+  },
+  {
+    "id": "a52ab26a42c8a2bdc7c875b4f3fe5f11d2383737",
+    "name": "Estaris",
+    "type": "chair_lift"
+  },
+  {
+    "id": "ed70f819b1b2e433c6fc9784f02e1c67444ca5cb",
+    "name": "Schusseis 1",
+    "type": "drag_lift"
+  },
+  {
+    "id": "121627a78515f457a911b3f8c9419ca6625bcd48",
+    "name": "Schusseis 2",
+    "type": "drag_lift"
+  },
+  {
+    "id": "4df8b380f1f8701d2e89ff2a6b265e6d32619dfc",
+    "name": "ESF",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "a4c9541307ab7f3ace183024eee27893a81d3f11",
+    "name": "Clot",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "f68ae6f203fb3b420f8bc1fdc269c7a4bd6561da",
+    "name": "jardin des neiges",
+    "type": "drag_lift"
+  },
+  {
+    "id": "2337b14f8bd3ed8ecf662e860d52326046d569d0",
+    "name": "Muande",
+    "type": "chair_lift"
+  },
+  {
+    "id": "425413f9a4a4c07b6346b8e0b45ebb4950daba4f",
+    "name": "Les Marches",
+    "type": "drag_lift"
+  },
+  {
+    "id": "30ae4dcd4d328ff7779479b29ad9bc5079893b8e",
+    "name": "Tapis de l'Étoile",
+    "type": "magic_carpet"
+  }
+]

--- a/lumiplan-maps/data/orcieres-runs.json
+++ b/lumiplan-maps/data/orcieres-runs.json
@@ -1,0 +1,342 @@
+[
+  {
+    "id": "89be4142e12ee2f0392e56e0af2e873dd7a28d3c",
+    "name": "Montagnou",
+    "type": "easy"
+  },
+  {
+    "id": "0c575a61f565b2750c9ac02d4b27810826a7222a",
+    "name": "Les Pépés",
+    "type": "easy"
+  },
+  {
+    "id": "9d092e33cafd0d5bd7e07249e52e29909473692a",
+    "name": "Sirènes",
+    "type": "easy"
+  },
+  {
+    "id": "dc17259c73d347024cf32b59ff205ad342296085",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1735a3e76630ddb71e8af9272d876342423817ac",
+    "name": "Les Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "83bee466db2c814c788bff4ac599444f3f36eda9",
+    "name": "Chardonnets",
+    "type": "easy"
+  },
+  {
+    "id": "59d860f245e205074618c63f774da3484b9e0784",
+    "name": "Le Méollion",
+    "type": "intermediate"
+  },
+  {
+    "id": "648330c2198177fd8d05a3d901ef3ed1eafee4c4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "df1c32a53b7b1e081f892337c3473ef5de0262b5",
+    "name": "Les Crêtes",
+    "type": "intermediate"
+  },
+  {
+    "id": "b5ade673bb42986933309b737d6815c61e2d88b4",
+    "name": "Le Goulet",
+    "type": "easy"
+  },
+  {
+    "id": "fccc2dbf3f8f8b1b09638d3bf19464af443c1581",
+    "name": "Les Bouquetins",
+    "type": "easy"
+  },
+  {
+    "id": "3dd15f531d5654789009f46f0ebeb303465b2d30",
+    "name": "Les Clots",
+    "type": "intermediate"
+  },
+  {
+    "id": "700e00d96b674793225352fe7c3baf9070485abc",
+    "name": "Mézelle",
+    "type": "easy"
+  },
+  {
+    "id": "6ac314038918058bb35afb91fd1d973fb5299b89",
+    "name": "Sirac",
+    "type": "advanced"
+  },
+  {
+    "id": "444e850fcaf88db62f713b772e910b09e09a01f5",
+    "name": "Les Portettes",
+    "type": "advanced"
+  },
+  {
+    "id": "34c58a6c782bcf34689acd51a6ef10c7fceacf28",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "952617e37f895e66d27b42b88b3817a7a39e59e9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "029234b77c55c59b3f6dc66311b566df6f72f8d3",
+    "name": "Les Provençaux",
+    "type": "intermediate"
+  },
+  {
+    "id": "7899dc7a521a52ba901ae81a798e71aa8879df8b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "42151d13c5b97dd81069e3a16a7261eb14a66f41",
+    "name": "Les Gendarmes",
+    "type": "intermediate"
+  },
+  {
+    "id": "b8655818b9c4d9415db8feff927f2e15c938906f",
+    "name": "Rocher blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "b38f64e36fb6e147be4081468f886f32d24efa4c",
+    "name": "Camille Ricou",
+    "type": "intermediate"
+  },
+  {
+    "id": "677b3beddeabf881546e4234aeb68549461edb18",
+    "name": "Les Lauzières",
+    "type": "intermediate"
+  },
+  {
+    "id": "dd169750102e74e91036d79b130f03c05d6b46d7",
+    "name": "Botte Croze",
+    "type": "easy"
+  },
+  {
+    "id": "8fcb2259c39574691ce86423720579cab667f099",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "158ebf808e48a679e3be33319eeafe12acb07623",
+    "name": "Les Provençaux",
+    "type": "intermediate"
+  },
+  {
+    "id": "73be11c65b3db3157f18c09c1bb6aec140cdb613",
+    "name": "Manrouse",
+    "type": "intermediate"
+  },
+  {
+    "id": "88302268d8fef61165ea945eee0e99198de2030a",
+    "name": "Bêche",
+    "type": "advanced"
+  },
+  {
+    "id": "9ed3668bb9b00ea4c41989f66dfc604f31eb0dc6",
+    "name": "Les Hommes",
+    "type": "advanced"
+  },
+  {
+    "id": "a8563046ee765b0a86016b92c9468d9695b01783",
+    "name": "Les Vallons Jartoux",
+    "type": "intermediate"
+  },
+  {
+    "id": "efcb99d7e7be4c95bce9600a479c9e302a093b7b",
+    "name": "Chardonnets",
+    "type": "easy"
+  },
+  {
+    "id": "0a47cf9d52f38fa44cfecff0d02d57df97e1bf8d",
+    "name": "Freissinières",
+    "type": "easy"
+  },
+  {
+    "id": "1197b4ca51a5a06d7f3c30221f6855123cd15159",
+    "name": "Les Jalabres",
+    "type": "intermediate"
+  },
+  {
+    "id": "573043411c550d2386c06bc470f364533830ed4b",
+    "name": "Piste du Gnourou",
+    "type": "easy"
+  },
+  {
+    "id": "c8873219603207eca5b486b2ad9a02c933b6e7c3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "c3189281402c3d73acfca4cf8a6ff601626d8e87",
+    "name": "Piste de La Marmotte (Milka)",
+    "type": "novice"
+  },
+  {
+    "id": "2b6e1f7e1f0f79edb62e58c39551f1a3ee2794ba",
+    "name": "La Marmotte",
+    "type": "novice"
+  },
+  {
+    "id": "b1f66d4def9f27a07763cbe9effdba6baaff1994",
+    "name": "Lutins",
+    "type": "novice"
+  },
+  {
+    "id": "1d6fa4286da0bce855f52e28d51d3f329c888dff",
+    "name": "Rocher",
+    "type": "novice"
+  },
+  {
+    "id": "c8514e24954892b1d6a0ddfa6d80c74f89387ea4",
+    "name": "Torrent",
+    "type": "novice"
+  },
+  {
+    "id": "73ed43a03eae793830d49ba30a1258cb86bff5d0",
+    "name": "Charpenet",
+    "type": "easy"
+  },
+  {
+    "id": "317883e4340c5d607ac73518bc2e062400e8fd46",
+    "name": "Le Gourou",
+    "type": "intermediate"
+  },
+  {
+    "id": "d6c2458142fb2f6838e11955b4be7e6ee2377711",
+    "name": "Le Gourou",
+    "type": "intermediate"
+  },
+  {
+    "id": "39a4f7c511f9ba21113d0e4e583bfd1e3352cb16",
+    "name": "Le Gourou",
+    "type": "intermediate"
+  },
+  {
+    "id": "99026057614c3f6590c81ab809fa324d7a8f55a9",
+    "name": "Favue",
+    "type": "intermediate"
+  },
+  {
+    "id": "6af94533dc3f1a6b12e13a47a09164eb9c606864",
+    "name": "Rocher blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "ea519d010162a39fb58908b40101be3638d995e4",
+    "name": "Le Gourou",
+    "type": "intermediate"
+  },
+  {
+    "id": "95f5c98e29231173cf6afa4f0c7644aea63c94ef",
+    "name": "Sirènes",
+    "type": "easy"
+  },
+  {
+    "id": "4d8c9e3737e98563bf5b93c4fd4d1dacc5d78b14",
+    "name": "Py-Marty",
+    "type": "easy"
+  },
+  {
+    "id": "aa26bc48b865cdb44e40bc08fe80bbd0a0718de3",
+    "name": "Les Marches",
+    "type": "intermediate"
+  },
+  {
+    "id": "2760dbd303a5509cebf6728be62af493d8dfe8e9",
+    "name": "Montagnou",
+    "type": "easy"
+  },
+  {
+    "id": "bdbe93a9e72debc12f5832e9bcac9a03947eb2da",
+    "name": "Les Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "f784f616e9a16d7e95411e4911297890b586890b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2a9a486cc25b2d4687144c108ffd714c5fa14fe6",
+    "name": "Le Méollion",
+    "type": "intermediate"
+  },
+  {
+    "id": "5280eb35ec239e5fad075e1ac36c355afda1e24e",
+    "name": "Rochasson",
+    "type": "intermediate"
+  },
+  {
+    "id": "ffa52028861fe135b00648700fa947b43c1c764d",
+    "name": "Le Gourou",
+    "type": "intermediate"
+  },
+  {
+    "id": "b4fe5d6f7a827a15b23836041e02c2f4a6d83c1e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dd6e7c122f51c8caf5e349b20e933afac33b1fc2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ea2d9b5facbee972548506ab317136e152c49aed",
+    "name": "Baniols",
+    "type": "easy"
+  },
+  {
+    "id": "d3d2204212348d777626b3a2bf1fc920bb5644b2",
+    "name": "Mézelle",
+    "type": "easy"
+  },
+  {
+    "id": "affd1c8e7fff1a2813946a1001086830c0840644",
+    "name": "Botte Croze",
+    "type": "easy"
+  },
+  {
+    "id": "f4796788a351bbbce363abdf6c2272fe2af4fe05",
+    "name": "Les Pépés",
+    "type": "easy"
+  },
+  {
+    "id": "51288077f4e3dc3d402d48430f5f4dbe1c44874c",
+    "name": "Manrouse",
+    "type": "intermediate"
+  },
+  {
+    "id": "c4c938e1b0706b3fea3ae82f05ad0fc185493713",
+    "name": "Chamois",
+    "type": "advanced"
+  },
+  {
+    "id": "da5634b0511a8cbdaebe179a9c6fc1ca780a8fae",
+    "name": "Bartavelle",
+    "type": "intermediate"
+  },
+  {
+    "id": "d06578a32285831f8721eeeabc33251722acbd77",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d3b4782eda97f05fe5a9284d72aed97f20fe222a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a2d13d433a0e0c10a7e3d54cd7384b5c9072313f",
+    "name": "Les Hommes",
+    "type": "intermediate"
+  }
+]

--- a/lumiplan-maps/data/paradiski-lifts.json
+++ b/lumiplan-maps/data/paradiski-lifts.json
@@ -1,0 +1,817 @@
+[
+  {
+    "id": "1e987dfa8498b170066b41da92dd7e0ca6c6b2e7",
+    "name": "Col de Forcle",
+    "type": "platter"
+  },
+  {
+    "id": "dfc38512d15484ab72bff4b9c1c08de8a41bfb51",
+    "name": "Funiplagne Grande Rochette",
+    "type": "gondola"
+  },
+  {
+    "id": "7120da0ea31f0327c9cea0dc2337727711882b7a",
+    "name": "Adrets",
+    "type": "chair_lift"
+  },
+  {
+    "id": "071dcefc883e46a5fe2a33268d0a5e3e979698ef",
+    "name": "Les Blanchets",
+    "type": "chair_lift"
+  },
+  {
+    "id": "dd3f9f4791af329854eddb14abe93fa1cc87f902",
+    "name": "Inversens",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a7701bfef5c9c571519f5ad6dcfd16f60e5b4b91",
+    "name": "La Roche",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8752b3682a621babb93e3201d8dce0ecf5e84c22",
+    "name": "Golf",
+    "type": "chair_lift"
+  },
+  {
+    "id": "e59e6813297a0d557352e65918643be573949a26",
+    "name": "Stade",
+    "type": "platter"
+  },
+  {
+    "id": "22d7c41cf3148125636c18c712c6793d6f9dd589",
+    "name": "Montalbert",
+    "type": "drag_lift"
+  },
+  {
+    "id": "2c74f0961a08972389438e80ee925a02213f7118",
+    "name": "Chalet de Bellecôte",
+    "type": "chair_lift"
+  },
+  {
+    "id": "e3d78f695538a679fe644358743965b1d7151db3",
+    "name": "Droset",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2cf0ae941d7d9fad4aa0bda205a6289ac2a5700a",
+    "name": "Marmottes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "345e535b98f7cd8b6ecb74d9dcea23b4665a5fd5",
+    "name": "Saint-Jacques",
+    "type": "chair_lift"
+  },
+  {
+    "id": "34436dd93a9429c4998e61a6aec4b08de9058d55",
+    "name": "Varet",
+    "type": "gondola"
+  },
+  {
+    "id": "2604ea02fdafbd79c0ff3a46019dd379d3a7d315",
+    "name": "Vagère",
+    "type": "chair_lift"
+  },
+  {
+    "id": "48a40bdb478d8c7f1593b7d4626113011ad4915a",
+    "name": "Derby",
+    "type": "chair_lift"
+  },
+  {
+    "id": "bd27990b769c99511d0efa0ef00d4ef78d0cb4c4",
+    "name": "Vallandry",
+    "type": "gondola"
+  },
+  {
+    "id": "0818b0e1826a3caa9145b5f56682d23189784d91",
+    "name": "Peisey",
+    "type": "chair_lift"
+  },
+  {
+    "id": "d3f066a7403457d41bb0736bdc1135289c171680",
+    "name": "Grand Col",
+    "type": "chair_lift"
+  },
+  {
+    "id": "69972871a1925a4bcfec5bd53e2ee28e47e28f7e",
+    "name": "Aiguille Rouge",
+    "type": "cable_car"
+  },
+  {
+    "id": "d3f848821b4b73ea58dea43c5a9ef4dfc63a3a1d",
+    "name": "Bois de l'Ours",
+    "type": "chair_lift"
+  },
+  {
+    "id": "ea1274f6ac4e3cfcc4c950896477f994b79e2308",
+    "name": "Arcabulle",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a9e7973d1baafb93a14c5e951a15dd621e9cff11",
+    "name": "Funiculaire Les Arcs' Express",
+    "type": "funicular"
+  },
+  {
+    "id": "35971105ba31b4d4c6d0d7d283bb3a6a0f9e3548",
+    "name": "Mont-Blanc",
+    "type": "chair_lift"
+  },
+  {
+    "id": "cc3385c2936a995747c74eba8ce7c72f634ce4e4",
+    "name": "Cachette",
+    "type": "chair_lift"
+  },
+  {
+    "id": "49cb81577d70667ea804372fa914efc33cd77d2e",
+    "name": "Dos Rond",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9478ddada2ef2af7bda3b441d64e73bf43dcdf9e",
+    "name": "Salla",
+    "type": "chair_lift"
+  },
+  {
+    "id": "e63d7d7838899583e5af9606af3923f388f6e093",
+    "name": "1800",
+    "type": "chair_lift"
+  },
+  {
+    "id": "613a10fb67ea42c968ba8126d90009bd4b71cfc0",
+    "name": "Crêtes",
+    "type": "drag_lift"
+  },
+  {
+    "id": "a6bef45b72923ffcb9decef507daebcf0ca5bea6",
+    "name": "Grenouilles",
+    "type": "drag_lift"
+  },
+  {
+    "id": "9d88855cb10ee87231d3d0148a981414c0e1ee71",
+    "name": "Replat",
+    "type": "rope_tow"
+  },
+  {
+    "id": "01cc5d65fbeef3d00fe17c57f4c52dd35b45b8c5",
+    "name": "Aollets",
+    "type": "platter"
+  },
+  {
+    "id": "665eafa22229c442bfbb9e437bc4a2993b4f0d42",
+    "name": "Chevrette",
+    "type": "drag_lift"
+  },
+  {
+    "id": "dd1a15158d6fd4c2a3f49c67d253b59866cfa218",
+    "name": "Verdons Sud",
+    "type": "chair_lift"
+  },
+  {
+    "id": "d54722dbdd5fd73fa94151ef9ef7c269c98dfb86",
+    "name": "Grizzly",
+    "type": "chair_lift"
+  },
+  {
+    "id": "54256956f20786cafa4ab1133702cd78bc44d02a",
+    "name": "Montchavin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "cf542b93bb29cd7945afb2be47ff0eca9e23a7d0",
+    "name": "Pierres Blanches",
+    "type": "chair_lift"
+  },
+  {
+    "id": "6a3c2865c80f4fb6304a6ad31125b35428d25fdf",
+    "name": "Plan Bois",
+    "type": "chair_lift"
+  },
+  {
+    "id": "70ccebf1236867a70ca9d1dcf5e5208603e66e47",
+    "name": "Les Coches",
+    "type": "gondola"
+  },
+  {
+    "id": "231d060a12ad9d7417a741a7d153c13a134b19c6",
+    "name": "Patinoire",
+    "type": "rope_tow"
+  },
+  {
+    "id": "831d4ca1d3e05a204bbd5fa477c3bfca8d310ccb",
+    "name": "Vanoise Express 1",
+    "type": "cable_car"
+  },
+  {
+    "id": "a5d3240a696741294f85c46bcc6243410de66e71",
+    "name": "2300",
+    "type": "chair_lift"
+  },
+  {
+    "id": "f73a6a906d0c6af3a50c8183f3125a4b3311cd10",
+    "name": "Petit Sauget",
+    "type": "platter"
+  },
+  {
+    "id": "dee686ac93c3798ebf3b692f550241ac504f554a",
+    "name": "Plagnettes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "bd2be119ebcfbea71f3af95977948f8e80c54086",
+    "name": "Arpette",
+    "type": "chair_lift"
+  },
+  {
+    "id": "87906369f5a60606d3203fead3ff7fe0bf7f8663",
+    "name": "Comborcière",
+    "type": "chair_lift"
+  },
+  {
+    "id": "bf7ee116217a43fee52d3a4e2705b91d7abed2a4",
+    "name": "Lanchettes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "706bdfafa3ed14a3c7f5d587322e0142e3f93ea8",
+    "name": "Cabriolet",
+    "type": "cable_car"
+  },
+  {
+    "id": "264028d286a92f1140996c23daf0c554f36c1a2c",
+    "name": "Cabri",
+    "type": "platter"
+  },
+  {
+    "id": "0fe7b82915cb9a590a78d80d3d45f1da5bcf6c74",
+    "name": "Snow Park",
+    "type": "t-bar"
+  },
+  {
+    "id": "ab72b98b1b45ab96d8a336546e81d3d074de92ff",
+    "name": "Clocheret",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3c8bb3f2af20caa71e353dc5ed5f66b8b4e27b01",
+    "name": "La Bergerie",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9ef5273a35c84495924e31769f0f76559889c9d1",
+    "name": "Mélèzes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "eada71f4e83050f46239d71e0b57957a33e9fe9f",
+    "name": "Plateau de Carella",
+    "type": "rope_tow"
+  },
+  {
+    "id": "8d7b41f93f9dbf50568130342463efeb3736d4dd",
+    "name": "Solu",
+    "type": "rope_tow"
+  },
+  {
+    "id": "ba9515debe0ce78ff78186970536641a591f0df5",
+    "name": "Boulevard",
+    "type": "chair_lift"
+  },
+  {
+    "id": "a1862071ea5de445efd57a69e4cd58c2733eb3b3",
+    "name": "Premiers Virages",
+    "type": "platter"
+  },
+  {
+    "id": "ae079978924c0748265c26665e2b9ccbabd93021",
+    "name": "Télémétro",
+    "type": "cable_car"
+  },
+  {
+    "id": "8d634dcecdefc2811ab17e19d59a14c9d8328c81",
+    "name": "TKE - Gentil",
+    "type": "drag_lift"
+  },
+  {
+    "id": "62711ea49441dc04c5f16ed4617770e17a23e60f",
+    "name": "Borseliers 3",
+    "type": "drag_lift"
+  },
+  {
+    "id": "069845759b0731dfd13c26e0b0d7118e29e44231",
+    "name": "TK Éterlou",
+    "type": "drag_lift"
+  },
+  {
+    "id": "6162a4a885fb9949e107114e735f39e33fd9dc86",
+    "name": "Télébus",
+    "type": "gondola"
+  },
+  {
+    "id": "c0a105a0de11e8369d41b9dbeefb55d29ccb0efc",
+    "name": "Rhodos",
+    "type": "drag_lift"
+  },
+  {
+    "id": "f35114b95b7be69dfeac44d7a5621b92d5a346c8",
+    "name": "Eldorador",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "3a928de1ace0b2457b6f09f7518baf834c941b75",
+    "name": "Éterlou",
+    "type": "rope_tow"
+  },
+  {
+    "id": "339c8ded6c1d8b375e90702a1efa6f98ff0be5b8",
+    "name": "Funiculaire 1",
+    "type": "funicular"
+  },
+  {
+    "id": "b874bb8e85a5cef1c6950beb31388fb03a9c21d6",
+    "name": "Parchey",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8d8695b41b04eb86a0e2cbbda9e126a9a64b726e",
+    "name": "Praconduit",
+    "type": "drag_lift"
+  },
+  {
+    "id": "940696c7abf0425ff25898abc3bcac0478c5bd4d",
+    "name": "Lonzagne",
+    "type": "gondola"
+  },
+  {
+    "id": "f7921eb8631729a444cbd27985eccd7408b2c38c",
+    "name": "Sucette de Montchavin",
+    "type": "rope_tow"
+  },
+  {
+    "id": "f0a3760e297602763380f8cd71f7bffad2c4bf3d",
+    "name": "Tyrolien",
+    "type": "drag_lift"
+  },
+  {
+    "id": "8eeaeeb9b9f625d9b3a26c2bee37f8d85f689faf",
+    "name": "Bauches",
+    "type": "chair_lift"
+  },
+  {
+    "id": "baf2e7e4079ebde944ebdc06586c08d843f645ac",
+    "name": "Biquet",
+    "type": "platter"
+  },
+  {
+    "id": "cd7e1b8fce551671b60d8a0f963cbef2623d96df",
+    "name": "Combettes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "4af3139db593d9b2bb2e86223598cb1ec1fa39cd",
+    "name": "Tommelet",
+    "type": "drag_lift"
+  },
+  {
+    "id": "6209770afe67c9aebed25d3dc291fdc3f2551a63",
+    "name": "Rhonaz",
+    "type": "platter"
+  },
+  {
+    "id": "0b78c525f3035ca5bda3f13e952701d6e75a1fa7",
+    "name": "Vezaille",
+    "type": "drag_lift"
+  },
+  {
+    "id": "118789b19c97eebac7e7b8a0e8598299a26a2b5b",
+    "name": "Millerette",
+    "type": "drag_lift"
+  },
+  {
+    "id": "6f8e97c5641e9edd86944b1683792ff6307b80fe",
+    "name": "Flamme Olympique",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "4c8fa686a871486156bc4397a9932562ccf6155e",
+    "name": "Raffort",
+    "type": "platter"
+  },
+  {
+    "id": "3f59f6373e8c8956d42bacfef36e9e2328316c04",
+    "name": "Aiglon",
+    "type": "drag_lift"
+  },
+  {
+    "id": "8a8928ed9b44c59d61817149d33476d97cedabac",
+    "name": "Ourson",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "fddcfbc94e07663ad0d8e267c45179411d4d774c",
+    "name": "Plan Leschaux",
+    "type": "platter"
+  },
+  {
+    "id": "1a18dc1b20f3c6a473c5d0d9001e00aa0abcf87f",
+    "name": "Écureuils",
+    "type": "platter"
+  },
+  {
+    "id": "bc9e1098c72004dfe7adab461a7f33f14add4ebb",
+    "name": "Quillis",
+    "type": "chair_lift"
+  },
+  {
+    "id": "18ee6c1765a04e05e42826f3361c5f095271a647",
+    "name": "Jardin Alpin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "6908cae27771140a8d7503bf0093205876b7f16e",
+    "name": "Charmettoger",
+    "type": "chair_lift"
+  },
+  {
+    "id": "058513fb776e1d268159cf06f97a35b27675af65",
+    "name": "Manège Club Med",
+    "type": "platter"
+  },
+  {
+    "id": "83df946e7be037eb0b490bd0f676d7d9a24796bd",
+    "name": "Dromadaire",
+    "type": "platter"
+  },
+  {
+    "id": "db16ee663fe00a2c598701300c7a1c37fad6531e",
+    "name": "Le France",
+    "type": "platter"
+  },
+  {
+    "id": "ab93d94b186fe06965e869c36e5849977bedf158",
+    "name": "Jardin d'Enfants Plagne Villages",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "72bfcabae53bbe84714a0cf2df833a0e1b5d3769",
+    "name": "Oxygène",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "ddda58466cb21edef8da1fd11282ce9a0551d817",
+    "name": "Tétras",
+    "type": "rope_tow"
+  },
+  {
+    "id": "7ebbd2ddf85b41f43aae65782bc100d9a2ea73bf",
+    "name": "1ers virages 1800",
+    "type": "rope_tow"
+  },
+  {
+    "id": "13030847a8497a4d210b68fa74ec964390038118",
+    "name": "Dou du Praz",
+    "type": "platter"
+  },
+  {
+    "id": "3ed550a1d8a471887862881611f189095c9b867b",
+    "name": "Villards",
+    "type": "gondola"
+  },
+  {
+    "id": "ce3844826b138a1809b23295534aa86070600e21",
+    "name": "Montalbert",
+    "type": "gondola"
+  },
+  {
+    "id": "a809f634ad9e22f1f87e04fc6e0b50f478e78ae1",
+    "name": "Dahu",
+    "type": "cable_car"
+  },
+  {
+    "id": "19ade90b2bb9390070b52a649aeb5fa812450bd6",
+    "name": "Carreley",
+    "type": "chair_lift"
+  },
+  {
+    "id": "eb214c2f16de75746241849d0e9d7ffeda795baf",
+    "name": "Plan Vert",
+    "type": "rope_tow"
+  },
+  {
+    "id": "354ee76be19807c6633b9298de4e3caff733c32d",
+    "name": "Grangette",
+    "type": "platter"
+  },
+  {
+    "id": "b823f406101f91d116695435bee76ab8b037064b",
+    "name": "Aime-la-Plagne",
+    "type": "platter"
+  },
+  {
+    "id": "7c08cf358a3ec49b19fbacbb8083e9777575e36c",
+    "name": "Envers",
+    "type": "chair_lift"
+  },
+  {
+    "id": "bb94f2231c9087288aec0c162257e84336cb986f",
+    "name": "Blanchot",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "125c6bb7146541de2dfaa6ba17afdaed7f5fe168",
+    "name": "Pré-Saint-Esprit",
+    "type": "chair_lift"
+  },
+  {
+    "id": "def0a5a792423f29db7b3d131a2a83a5eb67869c",
+    "name": "Lac des Combes",
+    "type": "platter"
+  },
+  {
+    "id": "d09799613ad2b490d5884ef7dc729c494849854b",
+    "name": "Patinoire",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "e7741f884bac0089de8288c5bf70e32b2b076bc1",
+    "name": "Lac Noir",
+    "type": "gondola"
+  },
+  {
+    "id": "cb5f1f1383f14251feaa31597de66aa6de32abd3",
+    "name": "Télébuffette",
+    "type": "gondola"
+  },
+  {
+    "id": "fe7c627f26569770504d24bdfaca1d49687dc9d3",
+    "name": "Vallandry",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "5463b099472bbff3226286252b3eccdd852abf32",
+    "name": "École",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "1d749d109bf26d7f2aff8e1db7fb7f0acb239c25",
+    "name": "Ange 2",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "70af662c4f0d83aaf8604abea4c4d659ad2871ea",
+    "name": "Vanoise Express 2",
+    "type": "cable_car"
+  },
+  {
+    "id": "9625135bc60128ac66c6c891d62312fd1a9f8700",
+    "name": "Bécoin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8c7bed527cea2f1b537ad093b415fff9702a0774",
+    "name": "Colorado",
+    "type": "chair_lift"
+  },
+  {
+    "id": "77d3b57b5d570794b50b52ff51bdf742149a814e",
+    "name": "Belle Plagne",
+    "type": "gondola"
+  },
+  {
+    "id": "73ac6979ababef66b56b7cd4617c4568d2bbff49",
+    "name": "Colosses",
+    "type": "chair_lift"
+  },
+  {
+    "id": "1be0ab8b9d0cc6c450109d8fb50e324608a4302b",
+    "name": "Arpette",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c38c317a156484148a00f103f5ca5ecc01f4a333",
+    "name": "Carella",
+    "type": "chair_lift"
+  },
+  {
+    "id": "513a692c9d6d3b26b130330e4b895015df47ce97",
+    "name": "Rossa",
+    "type": "chair_lift"
+  },
+  {
+    "id": "64c5d8f323f79c79fe6a7b81a7bb082daaa606ec",
+    "name": "Borseliers",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b4f0ea0ac6b36c1bf8a956ff4fbe1d51929a1b6c",
+    "name": "Champagny",
+    "type": "gondola"
+  },
+  {
+    "id": "3ff4b948b72409ff312d3662aced4e6bfeaccf01",
+    "name": "Crozats",
+    "type": "chair_lift"
+  },
+  {
+    "id": "8318db91aad3fb8fdb0b8fa549adbd5659f1ca76",
+    "name": "Bijolin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "fe5cb6519957aa522ea8f44278fae5a2de39186d",
+    "name": "Lovatière",
+    "type": "chair_lift"
+  },
+  {
+    "id": "15e8fe7a46eea5c2301c5b0cd90bb62f794d10d9",
+    "name": "Ourson",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "34d03deead2012c9d95814f7d07ff66c348c06d8",
+    "name": "Mélèzes",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "c670d0a9cae5dfe7e1212a5ae3e88ac77c1ee9ad",
+    "name": "Sifflote",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "9b80280be1910eaf3753439d99454b479b67b45f",
+    "name": "Mini Club",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "8888bbc5eb5f9c2b26e4ca864d7ccdd65679297e",
+    "name": "Pente École",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "7bd988fc0256141103a017bc466d3679886bb5db",
+    "name": "1ere glisse 1800",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "0109d858d552faf26c22f679e8e4a93d1e610861",
+    "name": "Jackson",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "89525ed8ffc8e425662673238a426108e4f0f4bc",
+    "name": "Bougnette",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "0b712eb5c6d1646b1aac40dc8bdaf5c519dff0e6",
+    "name": "Ange",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "7db917acf0a1fc964059d89b384724c6854ac47b",
+    "name": "Funiculaire 1",
+    "type": "funicular"
+  },
+  {
+    "id": "5fd1825a3bd2ddb7d5563b23931f388e8cb369ed",
+    "name": "Oursons Plagne Montalbert",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "7c2932550db84aeed27aac5125f7cd2d42bd60d7",
+    "name": "Piou Piou",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "3552bc1addb6795eb2f7d70601dac39b221ef6aa",
+    "name": "Cap Vacances",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "1dc2798563fe9db6b8a1d8fc6077a20c20d15e75",
+    "name": "Petits Loups",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "091186b6b992bb0f95a978806810146fcd5fd007",
+    "name": "Planchamps",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "445a7b33c426b7344401a4a82537074d5d271d7a",
+    "name": "Club Med",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "ec3749a48b195a72e1a2ab990b055e8e2943067b",
+    "name": "",
+    "type": "rope_tow"
+  },
+  {
+    "id": "c202f2d74f359997b54af092fabb8112b01cab76",
+    "name": "",
+    "type": "rope_tow"
+  },
+  {
+    "id": "bd30dd6a37a2c53550875bfdf7f5b3921b8bbf66",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "5054d58034b82dc2cc5766766fc05fb3669e4c0d",
+    "name": "Premières Glisses",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "c16e119fae16704b1edbf5a8017cd02e5375ff55",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "2eb3fae420193e2a8d83e84cb719b65112144390",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "f54fb9db6070141b07be204b458a2c2e81c68a04",
+    "name": "Glaciers 1",
+    "type": "gondola"
+  },
+  {
+    "id": "7d5710f34c10b08681afcf775585140865b6c31b",
+    "name": "Glaciers 2",
+    "type": "gondola"
+  },
+  {
+    "id": "560c90c6e4eadf04ed49670f53a6889a209f093a",
+    "name": "",
+    "type": "rope_tow"
+  },
+  {
+    "id": "6f6b570bb2b2bd04e436f4a1ec70426b79fd01ff",
+    "name": "",
+    "type": "rope_tow"
+  },
+  {
+    "id": "4bdcb508691a3633a5d6646144f31a07e603d369",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "d2ef58cd09839da6e3d01b1236ff25c6fae01578",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "c20ed2287fcd062a1e335cdf899ea9c13a60683c",
+    "name": "Glaciers",
+    "type": "gondola"
+  },
+  {
+    "id": "ec911939f1679e681590e635d7dd094cc1621f0b",
+    "name": "",
+    "type": "platter"
+  },
+  {
+    "id": "bb14a4e37e55db1184dd7038087e4af34ca0531d",
+    "name": "Transarc II",
+    "type": "gondola"
+  },
+  {
+    "id": "c693db65c8235481bfc67bb466354ef84e978142",
+    "name": "Transarc I",
+    "type": "gondola"
+  },
+  {
+    "id": "85d46b3f62750e140c59b056371ffcc969f61bd1",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "f54c907a56b26b31712bb96d6febe41b01c27007",
+    "name": "Tétras",
+    "type": "rope_tow"
+  },
+  {
+    "id": "a8316555188f14133d92edc5e57fe3d8351f7077",
+    "name": "Villaroger",
+    "type": "gondola"
+  },
+  {
+    "id": "be7d3a88195b1daf9a89c417e333ebfbf80713f0",
+    "name": "Roche de Mio 1",
+    "type": "gondola"
+  },
+  {
+    "id": "5560546b2c2e47af875d6f95e773184f503f6e5d",
+    "name": "Roche de Mio",
+    "type": "gondola"
+  },
+  {
+    "id": "8f4d227d534c513721bc716cbdd0c72c87aca1df",
+    "name": "Roche de Mio 2",
+    "type": "gondola"
+  }
+]

--- a/lumiplan-maps/data/paradiski-runs.json
+++ b/lumiplan-maps/data/paradiski-runs.json
@@ -1,0 +1,4797 @@
+[
+  {
+    "id": "8654e4993e9258fdfbee37f8740469a25b8ce5f8",
+    "name": "Murs",
+    "type": "advanced"
+  },
+  {
+    "id": "acb76ef9432be257b69fdab7fdccd0a485d5445e",
+    "name": "Murs",
+    "type": "advanced"
+  },
+  {
+    "id": "500f419eb7ef2f1ec02ee142e3c5dc02eeef0bfb",
+    "name": "Montchavin",
+    "type": "intermediate"
+  },
+  {
+    "id": "7bcc2aa18946f31e5d9f16fa0198615f54463242",
+    "name": "Montchavin",
+    "type": "intermediate"
+  },
+  {
+    "id": "9c176d9415f4c6c7d3d57885512f6cbc9af9f2dc",
+    "name": "Montchavin",
+    "type": "intermediate"
+  },
+  {
+    "id": "eac7340266454fe1e27a4636767b6385fd579b74",
+    "name": "Montchavin",
+    "type": "intermediate"
+  },
+  {
+    "id": "8fbebcea7da442768bfdc88342dc5836eac8f859",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "762cf3dd712aa89a668506c6c157308a33e01393",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "0d7fc9227fc7d1b8ec24f0cd8b3c061bd3c2b4db",
+    "name": "Mira",
+    "type": "easy"
+  },
+  {
+    "id": "ab28573a67693324925a3c4fe102598252b42396",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b2a85fb8b5db4dfe71c68f8fb60d7f88c0e7ab45",
+    "name": "Bridge",
+    "type": "easy"
+  },
+  {
+    "id": "e67405fb608470c3bd41f9c3ae4875b0c83a35bf",
+    "name": "Dolines",
+    "type": "easy"
+  },
+  {
+    "id": "005f62120a4b1120c016088654d162439729cd8d",
+    "name": "Petite Rochette",
+    "type": "easy"
+  },
+  {
+    "id": "14ef1907dc041c14c35d318f0b96137edb04b9fb",
+    "name": "Chevrette",
+    "type": "easy"
+  },
+  {
+    "id": "dc0a4302640e3fb1ed8fcb0a474d62e8280eb27b",
+    "name": "Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "dda4bf5121431774dd83687b3714d0eb2b02ee23",
+    "name": "La Frête",
+    "type": "easy"
+  },
+  {
+    "id": "b653f89f23f221adfe6d9af0b95f81f1f499282b",
+    "name": "Lognan",
+    "type": "intermediate"
+  },
+  {
+    "id": "435a3558f33d5970297aeb2f6f7e5329298a79cd",
+    "name": "Rêches",
+    "type": "intermediate"
+  },
+  {
+    "id": "47a4f1b1bf2a50742692ddd96d3674d7686ea777",
+    "name": "Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "33df36b09e5a991fd870614d05e86568c3e02318",
+    "name": "Fond Blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "6448f275380f3d46754fd94076c7790792ee5301",
+    "name": "Lanche Ronde",
+    "type": "intermediate"
+  },
+  {
+    "id": "9412bfddff2d1add7c742099e45edbefac62b213",
+    "name": "Hara Kiri",
+    "type": "intermediate"
+  },
+  {
+    "id": "1f9fa00e181fb3cbd18d3662a551bb9f96f56cbc",
+    "name": "Boulevard",
+    "type": "easy"
+  },
+  {
+    "id": "6b967e59c9456baa7839d3b28a98b18861a28556",
+    "name": "Stade de slalom Jean-Luc Crétier",
+    "type": "intermediate"
+  },
+  {
+    "id": "373d0ec2e758751313cd80f9714419d2f9db27a8",
+    "name": "Rochette",
+    "type": "advanced"
+  },
+  {
+    "id": "19e727a3f7ae53281eb26c6423fb42925449c34e",
+    "name": "Combe",
+    "type": "intermediate"
+  },
+  {
+    "id": "88faddc0432f206e979e0b39df6aec38742962ea",
+    "name": "L'Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "f1f7d7395dce0c23bee2cdd38c1b4b06ac3db694",
+    "name": "Carroley",
+    "type": "easy"
+  },
+  {
+    "id": "d20602148e30ba2ab7b604c880859cd0f148bc8e",
+    "name": "Le Tunnel",
+    "type": "easy"
+  },
+  {
+    "id": "483bc2960595999493d71d0b3178618c233e96b7",
+    "name": "Le Tunnel",
+    "type": "easy"
+  },
+  {
+    "id": "cfe05705445e518bcf929080b8bf7ec7ccafe784",
+    "name": "Les Arolles",
+    "type": "easy"
+  },
+  {
+    "id": "6948ef1f9046f01069bea0b39c9227f09a9c2149",
+    "name": "Les Dunes",
+    "type": "easy"
+  },
+  {
+    "id": "53c756a561bdef9e2aa75b5531405730ccdfa920",
+    "name": "Les Leitchoums",
+    "type": "easy"
+  },
+  {
+    "id": "0b9fc473d327a20295508637da6995b8cd485917",
+    "name": "Mont Saint-Sauveur",
+    "type": "easy"
+  },
+  {
+    "id": "3e957cbe4aeb796ba349fd1b3cf45f11c6e538ff",
+    "name": "Ours",
+    "type": "easy"
+  },
+  {
+    "id": "a71a32020a316d4184a36f4cd3a8684cbdd52992",
+    "name": "Pavane",
+    "type": "easy"
+  },
+  {
+    "id": "be8b94cba2e7857af13c18fb1b5751821f9e8cd4",
+    "name": "Puy du fou",
+    "type": "easy"
+  },
+  {
+    "id": "d591176c6ce5f82a621c2c2c7d987cda3eda4d99",
+    "name": "Replat",
+    "type": "easy"
+  },
+  {
+    "id": "8b59cd48aa7a207eed2b38e050a9bdb07b55efbe",
+    "name": "Reservoir",
+    "type": "easy"
+  },
+  {
+    "id": "263e65716f5b0aa98da297985c70b0163e467cce",
+    "name": "Samba",
+    "type": "intermediate"
+  },
+  {
+    "id": "b7b9828ce09711d2e1dbd492fa2390b0c43d0953",
+    "name": "Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "a6c8aa5ea84ab56bf266b86db32993646eac7d56",
+    "name": "École Aime 2000",
+    "type": "novice"
+  },
+  {
+    "id": "b72c53138e777eabe09fe9b50a5a6c14e17dd28d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5435e336ca82272f3a17e218ee7de2a556bdf00c",
+    "name": "Liaison Combe Écureuils",
+    "type": "intermediate"
+  },
+  {
+    "id": "824c779f194eaa991f4f6d1c189cc9be3e620071",
+    "name": "Dents du Peigne",
+    "type": "easy"
+  },
+  {
+    "id": "7f6a14b16b445c890228c19a89d935ce55fd3c93",
+    "name": "Frisbee",
+    "type": "advanced"
+  },
+  {
+    "id": "ba02df61a346b839464a4ca795572847e4ea8d85",
+    "name": "Morbleu",
+    "type": "advanced"
+  },
+  {
+    "id": "9cba031a3003c1fe4f297f7f595313aad565cce2",
+    "name": "Renard",
+    "type": "easy"
+  },
+  {
+    "id": "7f50cbeacb54d8e44c109b3c3530cec0cd1b4c5d",
+    "name": "Carina",
+    "type": "intermediate"
+  },
+  {
+    "id": "de512a72bd4d457e7de9fcc4f19e3b0abc49969b",
+    "name": "Bosses",
+    "type": "advanced"
+  },
+  {
+    "id": "ee58f0743c01212be154b59507336173e55c7ad5",
+    "name": "Stade de slalom Borseliers",
+    "type": "intermediate"
+  },
+  {
+    "id": "3673fd1d205857d732a7ba7be7c1c1f0a4de7626",
+    "name": "La Mio",
+    "type": "advanced"
+  },
+  {
+    "id": "44137c148784e49bcff9a84a4420c28b0f38efd4",
+    "name": "Stade de slalom Dahu",
+    "type": ""
+  },
+  {
+    "id": "b2373535cf50bf0e28b55c6efa081ae6b1369f28",
+    "name": "Hara Kiri",
+    "type": "intermediate"
+  },
+  {
+    "id": "a422d0dc321ca28e43c8b25a9d699ac6983dff69",
+    "name": "Ramy",
+    "type": "easy"
+  },
+  {
+    "id": "35ad8251710a9f841a28e15a231b81ee5e90b873",
+    "name": "Stade de slalom Belle Plagne",
+    "type": ""
+  },
+  {
+    "id": "4e3d95b313d3d4cfab7d657737fc2586b9bdef8a",
+    "name": "Snowpark Belle Plagne",
+    "type": "intermediate"
+  },
+  {
+    "id": "00866ff6b2d25a377d8533e804b28ba2df5830a8",
+    "name": "Stade de slalom Plan Leschaux",
+    "type": ""
+  },
+  {
+    "id": "13d335efb5e4e19614b8823087ddc1ec64e417c5",
+    "name": "Ourson",
+    "type": "novice"
+  },
+  {
+    "id": "4efe8f12639ccb25217dab661b091fe8dda7357b",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "a979894425ef6faf262c1c50e7c46ea120fa9a67",
+    "name": "Clair Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "4a8a953eb775f0a2ee05f449d8f959f118ae6f5f",
+    "name": "Rouelles",
+    "type": "advanced"
+  },
+  {
+    "id": "0ecd1fc45482c923465e3f0de892a217df045f31",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "b5231e724cbff3c16ef12e434c6c30300e7c8ee8",
+    "name": "Combes",
+    "type": "advanced"
+  },
+  {
+    "id": "1a40d5e814ce7a97646d17270612755da67c7180",
+    "name": "Bois de l'Ours",
+    "type": "advanced"
+  },
+  {
+    "id": "3e2d54f397e84e50774c5166ed4a9b28e98fbfa1",
+    "name": "Mont-Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "1c38b088f494826d7e9b573dfe569e19d41738ae",
+    "name": "Levasset",
+    "type": "easy"
+  },
+  {
+    "id": "fcb3e0a56b17de59f87459627365e6e2ad400503",
+    "name": "La Combe",
+    "type": "intermediate"
+  },
+  {
+    "id": "36121978c03c7ed38612780bc6622986e49ca211",
+    "name": "Kamikaze",
+    "type": "intermediate"
+  },
+  {
+    "id": "4fd01fc8b7879737226621ade0eb8a79573118c3",
+    "name": "Emile Allais",
+    "type": "intermediate"
+  },
+  {
+    "id": "471d1cd62602154d7d7b84d86535374cf17437ac",
+    "name": "Prajourdan",
+    "type": "novice"
+  },
+  {
+    "id": "b401d6da9667ea39e445c11e62ede48c6dd4849c",
+    "name": "Les Grenouilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "5cffacb210f54ac4b982d8d3d88eab63c9407218",
+    "name": "Crête-Côte",
+    "type": "advanced"
+  },
+  {
+    "id": "dfc582979940b6656a978387af703372e55cab60",
+    "name": "Lac",
+    "type": "intermediate"
+  },
+  {
+    "id": "6f3ec4bb652ea015c0998ec6481e841488c8759c",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "b23bac447f197f49428f6e569069befda072a44e",
+    "name": "Ecureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "1114592294bda1586411e312a9edd699b7925847",
+    "name": "André Martzolf",
+    "type": "intermediate"
+  },
+  {
+    "id": "7f70aa2a211f5905624b190a7d8522ce29535ab0",
+    "name": "Java",
+    "type": "intermediate"
+  },
+  {
+    "id": "bbf8a1f5f59552b4e7e509996dc29ff380ce34e6",
+    "name": "Crête-Côte",
+    "type": "advanced"
+  },
+  {
+    "id": "10f10b11c19a8e841c9db2523e6f597c2e6c668d",
+    "name": "Espace luge",
+    "type": "novice"
+  },
+  {
+    "id": "29065bb9d75f7aace13c0777ef243e38c3f9ac47",
+    "name": "Col des Frettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "77d8dd9e6fa660b3081d8eb555511df05ffde812",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "e3df0275afd023ba567068387ef1e5b3add70424",
+    "name": "Palsembleu",
+    "type": "advanced"
+  },
+  {
+    "id": "ce6c042c88a2722d45e9df8722cb1fb10be9ace3",
+    "name": "Froide Fontaine",
+    "type": "intermediate"
+  },
+  {
+    "id": "d66eebe50bec2488c0388a658006788aa0d03426",
+    "name": "Arolles",
+    "type": "intermediate"
+  },
+  {
+    "id": "f6df9d9602e89b027f0883d1693e097b5676fa96",
+    "name": "Cachette",
+    "type": "intermediate"
+  },
+  {
+    "id": "5fae19a72fb522bd6412bca19b6c356037ea6646",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "5597636b8bd7a406d6bdaf308d6687059aa58d79",
+    "name": "Snow Park",
+    "type": "intermediate"
+  },
+  {
+    "id": "59c3b6baccb449efda85912eaaa6713178bde87d",
+    "name": "Chantel",
+    "type": "easy"
+  },
+  {
+    "id": "e6a937f43adff2e0d6176384c92861d01bf54ec4",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "589dadf77d6f01f038061c4138d32daef97de896",
+    "name": "Golf",
+    "type": "intermediate"
+  },
+  {
+    "id": "3e0b874b82795c57c20e44adac2640b3caab701c",
+    "name": "Grands Mélèzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "bf8235359018f1778bc83b9a2bf24dc7c30507cc",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "f94943e934d16738c05cde3a2967b5c098390c25",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "ecff651dcdca73cc9bc3aecf1c7527959a3542f4",
+    "name": "Liaison Grizzly",
+    "type": "easy"
+  },
+  {
+    "id": "75a473d558f49ca19e7161472edbd597f02ad797",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "e47ccf3674c9a994d1fd68f34dd59ff33fe5573d",
+    "name": "Ours",
+    "type": "intermediate"
+  },
+  {
+    "id": "ca5c3df94ffad96b9978b12b3c2b95967a00f411",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "381e3bf7567082538a2ab4a41b94bfcb6569af9d",
+    "name": "Salla",
+    "type": "easy"
+  },
+  {
+    "id": "8aa88b533b3b8d4aeca9ea2159be5c45250dd30a",
+    "name": "Grand Col",
+    "type": "intermediate"
+  },
+  {
+    "id": "6d66036901caa7e7eb7a71e92f2acc0af3cba11f",
+    "name": "L'Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "cf467958d5617712038b29288711c421964c5569",
+    "name": "Le Tunnel",
+    "type": "easy"
+  },
+  {
+    "id": "5ff094024d4f33c0cfab21a9cb5086dd61d382e6",
+    "name": "Les Laines",
+    "type": "easy"
+  },
+  {
+    "id": "7280df4939f0bf562ecc5a9806981fa1bc0eb4fd",
+    "name": "Les Laines",
+    "type": "easy"
+  },
+  {
+    "id": "5e8b7bb671f6ca3a9474c620e395f817431da992",
+    "name": "Les Sources",
+    "type": "intermediate"
+  },
+  {
+    "id": "8f52e2f71aae6f53b98cfe750fc6f5645298cd02",
+    "name": "Pierres Blanches",
+    "type": "easy"
+  },
+  {
+    "id": "a513169d2121452fcb3395081f69056bb4a16979",
+    "name": "Refuge",
+    "type": "advanced"
+  },
+  {
+    "id": "fd2ac51d600be60564cb4ed793209b244ca17f25",
+    "name": "Arandelières",
+    "type": "intermediate"
+  },
+  {
+    "id": "e607c84a84841f8dbbf53e56481b2eb7c7099442",
+    "name": "Col de la Chal",
+    "type": "easy"
+  },
+  {
+    "id": "3c322cb1c91589564a61ecdb0954a4f2340efc87",
+    "name": "Vallée de l'Arc",
+    "type": "easy"
+  },
+  {
+    "id": "7b51d5d7fe7ca06e5bb79819bd2249c7e11c218e",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "b580c4476dea0c58b8b21da01f753c2820974035",
+    "name": "Aiguille Rouge",
+    "type": "advanced"
+  },
+  {
+    "id": "a450aa248be1a5fec3a550cf91dff9bc6581c05f",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "07e7817f2fed5b44ee247aa470e6427f44f07778",
+    "name": "Arandelières",
+    "type": "intermediate"
+  },
+  {
+    "id": "cd364cc4fc0df3bfa6c041dbdfacb92e79a2d19c",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "b10daf84c9ce7c78d40ba67ba148191fe21c8d03",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "af2f969c0868f8d6e3436653bf208d783a6866ca",
+    "name": "Marmottes",
+    "type": "easy"
+  },
+  {
+    "id": "f620b46df7b1bade458b749444bf4e72990d77e1",
+    "name": "Plagnettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "2d241bcb6aaede88d7b9408e2898b8ce8c26bcc0",
+    "name": "Plan des Eaux",
+    "type": "easy"
+  },
+  {
+    "id": "0621bcd70abab901a3106074220873a332612ac5",
+    "name": "Plan-Vert",
+    "type": "easy"
+  },
+  {
+    "id": "68488f54df8f76d0aae702c564eca599d1724ea0",
+    "name": "Plan-Vert",
+    "type": "easy"
+  },
+  {
+    "id": "4587308ffa08c1077d039b244fedc0c7947acc0b",
+    "name": "Plan",
+    "type": "novice"
+  },
+  {
+    "id": "d79964ad4dcf62bf5d4cfbd7b7251733e84b5d99",
+    "name": "Réservoir",
+    "type": "easy"
+  },
+  {
+    "id": "dc5bc161b685e5db834cad1f5fddea8d8d5975e4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a4c30c7e8782a6e68de119f40ab02baff4815ce6",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "0c259344c765af12511d06b5f5d865d30f845d39",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "06939ce24218c6036e4af139f6d34a6e495396fb",
+    "name": "Esselet",
+    "type": "intermediate"
+  },
+  {
+    "id": "1028dd9ac2c4f8ba4c98aaa8723ebc650b334cee",
+    "name": "Clapet",
+    "type": "easy"
+  },
+  {
+    "id": "b6da527fd77ab63d4bf079c4d35fddbf0b0d29b5",
+    "name": "Stade de Slalom",
+    "type": "intermediate"
+  },
+  {
+    "id": "b0be2ef94644c30dd896c79d10c47df4b4066ddb",
+    "name": "Ourson",
+    "type": "intermediate"
+  },
+  {
+    "id": "f9cc0b9ea9ae65926204b0cdf717d4648fa7dbcf",
+    "name": "Morey",
+    "type": "intermediate"
+  },
+  {
+    "id": "64a7b2a22ee9c78de4586356019990b8d5639df6",
+    "name": "Morey",
+    "type": "intermediate"
+  },
+  {
+    "id": "5a6bb788c099a9f39f221b5e8ad2c2e9c5e1f182",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "4c54e6738bc5447579a40575c25bf91c0565e1db",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "d28cd5db0465356c964fe89c02c34406a4a27a39",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "a9cc7c6233bb0104617803694defeed8c31ebf4e",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "1a3eaf10fb2d9c50cee0d808a36769db23c6e067",
+    "name": "Barmont",
+    "type": "easy"
+  },
+  {
+    "id": "82e9191c0f502162fff755d1bfb0f31f092c585a",
+    "name": "Rhodos",
+    "type": "easy"
+  },
+  {
+    "id": "d24aa35939b2dc3fbbe4e98a40086ab4442a6ac7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a65a94b6d9b2d4b69e63f32e1e7e939c90a83504",
+    "name": "Belette",
+    "type": "intermediate"
+  },
+  {
+    "id": "5ca96d33c1081d3f5c80b684959065e55884178c",
+    "name": "Morey",
+    "type": "intermediate"
+  },
+  {
+    "id": "fa60d85f00f3cda5f684f953a5625a748102e077",
+    "name": "Stade de Slalom",
+    "type": "intermediate"
+  },
+  {
+    "id": "61ab5b6f985774d5c4e67cbc054acd8b65a1a9c3",
+    "name": "Espace débutant Club Med",
+    "type": "novice"
+  },
+  {
+    "id": "089c88d98b8aab4f777f80b183b5956b7c2497e2",
+    "name": "Espace débutant Club Med",
+    "type": "novice"
+  },
+  {
+    "id": "8c8d2b2a76f74e4d90fb77c8187a011c0b702dd8",
+    "name": "Quillis",
+    "type": "easy"
+  },
+  {
+    "id": "f6c8ef4812b54176bb86158977104a826891f337",
+    "name": "Clocheret",
+    "type": "intermediate"
+  },
+  {
+    "id": "441c8bc7810a509d42fb88a493532b8de0ce8654",
+    "name": "Clocheret",
+    "type": "intermediate"
+  },
+  {
+    "id": "d75a16b95c46c5a525b0abc1498a156a6b5f14ff",
+    "name": "Clocheret",
+    "type": "intermediate"
+  },
+  {
+    "id": "6243daa67003a2e382d70cc00a0f3fbe41ecb887",
+    "name": "Bosses",
+    "type": "advanced"
+  },
+  {
+    "id": "ddc724801fdd66e2cfb4401c952c097db128c70d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "664396930160f1b682717c4cd9e72df8f3760120",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "c6d965259ff77f6cfa3a2be3684be5fbd89614f2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ab39eda5ca53c76263e0230df4a2cf56ed7ec923",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "e5293967bcf7c12504e5388bf7f04c0611ec3c73",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "01661ee61544c81cfde2bf46c7cc7b5ef9938860",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "467891df35bb4fa5e571c39b83c0a599455341cd",
+    "name": "Myrtilles",
+    "type": "easy"
+  },
+  {
+    "id": "e2e0806c08d22126758bdb5f0275202ade044db2",
+    "name": "La Duy",
+    "type": "intermediate"
+  },
+  {
+    "id": "d5df7e6fb66070755e7e9ca7724a714a6acd6251",
+    "name": "La Jaccotaz",
+    "type": "easy"
+  },
+  {
+    "id": "7239af793672ec75024cc19fad56503f6b2e0d7e",
+    "name": "Route des Bauches",
+    "type": "easy"
+  },
+  {
+    "id": "d53a4bea2eb39639524db77f6cca399e232179d5",
+    "name": "Les Coches",
+    "type": "intermediate"
+  },
+  {
+    "id": "2353cc0ba76887ee2ff14c33614217239cc57591",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "a0d00d03e14bd82d1505d23031750b9b80e7225c",
+    "name": "Stade de la Buffette",
+    "type": "intermediate"
+  },
+  {
+    "id": "9545fd992a02936d5eae8c89ae04f123cb08c7b5",
+    "name": "Crozats",
+    "type": "advanced"
+  },
+  {
+    "id": "eeecbbb03b14349645d84a3b448ad99122588e42",
+    "name": "Bauches",
+    "type": "easy"
+  },
+  {
+    "id": "ff15b9a558c77430f23d6fbc198a7b454913412b",
+    "name": "Les Marmottes",
+    "type": "intermediate"
+  },
+  {
+    "id": "8056395de18f1d032572bf070132c09638567b6b",
+    "name": "Les Barrieres",
+    "type": "easy"
+  },
+  {
+    "id": "258f5bfd535dcbf02afe06b082799127d6cb8517",
+    "name": "Les Teppes",
+    "type": "easy"
+  },
+  {
+    "id": "4872f25ac80e5094a07feffb5854b99f63742aa9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "93ac133c5f7ae74ac90a68b4a3fb2545d49965f7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "4425c69efce05714d2936554ad8f8d96cc109756",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8f6e11220a943db08c75130e660b89c2f1507283",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6543f9e72efddfedc3b995a510386911af2183d1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dc17dfa696e9088d48cc87c77b7f3412ab24e4f4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "20d2ff94f76e49be517a98bc8923c99f14f90066",
+    "name": "Adrets",
+    "type": "easy"
+  },
+  {
+    "id": "96e46661f741cfdd2ef86ef9748ae73fa22aaacc",
+    "name": "Mur des Adrets",
+    "type": "intermediate"
+  },
+  {
+    "id": "84d6e3c17de7b3310f0458b6322aafc6b45da4cc",
+    "name": "Montalbert",
+    "type": "easy"
+  },
+  {
+    "id": "2c0f34052891ac611e7e00b5f12ce4dba5891638",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "00c4447ce69f9240597e1004257462fd03873518",
+    "name": "Col des Frettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "e1ca4ae58523e44134d08ca8a2d6bfa5d1684517",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "1bff1430bd7a87b54e402404f7dea4b96f478ca2",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "b3f8777c7c49ffd1cba50578cef412ad51ef53af",
+    "name": "Marie Chantal",
+    "type": "easy"
+  },
+  {
+    "id": "a0e991df329c01331851c07740395f56140efa2a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d5644cb22a4ce35de77b59a83ca14ad9b30439c8",
+    "name": "Capella",
+    "type": "easy"
+  },
+  {
+    "id": "3a273e668df503a7f11b36152ae1aae3861d899d",
+    "name": "Verdons",
+    "type": "easy"
+  },
+  {
+    "id": "26e26bc4feea2626c4c60fb9ac7758eb5aa1edd1",
+    "name": "Espace luge",
+    "type": "novice"
+  },
+  {
+    "id": "41b0e6633aa4bcac378218357631b0616bf45c92",
+    "name": "Lovatière",
+    "type": "intermediate"
+  },
+  {
+    "id": "1c100b14735bf5e3349b8f41c8ccbc555a8943df",
+    "name": "Jean-Marie",
+    "type": "easy"
+  },
+  {
+    "id": "dd5cad46d8e193a21996bb4bae9ebb0aa696ec9d",
+    "name": "Loup Garou",
+    "type": "easy"
+  },
+  {
+    "id": "1db8a5fb15d0db104f22f11e5272b922cd47cdac",
+    "name": "Liaison Mélèzes",
+    "type": "novice"
+  },
+  {
+    "id": "34f2bf89defb196d6e78d95b50cefdeb03199820",
+    "name": "Praconduit",
+    "type": "novice"
+  },
+  {
+    "id": "66db8540bc87501023b5032e26c10262bffaf92b",
+    "name": "Loup Garou",
+    "type": "easy"
+  },
+  {
+    "id": "f72b6a3d02fbed5a3092eed8542a30b7f916c318",
+    "name": "Les Mines",
+    "type": "intermediate"
+  },
+  {
+    "id": "4fa4eed0452782365dc02f8645bb43d2ee35844c",
+    "name": "Loup Garou",
+    "type": "easy"
+  },
+  {
+    "id": "064eedc882fd8c898c3afd858cb2a175fe869d65",
+    "name": "Écartée",
+    "type": "easy"
+  },
+  {
+    "id": "ce6ee6a39105d29b8403f86c412791b80b7cddf4",
+    "name": "Soleil",
+    "type": "easy"
+  },
+  {
+    "id": "134a9fb0ae447fe4de97af33885a9ad8c1af6e55",
+    "name": "Dou du Praz",
+    "type": "easy"
+  },
+  {
+    "id": "d9649699889aa4d8d1fff39ac058e4d59f02d5a0",
+    "name": "Bretelle Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "438a646073bc71936a17282ff1dee528b1d1c655",
+    "name": "Vega",
+    "type": "easy"
+  },
+  {
+    "id": "eea61c616cb0a8cafd2a59385d511e2479303ec5",
+    "name": "Col de la Chal",
+    "type": "easy"
+  },
+  {
+    "id": "9d1126ad0e86a56c48bca7364e88f7174c86459f",
+    "name": "Arc1800 vers ND des Vernettes, Retour Plan Peisey",
+    "type": "easy"
+  },
+  {
+    "id": "b50075b3f27a3d9f309f90b2dde73ab2626982e2",
+    "name": "Arc1800 vers ND des Vernettes, Poney",
+    "type": "easy"
+  },
+  {
+    "id": "7ce0da7aae67a170319467d44159448fab7fb018",
+    "name": "Arc1800 vers ND des Vernettes",
+    "type": "easy"
+  },
+  {
+    "id": "a56a5264a9f8c44651a806d046e1d8118ed820d6",
+    "name": "Arc1800 vers ND des Vernettes, Accès Peisey-Vallandry",
+    "type": "easy"
+  },
+  {
+    "id": "57f5e8c4820606738558d74924ff097e647b6f2e",
+    "name": "Arc1800 vers ND des Vernettes, Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "efeddf36e93e829c184d4d2070ab3293c080d418",
+    "name": "Arc1800 vers ND des Vernettes, Route des Espagnols",
+    "type": "easy"
+  },
+  {
+    "id": "bdd74cd6239fe19f036d03643d5b1adb100fdcfb",
+    "name": "Chemin Bellecote, Tommelet",
+    "type": "easy"
+  },
+  {
+    "id": "9c00eced5a40661aa7560d50917c3b08955cb665",
+    "name": "Boucle de la retenue Collinaire des Adrets, Plan",
+    "type": "easy"
+  },
+  {
+    "id": "1bd2f69366ba83c12760ce82a6ab75ac9d6be6fa",
+    "name": "Boucle de la retenue Collinaire des Adrets",
+    "type": ""
+  },
+  {
+    "id": "d46deec48eca2a97dfb10430ab0207853752531e",
+    "name": "Boucle de la retenue Collinaire des Adrets, Plan",
+    "type": "easy"
+  },
+  {
+    "id": "6317f7c449675ef7c70f16a514b6ca1858ebb1a8",
+    "name": "Boucle de la retenue Collinaire des Adrets, Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "af66102d406a4bf3bdf7a0f984ad93e255ecd695",
+    "name": "Boucle de la retenue Collinaire des Adrets, Marais",
+    "type": "easy"
+  },
+  {
+    "id": "706ed8e847b80d5ed459d25f8cc1738b1a2d555f",
+    "name": "Boucle de la retenue Collinaire des Adrets, Piste à Steph",
+    "type": "easy"
+  },
+  {
+    "id": "4276591a862c9974a5f80ac9147daf7eaad05732",
+    "name": "Boucle de la retenue Collinaire des Adrets, Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "9044f79a4b60868543b3a3bc40fd685b9702be0a",
+    "name": "Boucle de la retenue Collinaire des Adrets, Piste à Steph",
+    "type": "easy"
+  },
+  {
+    "id": "698b21c56de841215e6f2b71cb98872305fa235f",
+    "name": "Boucle de la retenue Collinaire des Adrets, Arc 1950",
+    "type": "easy"
+  },
+  {
+    "id": "27d90cd597849afcfed4617b0f99c22dfa6610c3",
+    "name": "Boucle de la retenue Collinaire des Adrets, Arc 1950",
+    "type": "easy"
+  },
+  {
+    "id": "ea9161822028e9f12c04315a7a9e2eef3288860c",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "8318589a82bc4a550ddc889161244e425afa75ad",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "981fd5b3bbf5d49dceb1397111d270178de72345",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "587ea8fdf5d0351463ffc260b71769f4f94f320c",
+    "name": "La Forêt, Myrtilles",
+    "type": "easy"
+  },
+  {
+    "id": "32fbdced26bf08c4cdf0404851fa91e9f9de5ca0",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "f9308d56f554d91f075b7d85319fd67949b1a31d",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "f1bc90b9f95c1c01481c79c0a3a796a9409229fb",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "cb5cebbd8c5f871b4bf68bfc9dcf4e76b770faa2",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "9a4bff80066eb827f573938e4c4d038b588e7777",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "b3a2d3d69e2ea0d22efd31f256239ab68fb7a024",
+    "name": "La Forêt",
+    "type": "easy"
+  },
+  {
+    "id": "86361d478a319ec621adee879cd9ee9e2c38f63a",
+    "name": "Le Tunnel",
+    "type": "easy"
+  },
+  {
+    "id": "7ee4cae057bb7d26e162508ae3b8ff2ec77fcf78",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "df8fbba1125fcf18ef8b76c92eee955b7cc30be6",
+    "name": "Fun Slope",
+    "type": "easy"
+  },
+  {
+    "id": "e2974bc1e1ca0d9c3214af0e05c3d0ae05934827",
+    "name": "Les Laines",
+    "type": "easy"
+  },
+  {
+    "id": "e728ccc1fc315c65099ea9a60000fa0765edd189",
+    "name": "Les Teppes",
+    "type": "easy"
+  },
+  {
+    "id": "b8c39b47411dfa15b78f8d81fa7427e6ec9fb993",
+    "name": "Les Teppes, Les Barrieres",
+    "type": "easy"
+  },
+  {
+    "id": "074de0cc7f85f2d588cb4d0fd5dc05598dc9bc3b",
+    "name": "Les Teppes",
+    "type": "easy"
+  },
+  {
+    "id": "76337128baa9211946713b38eb9f2e7adad06dcd",
+    "name": "Les Sources",
+    "type": "intermediate"
+  },
+  {
+    "id": "e5cea5fb4b985e54b1f20dfb65172df0c331f9fe",
+    "name": "L'Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "3426be78eaf21972b632df1710a6d4a2ba1069fd",
+    "name": "Les Grenouilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "7e64ee78fd0bce7339b1ad09ef386ef8b595cfb7",
+    "name": "Les Marmottes",
+    "type": "intermediate"
+  },
+  {
+    "id": "22c061f44838b6b9cfe5b77f468e8c9eb3803439",
+    "name": "Les Marmottes, Les Inversens",
+    "type": "intermediate"
+  },
+  {
+    "id": "ed863df78e71693fa51ead621e31745c75632228",
+    "name": "Les Marmottes, Crozats, Les Inversens",
+    "type": "intermediate"
+  },
+  {
+    "id": "9e3885853250d091145351d1df46de93d47a92dc",
+    "name": "Les Barrieres",
+    "type": "easy"
+  },
+  {
+    "id": "072483522eff6a38712e22af8e480801a8f33b56",
+    "name": "Quillis",
+    "type": "easy"
+  },
+  {
+    "id": "336640df18a5b257c43c09568204177a1338699c",
+    "name": "Capella",
+    "type": "easy"
+  },
+  {
+    "id": "ae0bcf9463f5cff4098964b16ccdc8001af67ef7",
+    "name": "Pavane",
+    "type": "easy"
+  },
+  {
+    "id": "484b988fad4c5bdeb6f60e0b04a184ae41f17733",
+    "name": "Java",
+    "type": "intermediate"
+  },
+  {
+    "id": "a81eb506bcdf1a8da1559b457366f6e43b1664d6",
+    "name": "Pavane",
+    "type": "easy"
+  },
+  {
+    "id": "e3c0a17cec60ae8105580a27633d419b77e428ed",
+    "name": "Dou du Praz",
+    "type": "easy"
+  },
+  {
+    "id": "14d89ebfd86e841acfc1643aca9ed63f8b824ed3",
+    "name": "Bretelle Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "66442c1d4764da0d44abb57815b63357ef02ce71",
+    "name": "Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "066480ee63e02e3ccce6797472951222e2bc2539",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "30afa852fc189566b3adfa4636ef61407520ad25",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "afa6ddc5bfe126cfe487b713c42cf9c7f38a34f2",
+    "name": "Crozats",
+    "type": "advanced"
+  },
+  {
+    "id": "97ad46e3e6cf747bbd20159f34b27d14a1f67065",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "673d2be616d7accd33163fad22e581d536230080",
+    "name": "Grive",
+    "type": "easy"
+  },
+  {
+    "id": "0993fc1bf88757a7960825f6a1ca2dbca2a3d4ae",
+    "name": "Grand Renard",
+    "type": "intermediate"
+  },
+  {
+    "id": "a3a43ec05e95fd022340611a5c9217886b5c71f5",
+    "name": "Plan Bois",
+    "type": "easy"
+  },
+  {
+    "id": "2a93c73b0b0779f299f9a954bda7527852f198b7",
+    "name": "Rhodos",
+    "type": "easy"
+  },
+  {
+    "id": "04e137debc85c6c40bd12590cbcd00be2fdb8d93",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d0822e80fef770728c3ebbb040db9966b451d80b",
+    "name": "Golf",
+    "type": "intermediate"
+  },
+  {
+    "id": "561e077c8f4686f20b14b629964cc4efce41d35f",
+    "name": "Lac",
+    "type": "intermediate"
+  },
+  {
+    "id": "209a5a864e3a9aed5bbab5a96ce68f168a2b5d39",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "4891c0ba38ebebab5d36230fa5fc5b043775a6c5",
+    "name": "Stade de la Buffette",
+    "type": "intermediate"
+  },
+  {
+    "id": "b5f6abc2c7b4cec875697d8b943c2a8eaa1d725d",
+    "name": "Esselet",
+    "type": "intermediate"
+  },
+  {
+    "id": "02ba17716cc9c237d0c4737027954c2aa34b0408",
+    "name": "Les Pelées",
+    "type": "advanced"
+  },
+  {
+    "id": "b8f9e03701da881eefc27ed060d7f67706175520",
+    "name": "Pierres Blanches",
+    "type": "easy"
+  },
+  {
+    "id": "82b9db7051374e059cefd5a6ea7b2a451e2a98bb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "adfcd75b68746284e9cb66f96598ae0035ddf647",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "a8b1e29f128e45dac6c6bc2576e0d3b41e7c726c",
+    "name": "Les Coches",
+    "type": "intermediate"
+  },
+  {
+    "id": "2b21f240a2f304d081477530e541e3575e7fc930",
+    "name": "La Duy",
+    "type": "intermediate"
+  },
+  {
+    "id": "8aefe67b3dd2bd519e45c7d7141fdd4884d94781",
+    "name": "Les Pelées",
+    "type": "easy"
+  },
+  {
+    "id": "e09cada7912c6523518ba4b65ee165b1db3c3494",
+    "name": "Ours",
+    "type": "intermediate"
+  },
+  {
+    "id": "66d399af949e18f6aa2d9a6bc83963d4dc32de76",
+    "name": "Bosses",
+    "type": "advanced"
+  },
+  {
+    "id": "9628af2b9e6c121cdaf248267ce3f83e9fcd65df",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e5c9df1b4b571526a4a28630528c5bc6a10e2c1e",
+    "name": "Dos Rond",
+    "type": "easy"
+  },
+  {
+    "id": "b33a1433f377f0682a0da29394ac5b9abd916933",
+    "name": "Salla",
+    "type": "easy"
+  },
+  {
+    "id": "c22879222ab277dbd1ce26e04acaeab45109a07f",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "b72371c2c25deb6354587361e959f1e26f2fc3c7",
+    "name": "La Tome",
+    "type": "easy"
+  },
+  {
+    "id": "eb7def7091f7e0f2307fba2b10dafd405893272a",
+    "name": "Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "d7ff332a16fc6740f7a8ae3cc5323d2791a06723",
+    "name": "Montalbert",
+    "type": "easy"
+  },
+  {
+    "id": "a58466533c6feb9d7df06a1609f82b5d496a8552",
+    "name": "Plagnettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "bda93dc3c13015812b2ef21212305966ebe1d449",
+    "name": "Plan des Eaux",
+    "type": "easy"
+  },
+  {
+    "id": "7b77254adc935e53b74a541abecbaf7422764fd7",
+    "name": "Teppes",
+    "type": "intermediate"
+  },
+  {
+    "id": "df371052f7e2f40ab821575095316b394b5c7cbc",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "70e36c10fff83480792a6b7317d4a7d0cfaa2498",
+    "name": "Vallée de l'Arc 1",
+    "type": "easy"
+  },
+  {
+    "id": "0c93c36465d33364c7fe10c12e7ac64fe44d82a5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0f9cc04eb01ac7dcf1dd87da097edea2d8999cd4",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "9f26ebdafe0c131f196b60d1bf4d7bf9c6db46aa",
+    "name": "Réservoir",
+    "type": "easy"
+  },
+  {
+    "id": "a70ae5ae9911776a6a29f2ae473d17fdf34257db",
+    "name": "Lanches",
+    "type": "advanced"
+  },
+  {
+    "id": "e32316a9d287cd4728563c2fbdd7622779761977",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "b64ec2c1bbd8273a51c3685328055b381f0fc836",
+    "name": "Grands Mélèzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "4b38b16c31996716d0ab4fa7a53436ecb3409f53",
+    "name": "Muguet",
+    "type": "intermediate"
+  },
+  {
+    "id": "809187aee4978000d5bb1c63ee102d222c3468ee",
+    "name": "Droset",
+    "type": "advanced"
+  },
+  {
+    "id": "3a168283a05bcbe35aad5b3a9f5fa35ce306762f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8b3952a98fb5943528f01435d0cca2ea9898701f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "02aea74251a29a2b62d9f31f79dbb370deee0b8a",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "5628b308e9e6d6018ce2a12742a6126a93bdb9b4",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "9e91706627b517709accbee26c7b12c6d67e05d3",
+    "name": "Retour Plan Peisey",
+    "type": "easy"
+  },
+  {
+    "id": "835fa813badc0e5350474ae6e0807ae5d1d538b3",
+    "name": "Morey",
+    "type": "intermediate"
+  },
+  {
+    "id": "62d2289b0dd8ac9287d00b149ab2651909280bb5",
+    "name": "Renard",
+    "type": "easy"
+  },
+  {
+    "id": "d5a41bcfdffa823e245fd03cabd9cd687347b5ae",
+    "name": "Maïtaz",
+    "type": "easy"
+  },
+  {
+    "id": "66aea86b8a75c38bb7bd15693dbb6a0aeb92bf2d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d0e66414585b41b27d57b0bcc70766499c247b8f",
+    "name": "Accès Arcabulle",
+    "type": "novice"
+  },
+  {
+    "id": "4827e0be887126a829b427d21a0eb349483ca20d",
+    "name": "Bois de l'Ours",
+    "type": "advanced"
+  },
+  {
+    "id": "e221cbab72bd225783c9f3ba6a673607149bbb30",
+    "name": "Génépi",
+    "type": "expert"
+  },
+  {
+    "id": "ae2b38d4657c8ecbcce936bd77dccb041b410fe9",
+    "name": "Combes",
+    "type": "expert"
+  },
+  {
+    "id": "d5fbf8de21443ceb185dee4e1aa13e1efa5f67db",
+    "name": "Solliet",
+    "type": "advanced"
+  },
+  {
+    "id": "d2c277b87ea376e30c44ac3b7c6967d46547d674",
+    "name": "Bauches",
+    "type": "easy"
+  },
+  {
+    "id": "cd6518aff85df8c4f36aaae2d1d39c961e73ba17",
+    "name": "Murs",
+    "type": "advanced"
+  },
+  {
+    "id": "1654c46fa3bc59bb821a84294547a274950a0e1f",
+    "name": "Marie Chantal",
+    "type": "easy"
+  },
+  {
+    "id": "ce6ad303a6fd18becd4ed970545a0bf70f4c1966",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1ef7dc401a67e73b4c6ccca72bb328b4baec9b13",
+    "name": "Les Dolines",
+    "type": "easy"
+  },
+  {
+    "id": "9e40ae5db4cb90724aa3e2ac75b2210c64d6e03f",
+    "name": "Trieuse",
+    "type": "easy"
+  },
+  {
+    "id": "6b6bc5644f3b6237719190d1eff0bdf7c1958d0e",
+    "name": "Banzaï",
+    "type": "intermediate"
+  },
+  {
+    "id": "2286d5b4538b82c6454ae1d0ae93dfaaddfe0f10",
+    "name": "Les Étroits",
+    "type": "advanced"
+  },
+  {
+    "id": "17febcd67581caadb5ee0dce0d889ce07093383d",
+    "name": "Mira",
+    "type": "easy"
+  },
+  {
+    "id": "96a94ad0cb5f46e97deabb499eab007827bd9fdf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "10ff4db27944c7fa81fabe81a927be31904a07e1",
+    "name": "Les Inversens",
+    "type": "intermediate"
+  },
+  {
+    "id": "90686309668842acab3bd00c74f7b9b4536be8cf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "383488cbe29534c59e4588ef9cc4f5e513af3ebc",
+    "name": "Hara-Kiri",
+    "type": "intermediate"
+  },
+  {
+    "id": "b8aecf50ac71c3a3205fb448d47276eb0de0fb6c",
+    "name": "Les Arolles",
+    "type": "easy"
+  },
+  {
+    "id": "db4f1ca345611f56cfce7ce758d933368df05cab",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "73ad75a9ae9f400095912f5b370dd4b3d89deb8d",
+    "name": "Premiers Virages",
+    "type": "novice"
+  },
+  {
+    "id": "0353132590a5149f3fde562e622513b6bda97da0",
+    "name": "Barmont, Accès Transarc",
+    "type": "easy"
+  },
+  {
+    "id": "dde80aa07e769fe63966ce1f2ec9db339fd219b8",
+    "name": "Barmont",
+    "type": "easy"
+  },
+  {
+    "id": "ce4c46f5b2d11b8df80f736dd0a9085a23927af9",
+    "name": "Renard",
+    "type": "easy"
+  },
+  {
+    "id": "ed3338e6347635795ac334c5cc492fd0158aeae6",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "480372511657642d5570e440c9cfebc6d305e21d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7a6f72b037627b0f2031ed2f5c9a842f3abcb7d8",
+    "name": "Barmont",
+    "type": "easy"
+  },
+  {
+    "id": "1a004dad9c00b40b1a6f11e86383fcfbc53e4b0e",
+    "name": "Traversée",
+    "type": "easy"
+  },
+  {
+    "id": "29f293f1024c09e941a887a8eca7fa7bc7f6a046",
+    "name": "Route des Espagnols",
+    "type": ""
+  },
+  {
+    "id": "137746c3e07de77f26bc9edfe450895acf62fda5",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "91115ce644b912f44e4fa189e31c1788224cf0cb",
+    "name": "Mont-Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "702fd9c7bb9b4ceb88e5a4e112e1984c09b352ea",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "4a673c3194f060cbd56cce8c299447bb8e77b181",
+    "name": "Sollières",
+    "type": "intermediate"
+  },
+  {
+    "id": "01b2781e145df2ec23d92ee483b7b34be08028e2",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "0679107ad03ca2fa26a8575c759ce79c75f9dd72",
+    "name": "Jean-Marie",
+    "type": "easy"
+  },
+  {
+    "id": "ae2f8fc5d29986d19d4514a6e5c17742dd75b3df",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4b2f805dc7768b5554a798b330792463cb139a13",
+    "name": "École Montalbert",
+    "type": "novice"
+  },
+  {
+    "id": "e82f8e303909362d37c34fb70f00e0010998cd02",
+    "name": "Bois Crozelin",
+    "type": "intermediate"
+  },
+  {
+    "id": "1f5edd879d04074a1876982fa9bbcad52d7c3c00",
+    "name": "Bovet",
+    "type": "easy"
+  },
+  {
+    "id": "250dd3017b53e89e6ac759535e8ab4254c7bfcbc",
+    "name": "Maignonne",
+    "type": "intermediate"
+  },
+  {
+    "id": "0970b6c7cc80018758af089631299591b52f4cab",
+    "name": "Plantes",
+    "type": "easy"
+  },
+  {
+    "id": "6b0bdf7d320102a20e7b09143ddc97f1ef2fce7c",
+    "name": "Roclisse",
+    "type": "intermediate"
+  },
+  {
+    "id": "4acaac9664773113bf5361ce2f20a18d675140f9",
+    "name": "Mont Saint-Sauveur",
+    "type": "easy"
+  },
+  {
+    "id": "6c9bf88ba7dc942e39219857224afb5a3d8e6236",
+    "name": "Reservoir",
+    "type": "easy"
+  },
+  {
+    "id": "00c636693e79911a2bc5694e0fd58b5f7d00b93d",
+    "name": "Samba",
+    "type": "intermediate"
+  },
+  {
+    "id": "2f0886c612294c5a4aac3e494fa9c328ad203a0d",
+    "name": "Bridge",
+    "type": "easy"
+  },
+  {
+    "id": "9ede32d833534b2c397aebfecf7f28df7029d8f6",
+    "name": "Ramy",
+    "type": "easy"
+  },
+  {
+    "id": "d48610d79d8afe0025e7510cc01bc0f64bfde45a",
+    "name": "Rossa Haut",
+    "type": "easy"
+  },
+  {
+    "id": "aaf65594851ae4910a856888ada5bc3734545f8d",
+    "name": "Le Serac",
+    "type": "easy"
+  },
+  {
+    "id": "adf55231aa75f86c891f4e913442326b59d2d8f5",
+    "name": "Les Crepines",
+    "type": "easy"
+  },
+  {
+    "id": "4b98b2f0a631c54e041b01d9c6900e1deb14dfab",
+    "name": "Geisha",
+    "type": "easy"
+  },
+  {
+    "id": "a2bb363fd438a0c20cd6b8ffbc088bf3813f5d0e",
+    "name": "Mont de la Guerre",
+    "type": "intermediate"
+  },
+  {
+    "id": "4c8df94f881fda696733ff9392a87968fefcc9c9",
+    "name": "Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "bb78d0ca3bcef7bc95bfe9f3ecaa9152be61141a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1b551f4cdf296e1393be0268acd79e5bff83f280",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1a56cf79178fc03090c23c47a67592e41a6da6d8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f924239ca0d933b9b80a219faf72efb2094c363f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5260493668ec816f4c56aad6ed5f416daada9c96",
+    "name": "Réservoir",
+    "type": "easy"
+  },
+  {
+    "id": "4acf1138f7b0536d18394edc457580cd700c7332",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "977fe0418e6e18f30b5cd9afd50fbfe16a0275c4",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "bd319fa08e75a01d6a3fb2dd66623dd80520f261",
+    "name": "Col de la Chal",
+    "type": "easy"
+  },
+  {
+    "id": "492f43335ef07722d49516c0013129f18c6554b1",
+    "name": "Dents du Peigne",
+    "type": "easy"
+  },
+  {
+    "id": "ed2a0742f22c3174582049e5b75c254d24fb3977",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "03efcab6ea279fd11485116c696a9be5e6032c0a",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "c80b33539a6540dbfc755e90dccc6583ab94caf5",
+    "name": "Col de la Chal",
+    "type": "easy"
+  },
+  {
+    "id": "413458dee9b828a8620424ee6e272a45bb7b3eff",
+    "name": "Accès Transarc",
+    "type": "easy"
+  },
+  {
+    "id": "bf10a2953487047f4dcca351f90827ee67de08bc",
+    "name": "Ours",
+    "type": "intermediate"
+  },
+  {
+    "id": "00cc2d72555cf74c3053a21bbaa7b3b08d22da04",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cb871c31076cf196205092a16f04146eaba36292",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a4296c9a2e77dea15068e3649a981a9dfed35151",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "80090d19c052fffd2bb1392c416e99ac2c1c928b",
+    "name": "Coqs",
+    "type": "easy"
+  },
+  {
+    "id": "724688e2f09ad13f2e1ab426afe61dee0c98ae31",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "ba2497dcaf29df7c3c3b4d5c018b4c09a7a11527",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4179fe4e6466ccaef9ea7c05d1a8cf91f6a11661",
+    "name": "Chantel",
+    "type": "easy"
+  },
+  {
+    "id": "89a641e52993c443b653db0117ada0a769e26f13",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f76d7b8abb63e7d139e9896ce3bae4e44a1a98e9",
+    "name": "Gollet",
+    "type": "easy"
+  },
+  {
+    "id": "d3116c8ca032e9183900e4506bfe07cd352b9dd6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cef3617f1d31e51c9a11baf65943a7a02fe1d480",
+    "name": "Clocheret",
+    "type": "intermediate"
+  },
+  {
+    "id": "d57f607009c955c47e3df707fca2906ad8ae0fd8",
+    "name": "Arolles",
+    "type": "intermediate"
+  },
+  {
+    "id": "10a99366b510556904acf376e67950c502fb4b0b",
+    "name": "Cachette",
+    "type": "intermediate"
+  },
+  {
+    "id": "91f9a0216907379e193418a24cd2a5005f55b0cd",
+    "name": "Pollux, Colorado Park",
+    "type": "easy"
+  },
+  {
+    "id": "00dbcc0d96f4b7e6bbf49063644a89e4125887d7",
+    "name": "Pollux",
+    "type": "easy"
+  },
+  {
+    "id": "3fb456d10d790c86e135363d39e593c5b36be901",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b201e59554eb6fb3df20fbaf6d6919071bc0bb02",
+    "name": "La Jaccotaz",
+    "type": "easy"
+  },
+  {
+    "id": "c0592fa96b7e5f0e3693710019dbbec1e4c1ff73",
+    "name": "Replat",
+    "type": "easy"
+  },
+  {
+    "id": "e57c23daf69ba6518bb14bbc39444244cb357cbf",
+    "name": "Golf",
+    "type": "easy"
+  },
+  {
+    "id": "6589e298827357983094c0bf4ccb255437ff61fc",
+    "name": "Mur des Adrets",
+    "type": "intermediate"
+  },
+  {
+    "id": "c0142110e5718d1ebfec5772357b96baf253cbad",
+    "name": "École Aime 2000",
+    "type": "novice"
+  },
+  {
+    "id": "83926894707f6eaba61a7295350e081e06443c37",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2462d3ab1b4c5f77aaec2355854a5adb16e3d883",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "8fdd2611847fb2f78e691cfb00cbf1eb59f5441d",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "e1a9af2bf61594d11316c6a5ede9ef3a83d06baa",
+    "name": "Arandelières",
+    "type": "intermediate"
+  },
+  {
+    "id": "9f5a624802e835362de8631a5ebe422838646eb0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c79f413dae7f56bb3d030fbf2dc09a4ed99c9117",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "54778d866f7f93b48929d7888941fb7a9262f3a2",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "609dd38cc2bc45cd658f7063b6615401660792fb",
+    "name": "Dérochoir",
+    "type": "advanced"
+  },
+  {
+    "id": "3d6806e3999c198eec9e2b907c6737b35f7efbac",
+    "name": "Loup Garou",
+    "type": "easy"
+  },
+  {
+    "id": "e9fb38d0d4827c1f71354204e0af7dd628e18cbf",
+    "name": "Morbleu",
+    "type": "advanced"
+  },
+  {
+    "id": "5704fd23a79ca3f87c22469867722faa4cf82489",
+    "name": "Route des Bauches",
+    "type": "easy"
+  },
+  {
+    "id": "f963c2cb67dfdc6f4a7372f7b3b5f50b6af4fe28",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ddd8fc7a014ef4b795925e1b0d61f5f8065ae60e",
+    "name": "Combe",
+    "type": "intermediate"
+  },
+  {
+    "id": "2ecac112a15f0eeb472fa626522d8745e51376ca",
+    "name": "Liaison Combe Ecureuils",
+    "type": "intermediate"
+  },
+  {
+    "id": "f36af93ea81c36287599819543e25d32809e8bfa",
+    "name": "Gavotte",
+    "type": "intermediate"
+  },
+  {
+    "id": "f1b05bec0253c91530afd7dd092e4f98e9764e39",
+    "name": "Grande Pente",
+    "type": "advanced"
+  },
+  {
+    "id": "5e3eee9b7cb6bef747f6949fa7808b65b3cc571f",
+    "name": "Lognan",
+    "type": "intermediate"
+  },
+  {
+    "id": "e75b30603ab2b9806eb788ac9f98773f966b0392",
+    "name": "Le Tunnel",
+    "type": "easy"
+  },
+  {
+    "id": "2a8ea99df1cf7c6b9d203fbbc21dfa3301aa0875",
+    "name": "Le Tunnel",
+    "type": "easy"
+  },
+  {
+    "id": "90dda4c9cb5d4dba1baaf20a79f4cc99bdc4071f",
+    "name": "Les Dunes",
+    "type": "easy"
+  },
+  {
+    "id": "6e775fb94d073496095f742a26bd883257bd7491",
+    "name": "Mont Saint-Sauveur",
+    "type": "easy"
+  },
+  {
+    "id": "9e8377ad392f1d49d7417572e45d460ee973f7ff",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "599c0075f127fc0c16691043fed12dc4430a8323",
+    "name": "Rochette",
+    "type": "advanced"
+  },
+  {
+    "id": "1fcafc7cd27a14675587ae44ce8669335a527693",
+    "name": "Verdons",
+    "type": "easy"
+  },
+  {
+    "id": "1434149892633c027ae46cec666cbc956c8dcd5a",
+    "name": "Gavotte",
+    "type": "easy"
+  },
+  {
+    "id": "ea64a076961ceeb28e3967ea5b91eec10d884c43",
+    "name": "Lanche Ronde",
+    "type": "intermediate"
+  },
+  {
+    "id": "65a364daca82ba4f100ad6d9f33a6c47e4d74f2a",
+    "name": "Boulevard",
+    "type": "easy"
+  },
+  {
+    "id": "56dd045ddbf09d774f202661c078945548eb0a21",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "318ac7953362c1a3772f413df303e079d0262722",
+    "name": "La Frête",
+    "type": "easy"
+  },
+  {
+    "id": "d4684fa5af343ee2c7f760842a424627bc46f394",
+    "name": "Rêches",
+    "type": "intermediate"
+  },
+  {
+    "id": "63c1522f1111059d9b6c64907754d9531c38218e",
+    "name": "Villaroger",
+    "type": "easy"
+  },
+  {
+    "id": "ba3626d715587130ee094978dc2fa51968e41c6b",
+    "name": "Accès Plan-Peisey",
+    "type": "easy"
+  },
+  {
+    "id": "d865d37bddf991351e86cea0a9d226cced310815",
+    "name": "Fond Blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "5943f55f0530c2761de5178a1ab6016a035fa8c8",
+    "name": "Accès Village des Deux Têtes",
+    "type": "easy"
+  },
+  {
+    "id": "abb40902c9760b1b55c504df17c6428585894db6",
+    "name": "Accès Arc 1600",
+    "type": "easy"
+  },
+  {
+    "id": "3f2b053e32a84212c1d56b77531916b06d800ae6",
+    "name": "Jardin Millerette",
+    "type": "easy"
+  },
+  {
+    "id": "861e7ef02b3466838a842306ce7ae93fb18b4d1a",
+    "name": "Bois de Saule",
+    "type": "easy"
+  },
+  {
+    "id": "13343cb9ae20e429847757842f9edc652c91aac2",
+    "name": "Les Granges",
+    "type": "intermediate"
+  },
+  {
+    "id": "dddf821938d2f9a61cdb46d07b803e4b9c7a9435",
+    "name": "Saint-Jacques",
+    "type": "novice"
+  },
+  {
+    "id": "e4e0a2ae1f8a57e77bba9db5ec055774bebcc8ec",
+    "name": "Accès Arc 2000",
+    "type": "novice"
+  },
+  {
+    "id": "bfd1f444cd1d78d7df6898685997f025b3947052",
+    "name": "Marmottes",
+    "type": "easy"
+  },
+  {
+    "id": "a47aeaaa57975e0effda34360ae009ddb9d5ba70",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3d96dfa23b51de05986d2543b0f4af3edc101645",
+    "name": "Chalets",
+    "type": "novice"
+  },
+  {
+    "id": "57e93bfe21a91f3e05ee6b63d360e9d24f1d026e",
+    "name": "Dou de l'Homme",
+    "type": "advanced"
+  },
+  {
+    "id": "b7f6110bee77fce786c09aaf4a2beb745c7ffbde",
+    "name": "Vers Crêtes",
+    "type": "freeride"
+  },
+  {
+    "id": "a3d4dfc61ebd0355460fd6f5001e3cce0208a9cc",
+    "name": "Crêtes",
+    "type": "advanced"
+  },
+  {
+    "id": "5494eec6ccd0315e14c871f81cf4dcec5c776262",
+    "name": "KL",
+    "type": "extreme"
+  },
+  {
+    "id": "a3ec5f16fa368e799a1b907c90f010fef7ebcf48",
+    "name": "Bellecôte",
+    "type": "expert"
+  },
+  {
+    "id": "b7eb924c8ea2e84420573aaa3f172c37164a49c6",
+    "name": "Le Rochu",
+    "type": "expert"
+  },
+  {
+    "id": "d6642f86d30dc05483f8e32f4625b4c65167f5ff",
+    "name": "Variante Mont de la Guerre - Liaison Les Bois",
+    "type": "intermediate"
+  },
+  {
+    "id": "f501475f866deceb52e3098e47d624cb91ca6e0e",
+    "name": "Variante Mont de la Guerre - Liaison Les Bois",
+    "type": "novice"
+  },
+  {
+    "id": "9222ed4d56d3c765be28a2229ecff9b89ffdd314",
+    "name": "Colorado Park",
+    "type": ""
+  },
+  {
+    "id": "051e07826da95f0ea9676dc37d47d264dc07ab62",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "dfba4868b2ca3531777c18d87222d7b6d7380745",
+    "name": "Hara Kiri",
+    "type": "intermediate"
+  },
+  {
+    "id": "f80da99178d39a09c5162041bd554ac107019efe",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "984403ae51ac9d3c8b836de0541b92dce68cce05",
+    "name": "Chevrette",
+    "type": "easy"
+  },
+  {
+    "id": "c5a6fe514a0de0c05f0a5b7c637c1e3a3d7a76bd",
+    "name": "Praconduit",
+    "type": "novice"
+  },
+  {
+    "id": "a4a75ba920552d15de0005ac728cba658576b0d6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "66bb65110fcfdb439bb70567aced3d779be18b69",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9992d62f934ba961f2314b93821a26f6f13073d0",
+    "name": "Boardercross Plan Leschaux",
+    "type": "easy"
+  },
+  {
+    "id": "14f57b3f96ae31e4529650f22d8060b438137081",
+    "name": "Route des Bauches",
+    "type": "easy"
+  },
+  {
+    "id": "cc8df5a1183eac3436a48b84ca2f9a540355a0e3",
+    "name": "Ourson",
+    "type": "novice"
+  },
+  {
+    "id": "eadf6d9a422082ebe6c108ea68556a3ca1a9b408",
+    "name": "Vega",
+    "type": "easy"
+  },
+  {
+    "id": "791a515944573f8252cc6d74d8a3bb0f819d27d0",
+    "name": "Rouelles",
+    "type": "expert"
+  },
+  {
+    "id": "2575d130a302646fe36480d24712988f6599a332",
+    "name": "Lutins",
+    "type": "easy"
+  },
+  {
+    "id": "a54feb128b0a67368e944a5b020aadc19b5266c2",
+    "name": "Aiguille Rouge",
+    "type": "advanced"
+  },
+  {
+    "id": "a72b11b18faf956875026b29c71497770e095626",
+    "name": "Tuffes",
+    "type": "intermediate"
+  },
+  {
+    "id": "4ce838bb18257597627919c271fb49dbc6ba9c01",
+    "name": "Blanchets",
+    "type": "easy"
+  },
+  {
+    "id": "4013e337484b3709e519e3c2c5cc07e1ee0b7177",
+    "name": "Blanchets, Les Ours",
+    "type": "easy"
+  },
+  {
+    "id": "cb4375eae8e94eba4aae40bb4f5987bee8bc9237",
+    "name": "Blanchets",
+    "type": "easy"
+  },
+  {
+    "id": "9a61e5d73f28e0aea596fe892f3cda32710612e0",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "3b78f3a0bcb19d3dfdb97a6dbac7c80d763b2b2b",
+    "name": "Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "18824335e0a0bf03830fe314bb4f8120b36728a6",
+    "name": "Clapet",
+    "type": "easy"
+  },
+  {
+    "id": "850ca81bf96415a0820171af98b6fc6bbe0910a8",
+    "name": "Combettes",
+    "type": "easy"
+  },
+  {
+    "id": "027885bde3f15cab6e4d89d5fe78b5668f19a50f",
+    "name": "La Mio",
+    "type": "advanced"
+  },
+  {
+    "id": "f2de7d4bc9647b59dc86f6aab538e27441a1ebd0",
+    "name": "Les Leitchoums",
+    "type": "easy"
+  },
+  {
+    "id": "fb35f34a81e1b6dbf1999825d462745a25916d70",
+    "name": "Levasset",
+    "type": "easy"
+  },
+  {
+    "id": "4906100ff9412fa7ce324deda6e0234afa725daf",
+    "name": "Les Bois",
+    "type": "intermediate"
+  },
+  {
+    "id": "07f36a67172d00db4df0a536e469fc04962586ec",
+    "name": "La Combe",
+    "type": "intermediate"
+  },
+  {
+    "id": "9957730f8a0be4095f8625996441e1a9534c0206",
+    "name": "Bois de Saule",
+    "type": "easy"
+  },
+  {
+    "id": "403227d31220390101bde0e447d918446634acb9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "faf134861c394822fe8a8459e8664912f296b3a8",
+    "name": "Les Borseliers",
+    "type": "intermediate"
+  },
+  {
+    "id": "e1335b779af9fac5984497153a3f33052298309f",
+    "name": "Rossa bas",
+    "type": "intermediate"
+  },
+  {
+    "id": "0d0995ac00104ed2b609e5108f3cedda7059a44e",
+    "name": "Bozelet",
+    "type": "easy"
+  },
+  {
+    "id": "39626a7d6a75d1ff472a8b19cda3f3757bfe1680",
+    "name": "Chemin de Blanche Murée",
+    "type": "easy"
+  },
+  {
+    "id": "d0a606dec2673f3f7db937079d5fad224ef99e9a",
+    "name": "Petit Renard",
+    "type": "intermediate"
+  },
+  {
+    "id": "c03af3b3a175ef81acf92be76171929f349c5cda",
+    "name": "Crête-Côte",
+    "type": "advanced"
+  },
+  {
+    "id": "f2024bc07673055894371ce074e91b752d5b86e7",
+    "name": "Refuge",
+    "type": "advanced"
+  },
+  {
+    "id": "3f7ce2676ce0b129cef0827f2585fd59631451c9",
+    "name": "Grand Col",
+    "type": "intermediate"
+  },
+  {
+    "id": "e6f2b2f9cea410cc2f8388cee504b806c596f523",
+    "name": "Comborcière",
+    "type": "advanced"
+  },
+  {
+    "id": "30860693dd67893783b2aa1daf1a3d20679f587d",
+    "name": "Tommelet",
+    "type": "easy"
+  },
+  {
+    "id": "ce67007eded55cca9b760cdf71993af9e1e0e931",
+    "name": "Gollet",
+    "type": "easy"
+  },
+  {
+    "id": "82224887f5c084a3d1489d43372bdeea2cc3f6e3",
+    "name": "Eldorador",
+    "type": "easy"
+  },
+  {
+    "id": "0c0ee5e7b802fe2ca66cbe033b3b9dc417fcf2af",
+    "name": "Liaison Plan des Violettes",
+    "type": "easy"
+  },
+  {
+    "id": "ee4641ac33e1dc5f3376a487bcc42a21f4edde2a",
+    "name": "Planay",
+    "type": "intermediate"
+  },
+  {
+    "id": "81f634afb37763fcf6fbc696e9a89e6acd8fbe42",
+    "name": "École Aime 2000",
+    "type": "novice"
+  },
+  {
+    "id": "35d4638ed580cc4fccaa79b401d447a47019fb92",
+    "name": "École Aime 2000",
+    "type": "novice"
+  },
+  {
+    "id": "1be96891f4c5ead5bb78a2fc1183df3f93a2490f",
+    "name": "Boulevard",
+    "type": "easy"
+  },
+  {
+    "id": "49ade55f757dcd2deb9389dba0d1c016551b4c4b",
+    "name": "Boulevard",
+    "type": "easy"
+  },
+  {
+    "id": "445a64036c1ff15a91520b3be43da2e088513767",
+    "name": "Route des Mairiers",
+    "type": "novice"
+  },
+  {
+    "id": "f783ff6f291bb64c27e80201ba5e1a1f58947dcb",
+    "name": "André Martzolf",
+    "type": "intermediate"
+  },
+  {
+    "id": "2a418bd5e61b57a096f0071e593eca6a0932c1af",
+    "name": "Aiguille Rouge",
+    "type": "advanced"
+  },
+  {
+    "id": "665c5555f76076a96242174f43f0272b8e7bbd72",
+    "name": "Robert Blanc",
+    "type": "expert"
+  },
+  {
+    "id": "d4eccb4ac99e303d1a4466852a8ab4d2af525317",
+    "name": "Lutins",
+    "type": "easy"
+  },
+  {
+    "id": "5b89c2745ea712fc135b807550f7c3cd68cde75f",
+    "name": "Lovatière",
+    "type": "intermediate"
+  },
+  {
+    "id": "fb23bf4adaec58772e5a745a058cd6d28d112e19",
+    "name": "Liaison Mélèzes",
+    "type": "novice"
+  },
+  {
+    "id": "5719a33a638657707ae22206deec5e803c4af912",
+    "name": "Boulevard",
+    "type": "easy"
+  },
+  {
+    "id": "5e4289a3b6150a791715c6dedd518ae19460fc06",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "deeefce730f8141da4f196f62ba9be13388f3b1e",
+    "name": "Émile Allais",
+    "type": "intermediate"
+  },
+  {
+    "id": "99cb07bc1b5f2816d8800b499a57ee723b1b0f80",
+    "name": "Cornegidouille",
+    "type": "easy"
+  },
+  {
+    "id": "d2f302d0a166d2c770a8bab0423aae75ec2376ee",
+    "name": "Golf",
+    "type": "easy"
+  },
+  {
+    "id": "05e2a0206d67a2661f0e9dfcd5ce27c63cd3d585",
+    "name": "Apocalypse Park",
+    "type": "intermediate"
+  },
+  {
+    "id": "5945d1ae3c866dc49e8464a750816a3e0cc86e24",
+    "name": "Tommelet",
+    "type": "easy"
+  },
+  {
+    "id": "6346453564d559cb0f2feea048e9322f94aac5b7",
+    "name": "Stade Vezaille",
+    "type": "easy"
+  },
+  {
+    "id": "3ee7d8867025b0edd66a63097ecccc3e8c6ac1e0",
+    "name": "Bois de Saule",
+    "type": "easy"
+  },
+  {
+    "id": "5d14e9885499ea63ef31de14c1487b99052a9ceb",
+    "name": "Crête-Côte",
+    "type": "freeride"
+  },
+  {
+    "id": "9407485dec865ab0453d933d5c92796ef2f99c9d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c0e51db7c74214fbf5bed5b4111147b5dd31622f",
+    "name": "Bozelet",
+    "type": "easy"
+  },
+  {
+    "id": "5a23e863f7838ce439d3a9204f278d235a58a023",
+    "name": "Ski tranquille",
+    "type": "easy"
+  },
+  {
+    "id": "c6a15de6db82f2a8da2a9eebf8aa6fa78710bbe0",
+    "name": "Dou du Praz",
+    "type": "easy"
+  },
+  {
+    "id": "0f53ec74acdd4745bcff6b84dc93a6867dc2b1d8",
+    "name": "Belle Plagne",
+    "type": "easy"
+  },
+  {
+    "id": "4cdc0254fa0692479dac4ead2083812a69baa6e0",
+    "name": "Belle Plagne",
+    "type": "easy"
+  },
+  {
+    "id": "d73cc44e54aa53821cf1b04d047e1c80ce9dd190",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "732d847bcc2374b65285914c42fa3edcd11ef52a",
+    "name": "Vers Arc 1800",
+    "type": "easy"
+  },
+  {
+    "id": "c67aef0d4b59785eddb7fe290a4f7f9a56e5737d",
+    "name": "Carreley",
+    "type": "intermediate"
+  },
+  {
+    "id": "9cfd29417d6547bff594e4b8500704a730114693",
+    "name": "Gollet",
+    "type": "easy"
+  },
+  {
+    "id": "2ffff3061ba881339fd3e246217d2b8b1224c2a4",
+    "name": "Aigle",
+    "type": "intermediate"
+  },
+  {
+    "id": "7cf7856d48dcb6d169c008bd0f6e841bf1a797b1",
+    "name": "Malatray",
+    "type": "advanced"
+  },
+  {
+    "id": "8528b16c13b8c33ad987c6bb14d97455ed6826f9",
+    "name": "Soleil",
+    "type": "easy"
+  },
+  {
+    "id": "ce7cf40863e5dd5a80c0d26eab2eefe8d8194c55",
+    "name": "Les Mines",
+    "type": "intermediate"
+  },
+  {
+    "id": "68f1c7e8d1504e16efb888e58fe17ff2315af39b",
+    "name": "Charmettes",
+    "type": "freeride"
+  },
+  {
+    "id": "28b64fb9a05b2511f33da2e7f00ac96bce730bd6",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "9d0afed3122cf267964fc77b6bdc1159876700eb",
+    "name": "Luge Villards",
+    "type": "easy"
+  },
+  {
+    "id": "9f0530e190289a1ca1e2f1368853e3d51a6ad8ba",
+    "name": "Luge Villards",
+    "type": "easy"
+  },
+  {
+    "id": "f270b0df9406606c5c84348e694050d1c004df7e",
+    "name": "Les Cabanes",
+    "type": "novice"
+  },
+  {
+    "id": "f77dac6823cd9c51efa265850e050359b0620979",
+    "name": "Pravendue",
+    "type": "easy"
+  },
+  {
+    "id": "3a3aded0cfaf9989047834169c581bc8889ba190",
+    "name": "Pravendue",
+    "type": "easy"
+  },
+  {
+    "id": "21a281f373d2d7d06fc30c9551f799c8b21058eb",
+    "name": "Variante Emile Allais",
+    "type": "intermediate"
+  },
+  {
+    "id": "0fefa853272e610150e0e00103a45406b86c25b9",
+    "name": "Roc du Diable",
+    "type": "easy"
+  },
+  {
+    "id": "b6921ed06a3495d9c61349e7427c4e688d2624ca",
+    "name": "Rhodos",
+    "type": "easy"
+  },
+  {
+    "id": "34e4561a2d9ad0ff8f6183baf7c974bcf78de07d",
+    "name": "Gentil",
+    "type": "easy"
+  },
+  {
+    "id": "115951134268ee06b48cf45683dda3bdbed6992e",
+    "name": "Écartée",
+    "type": "easy"
+  },
+  {
+    "id": "3bc235191001f00ba44839746576d74b27875445",
+    "name": "Tracé de l'ancien téléski des Leitchoums",
+    "type": "freeride"
+  },
+  {
+    "id": "c88b4f0f26322ce8f20fefc5eb2108a16a255c9a",
+    "name": "Liaison tracé de l'ancien téléski des Leitchoums",
+    "type": "freeride"
+  },
+  {
+    "id": "852a197a2e60d4d753fe6fda1f7f53691f5fe926",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "981540ac82df067587585b166f2093fd42b24cbb",
+    "name": "Fornelet",
+    "type": "intermediate"
+  },
+  {
+    "id": "424de8881b769b204c0702dd890a240312699925",
+    "name": "Les Adrets",
+    "type": "easy"
+  },
+  {
+    "id": "8488fdd45675573bb3cd158e8b28c605ecaa8aad",
+    "name": "Prajourdan",
+    "type": "novice"
+  },
+  {
+    "id": "2ef044924002154ad2a0572499a8dac69fe34c60",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "a7bdc4da4cea47524e4c2b3143287fd94ebea893",
+    "name": "Les Cabanes",
+    "type": "novice"
+  },
+  {
+    "id": "474e4e636988aac37f8189de5ad5b543a304cd97",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e30766d0579ff325cba13058166b7996898cfde5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "56fb3355feb7d79dad70e6572ad9af3bd7996e22",
+    "name": "Le Gentil",
+    "type": "easy"
+  },
+  {
+    "id": "b20af438a315c03c23701f6023f6548c3c29b429",
+    "name": "Traversée",
+    "type": "easy"
+  },
+  {
+    "id": "52a91be3e85cb217dd4c83365b02b70444c5afb4",
+    "name": "Vagère",
+    "type": "intermediate"
+  },
+  {
+    "id": "cea776e8b190d38c3e14ba12d933aad41483959b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "35977eee856538d9e023c26785420d81e0b987b7",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "dc7d1dc863c934640b133f269c0ff03065f79498",
+    "name": "Grands Mélèzes",
+    "type": "easy"
+  },
+  {
+    "id": "6971f2a5c06ac9e72556b0abb9d97aa37a215af4",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "611a5797258414914bf2d22474872639043e791f",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "96d8ab64d3c9a6e5e49d09efcb47e2391fa1c6cf",
+    "name": "Clair Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "0736cbb79c7f1ebe812613cd6963dc5564f792c0",
+    "name": "Col des Frettes",
+    "type": "intermediate"
+  },
+  {
+    "id": "6718faa38156f5978527358af9ce16825306f4e4",
+    "name": "Snow Park",
+    "type": "intermediate"
+  },
+  {
+    "id": "881f46fe1c4b0b530f3c1b3fbc2218313c84980a",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "65eee794cea72d33e46e7254b25c40f9a9c782c8",
+    "name": "Plan-Vert",
+    "type": "easy"
+  },
+  {
+    "id": "54375b3e290aa4b622be083145693c8431fa95f5",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "867f5d89866ec90e26152a810a48e5eb32fc1aac",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "a33c3fe77d4a3762b28e7c3ff43b0ca5bf18953b",
+    "name": "Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "bf4159caf1370213ed606fd6897b0df81e790d38",
+    "name": "Aiguille Rouge, Lys",
+    "type": "easy"
+  },
+  {
+    "id": "ef524115160c7c137bde1a8044a5909c8ef3b4ba",
+    "name": "Accès Centre de vacances Jean Franco",
+    "type": "intermediate"
+  },
+  {
+    "id": "d0e2bf8f94645ca77b159bcf9ba7d4e14c5b6a99",
+    "name": "Montalbert",
+    "type": "easy"
+  },
+  {
+    "id": "d14491ff3b66fcb867f8ba99d2abb2132b786fa0",
+    "name": "Fornelet",
+    "type": "intermediate"
+  },
+  {
+    "id": "fca6972a30a762ad0aa8cfd31bc73f163d4aa268",
+    "name": "Montalbert",
+    "type": "easy"
+  },
+  {
+    "id": "82d5c007e8efcfe982c2d51830d2809b79e9e0f3",
+    "name": "Montalbert",
+    "type": "easy"
+  },
+  {
+    "id": "99ae1d0258f852acfbc0004561d11aedabbf785b",
+    "name": "Lac",
+    "type": "intermediate"
+  },
+  {
+    "id": "99f009e5168bdb0db7edb9fd87b8a8c3b95bcacd",
+    "name": "Belle Plagne",
+    "type": "easy"
+  },
+  {
+    "id": "2dd6cbffb1e04e93c4159d86d5bd94ff0ed656eb",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d8aea350f86f8305bb6b44863775869ca8e3d892",
+    "name": "Arolles",
+    "type": "easy"
+  },
+  {
+    "id": "fa56dd4541eebbf0dc9082d1dac04d540c475f56",
+    "name": "Belette",
+    "type": "intermediate"
+  },
+  {
+    "id": "d64c0f4c82606cd95b39859866b57bc0abf3cff8",
+    "name": "Pralioud",
+    "type": "easy"
+  },
+  {
+    "id": "7969bad400a61438de8b1182020c92e02fb5bc84",
+    "name": "Palsembleu",
+    "type": "expert"
+  },
+  {
+    "id": "ff51c9f8872ddd0cc6e8fbaf406dee507d2dcdcc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "43373b1e369299edda15675afb031f4e97e029de",
+    "name": "Montchavin",
+    "type": "intermediate"
+  },
+  {
+    "id": "440308414acd05c955de90e0be2c8fabf8ed95fe",
+    "name": "Montalbert",
+    "type": "easy"
+  },
+  {
+    "id": "64173e2d4901fae863352b015911edc12d9bea5c",
+    "name": "Plan",
+    "type": "easy"
+  },
+  {
+    "id": "ecc67c3f5371a37a81e97b347deb03ecba94aa57",
+    "name": "Ravines",
+    "type": "easy"
+  },
+  {
+    "id": "a281c118092212eb40a8ae490cf3022cda48d20e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "07a39c6de53f84c2c4b1b9ebd03ccb761917002c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "efe2bf15749b4ef20fb4060b5e720ed8bca7a7ac",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c29b2b900ff0cd1b8715266f5ca666f89b79b29b",
+    "name": "Les Halles",
+    "type": "easy"
+  },
+  {
+    "id": "200a003f58d699fceeb87472a530b1ff78e77393",
+    "name": "Gavotte",
+    "type": "intermediate"
+  },
+  {
+    "id": "dffd6fad618f7db8b3fbd24a8514f34279e2aca8",
+    "name": "Les Coqs",
+    "type": "expert"
+  },
+  {
+    "id": "7e420760cc08eedf4128829b0b189ab2c715cad3",
+    "name": "Stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "8f0835256e3c236fe525452956fffcfb234c5746",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "def887c414f57c6ec755b312a259fc669e586166",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "95e70f433aa4da08e18ab0f7ffcd02692db0b3bf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8717e7196da04e595d36d408c77538eeba36722a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9dd9d0251d0afb30195edf5cefdec19275e46075",
+    "name": "Arolles",
+    "type": "intermediate"
+  },
+  {
+    "id": "49af903e2419c033c797332e3b3d276efb9228e9",
+    "name": "Mont-Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "3d55015ca457be81279771833feef5dded2f009f",
+    "name": "Plan Bois",
+    "type": "easy"
+  },
+  {
+    "id": "0e93bdf4fcd3e52a194ad906820ebba12ae66a17",
+    "name": "Plan Bois, Myrtilles",
+    "type": "easy"
+  },
+  {
+    "id": "4427beb3a4b7974b0e3c66d410f99eb43887cc43",
+    "name": "Plan Bois",
+    "type": "easy"
+  },
+  {
+    "id": "f168271d8296e5fbb393cc20f2cecc0044d5dd18",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "df0abad577c59ac04fe7767da0e1c9f687aa89aa",
+    "name": "Clair Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "141bf5cc18622af9d98de51455fbcbc8eae36fee",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5279ecc69e7c68351ac1515d34ab6c099a3e6fec",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2c4200637568c8dd975c6b3654c05977610792f2",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "26ac5ff559c53f51b35ef7576ccd503ddeb31a52",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "543a2acaf1a180c718d2d1b029be1f89dc264efe",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "075b7ef5e2c54d94fa5253e864e300a9479a073a",
+    "name": "Vallée de l'Arc",
+    "type": "easy"
+  },
+  {
+    "id": "791336c2df5ec10d40b28475def5786b1056f69e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dc4a942b5e051251531508a767ec0d883ae7dafc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "daed35f6c19619a87cb94768cc61701367db0ee7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a0496605abccfdd2dc72a715dd3f9779e8fc6020",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c4f290310d2b6fc517d733b02867bf3c6a77a8a3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f85cb969f70aad760c0f3bf1297ca59007e1fc35",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "4e19c67709682eaa22d660d05b10775492f28eaa",
+    "name": "Les Ours",
+    "type": "easy"
+  },
+  {
+    "id": "efe167d532f987951b50be7db21d65287222b2ac",
+    "name": "Les Laines",
+    "type": "easy"
+  },
+  {
+    "id": "0014ab5da7b3f0f1d801cbc2945a4d77db527909",
+    "name": "Rue de la Piste des Étoiles",
+    "type": "easy"
+  },
+  {
+    "id": "df3731c01d7dc19bfd722273a9686216a0e43d1c",
+    "name": "Arc 1950",
+    "type": "easy"
+  },
+  {
+    "id": "92dd0e77e69c4598069b03e18856b7d4f50cdac8",
+    "name": "Rue de la Piste des Étoiles",
+    "type": "easy"
+  },
+  {
+    "id": "f02a793fcb07264fe9b05c63444db32efd582326",
+    "name": "Rue de la Piste des Étoiles",
+    "type": "easy"
+  },
+  {
+    "id": "5e8c2699d5334f96dddd2e7e1694159c3f26e013",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9e0b11526093fbaea93c3901343ced51352a0551",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e1af6d01c438efadd7e6d7c4c9e85b4c0a1e3cfe",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "5e43096acfb5e9c0ab06c0d1462c62afa3c42a4e",
+    "name": "Vallée de l'Arc 2",
+    "type": "easy"
+  },
+  {
+    "id": "22bd33b91e8812b82cbb7c82c1b1264a2344c93a",
+    "name": "Vallée de l'Arc 2",
+    "type": "easy"
+  },
+  {
+    "id": "c448957be345b2955763817229225bb143a43bd8",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "0cc52297481738ad9a15b4c2b4eaeb3c8156263d",
+    "name": "Plan",
+    "type": "easy"
+  },
+  {
+    "id": "e0cdd2270916defc7e4fd487860b4cc08d0adf93",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "0bec8fef87ac1c38caaedea6f0d47e89d0a6e80c",
+    "name": "Plan",
+    "type": "easy"
+  },
+  {
+    "id": "9db77a82b62ca35f248b64c7ccfd32576c534ec9",
+    "name": "Route des Chalets de l'Arc",
+    "type": "easy"
+  },
+  {
+    "id": "c9e1e3ad23db822c4c87a9342fe85f578b22811c",
+    "name": "Route des Lanchettes",
+    "type": "easy"
+  },
+  {
+    "id": "9249ad6551145290ab46e6b2fb11ac0e8ed5b514",
+    "name": "Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "85f9812fc5f750419405883e27077a718f118b98",
+    "name": "Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "7a8d502533ffedbfda61a050e389896c2fe0f2cf",
+    "name": "Arc 1950",
+    "type": "easy"
+  },
+  {
+    "id": "9e8f6103dff98940bfb9b5170686130474584e63",
+    "name": "",
+    "type": "freeride"
+  },
+  {
+    "id": "aadcbd9ab2de8e81ac1d5b573ea3bab16ebee37f",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "e8e6915096a1353961443f37238235e1e16abea6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f249d78f66114f7b17f2dbd53182301c16fa5e24",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2048e8f93534ff8fc7254861a36f2e4f23548ce5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "39dcd50263c8f2081bced431ee67f765836a2ee6",
+    "name": "Carroley",
+    "type": "easy"
+  },
+  {
+    "id": "472e8ce4d9b500397d98ddf358748c345601721e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "919750047734739542885ee58518f3b534328619",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1daef69f65c7b9843bdb61f0077fdea80308cb27",
+    "name": "Éterlou",
+    "type": "easy"
+  },
+  {
+    "id": "08447e0e9119635ac75ad44c662d51dfc22ead62",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6a2514d894dfb32e4c97ecca9f8743f6954b13d6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8cf6c9cedd884f47951bd86cbca85c6ff7d06f39",
+    "name": "Les Arolles",
+    "type": "easy"
+  },
+  {
+    "id": "4af0099189b6be2c1e7e2c0c9e38e679d5dcb624",
+    "name": "Les Arolles",
+    "type": "easy"
+  },
+  {
+    "id": "95d528372e02f631009dacc44609940bebed1547",
+    "name": "Marie Chantal",
+    "type": "easy"
+  },
+  {
+    "id": "51746eea05fb3e5455320dba0c91c6a449fc459a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "37e51a581f15070f8196036b3119fc2aea6fdb73",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "c679705371a13c20499119598b7f1caf4f054991",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "d327064122719580919ff538ac7c0d7c3f051560",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f01c882f218db826e2cfcce19f17ce8b7c9543f1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b314e6586b9b60b486370538f799b71ee1efd6ba",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "931e7bfa23fb5568c1a0700795066ffa85107972",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d334b826c2edf889f7f0d0a7a4480f5ec7363014",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "27a0d148b70942e3941a5ba1b18243107a38642a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "189c5818afd206f1ef91699ccb57fd3ef710b5c7",
+    "name": "Crête-Côte",
+    "type": "easy"
+  },
+  {
+    "id": "fb58e257bd8f60623634813dec7b3b885c9f8365",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "40fbfdf62304f53e0a238625f70a1f75afb3dc50",
+    "name": "Crête-Côte",
+    "type": "advanced"
+  },
+  {
+    "id": "c8b8265420ccaad16390ea344624a5cd77eb7936",
+    "name": "Variante Emile Allais",
+    "type": "easy"
+  },
+  {
+    "id": "8fb9c477dff1bd9bde07d248d292473e45e61d6e",
+    "name": "Variante Emile Allais, Émile Allais",
+    "type": "easy"
+  },
+  {
+    "id": "7d00015c3efa28b0fa006c0374ee48547f5e461c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c7ce78d5a334f00f61462f34d5e3710f6b6654ea",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0f3fe43c5942ba23ad877e860ed7db463413d80e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "4247240dcf19337464c105110a31ffe7677b269e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1fe40a9a112dcdd1cd7a6d29704bf9caf3e94241",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5dd7ec5c628ca166e65d000190f92a0a31ce4f6a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ec69bcdeedf35ce7e48fdbdca541178edff30eac",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "ab7ab80cb61c9f71a6d418d01cc17b70e9dea89d",
+    "name": "Ski de bosses",
+    "type": "advanced"
+  },
+  {
+    "id": "1606205555e01ae895a39971928b65e07ba0889e",
+    "name": "",
+    "type": "freeride"
+  },
+  {
+    "id": "9129e9a32764b3ddc265f62067fd73e345ad6def",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "699f68936c86fcca676b59a3bfa5d491eafccab7",
+    "name": "Les Ours",
+    "type": "easy"
+  },
+  {
+    "id": "d1a87ef1ef783739708a8577dd0f191d0962380a",
+    "name": "Les Ours",
+    "type": "easy"
+  },
+  {
+    "id": "cbf66a5ff83e7dbb88ab145e57473468a278b4df",
+    "name": "Frisbee",
+    "type": "advanced"
+  },
+  {
+    "id": "5de4037ddf33110ccaf774385a396c0a4a7f470a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7d843da0ecf8b53dce2c3574d3fccf317e3ff7a0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "685f41b69ac9bc9abcce7afb954c382775c6b2b9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ce342b2c0bbd7803114a1a4456df3d45cfe8b28d",
+    "name": "Stade de slalom Jean-Luc Crétier",
+    "type": "intermediate"
+  },
+  {
+    "id": "f02b1c5e19ee4b40b5167d4b9fdfac81c782b762",
+    "name": "Accès télécabine Glaicers",
+    "type": "easy"
+  },
+  {
+    "id": "c75e6ee8153aa753f6a9dfd7aee0e42d3e53a219",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2c79d76988a4901acda173a530aa46691fc7b379",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9e8189956e1b5ca331b002b86546f60a43b55415",
+    "name": "Secret",
+    "type": "intermediate"
+  },
+  {
+    "id": "85b03691cc8da1cce1474f0f08bc3d911bc36a88",
+    "name": "Pré",
+    "type": "easy"
+  },
+  {
+    "id": "7d049506f199a873e06d811f2afdae06ea13852f",
+    "name": "Malgovert",
+    "type": "advanced"
+  },
+  {
+    "id": "9eb6858e8f5677a57ed99dbde6f9033819896105",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a37ff015966ec72121f8451cd0129a1aad988368",
+    "name": "Muguet",
+    "type": "advanced"
+  },
+  {
+    "id": "e730100e4c20687f161258f85f2fc92f86dce00d",
+    "name": "Arc 1950",
+    "type": "easy"
+  },
+  {
+    "id": "550ad28a7e0d769d35038fc87f0afa105d945914",
+    "name": "Rossa Bas, Rossa bas",
+    "type": "intermediate"
+  },
+  {
+    "id": "af2b9e451e1aebc36a470b7a7ca7e2fbea866e03",
+    "name": "Rossa Bas",
+    "type": "intermediate"
+  },
+  {
+    "id": "dcf616a2728f1c0dc9a7e71b930564afc2ef9ed7",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "185348c60e43434bdfcdddbd5550a98a43097950",
+    "name": "Écartée",
+    "type": "easy"
+  },
+  {
+    "id": "2aad936ab2cf36651592fea5016b76513b9007ab",
+    "name": "Soleil",
+    "type": "easy"
+  },
+  {
+    "id": "3e44a0afcd1de4aa3eac735b6ff4ab114642c524",
+    "name": "Biquet",
+    "type": "novice"
+  },
+  {
+    "id": "e5fda0b6c3db59ba64f5fc67dd90acd0d9e45653",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5780cf2c89776e2f0c55c59175e54efd8c2cc06f",
+    "name": "Kamikaze",
+    "type": "intermediate"
+  },
+  {
+    "id": "a6f3f8e1110c734d1ab2df96c93e99563a54f8cd",
+    "name": "Petite Rochette",
+    "type": "easy"
+  },
+  {
+    "id": "2836e5ed7efc0cbf8f72aafe9388b7a567051e79",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "55d9327926f4a934c95a9941829406be5200219d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "39a4e7f14509a2488e8ea64567bc45e87a5f2955",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6846fa6831979df8713463b3140dd13044994592",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6f305a64ce63a7d06698dca890d8415480a20730",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2976acbdc3572bb13cd66f03cc3018e4179f231a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e8ac386958ffdabcc040d620a280c2fed340ab8d",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "afcd8f90a5eb86c5b47f2a4f0ab3fb7f9a80e6d5",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "9a204d2aad8527780c346ce6ef805d9a735c3775",
+    "name": "Dérochoir",
+    "type": "advanced"
+  },
+  {
+    "id": "038b65d6457de669520fe089671a0baa98185219",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4d4de9031c61b4af510cc2d4e4e66e927fc33d32",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "274cc4454751cf9af943fe37098f9f4f60c89d33",
+    "name": "SuperSlalom",
+    "type": "easy"
+  },
+  {
+    "id": "c67b14a3ffccef9a14c1e134c2774cb8fe936e46",
+    "name": "Edmond Blanchoz",
+    "type": "easy"
+  },
+  {
+    "id": "f956c9d3e17876b216bf46e6573bf9077b7cb216",
+    "name": "Retour MMV",
+    "type": ""
+  },
+  {
+    "id": "93fd0c8e116a97754bef391e32ab234e852d3c8e",
+    "name": "Départ MMV",
+    "type": ""
+  },
+  {
+    "id": "c6e483a19d8475953856d367c0955f6a09e367ff",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "b8bf12b96d95172f5ea5fa34599520f529e29aea",
+    "name": "Aiguille Rouge",
+    "type": "advanced"
+  },
+  {
+    "id": "56bd67bd0915bc0ef1adfce3d60b61ad758a40e0",
+    "name": "Retour Lagrange Vacances - Aspen",
+    "type": ""
+  },
+  {
+    "id": "82dd06fffc74a238ae1545237d3a6d2de5340422",
+    "name": "Accès Colorado",
+    "type": ""
+  },
+  {
+    "id": "a6860d2fa0adeb7980acac0bceae49c70cdbd3e0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a02f667a9efb84a5dd5997544d89cbff5070120d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e2724c0ef1eed643454be52007ece68af3316e8d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bb96057f77bab2949bc0f3320cbae4c00fbdf831",
+    "name": "Prajourdan",
+    "type": "novice"
+  },
+  {
+    "id": "e720cece1aa9df6facebdb60f5cd83ca085cea5b",
+    "name": "Montalbert",
+    "type": "freeride"
+  },
+  {
+    "id": "d2d1bcb177f9028059a8fcc9ee4046c8c6f700c4",
+    "name": "Émile Allais",
+    "type": "intermediate"
+  },
+  {
+    "id": "5c75dbb420a2c64e99c7ed7a1ee353757e8b5cb2",
+    "name": "Émile Allais",
+    "type": "intermediate"
+  },
+  {
+    "id": "7a7a6e8571375a2682e690c865da4a9c0ee9c490",
+    "name": "Golf",
+    "type": "easy"
+  },
+  {
+    "id": "7f8a50fca6e6b4905b121c0c94c1a4370505e947",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e96927e86766d6ef7a2de8ac72ac9ec4b119aaa7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "560a08bdc9143035e05ae1e56a5b9fb91f2489df",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "43f047f54ab413b900a0efcf33cc97aaaabcf215",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a420e1a7f02bd662339f1da64e0b7955f2ef9b33",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7fac1a4a5a6428006e3c37794c6d48fb265832e7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1d882f8f14795a032493b84dcb4c3fce56d927e0",
+    "name": "Liaison Combe Écureuils",
+    "type": "intermediate"
+  },
+  {
+    "id": "5e7f48a3f18f31b6be895a760956a88954093065",
+    "name": "Poney",
+    "type": "easy"
+  },
+  {
+    "id": "c8273ef50d430e0696696feda2785fdeda579bb6",
+    "name": "Poney",
+    "type": "easy"
+  },
+  {
+    "id": "e3bcfed3679f8dac80bde7d0f293b7cb2278224a",
+    "name": "Retour Plan Peisey",
+    "type": "easy"
+  },
+  {
+    "id": "622820fbc26585bc914e76b116f242d6a17b504e",
+    "name": "Liaison Grizzly",
+    "type": "easy"
+  },
+  {
+    "id": "4adb699a3d2a81a4c32d0f77a37ad952ffb1277e",
+    "name": "Liaison Grizzly",
+    "type": "easy"
+  },
+  {
+    "id": "63e3d7ba37c1cc7dfe8d6c9e2a89854328e790a0",
+    "name": "Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "af997819f1e0d9239dff66e06ed5ef3f104faac4",
+    "name": "Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "e164118386142a48bcacab4803eaffc96d36570c",
+    "name": "Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "4950a3a3cd04136efb32bc9a6a5631d09410a1e9",
+    "name": "Traversée 2",
+    "type": "easy"
+  },
+  {
+    "id": "27e3f5dfa0e2eabbdbb5b631e9c9e53ca1597e23",
+    "name": "Myrtilles",
+    "type": "intermediate"
+  },
+  {
+    "id": "75028765a78048369eda280747524098dff23ecb",
+    "name": "Barmont",
+    "type": "easy"
+  },
+  {
+    "id": "e9e3855c57b3593c6533cc82561d73588ca56a16",
+    "name": "Plan Bois",
+    "type": "easy"
+  },
+  {
+    "id": "2d33c4a950d17c19139c937b8d01c148ede730d6",
+    "name": "Maïtaz",
+    "type": "easy"
+  },
+  {
+    "id": "2de5f0c6ad96d58f340741734cf425636c955cb1",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "db4f7e417803691b239c35d788fdcbd611c32a13",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "d608e81fd88deaffa96d7ac030fb0d84da2ba811",
+    "name": "Traversée",
+    "type": "easy"
+  },
+  {
+    "id": "58446be40916bde7acb392d48546d2b1bff0cfbf",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "3d3eb17516368f5efeebbab5c1fa105358a8eb98",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "8b0e22e52e2d93ebd4a344c334778d1ae2423519",
+    "name": "Arpette",
+    "type": "easy"
+  },
+  {
+    "id": "915dcbe2d07d70867d872f252176b6ee315041b7",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ca945015599873bfdc4ea9a8becc3720d81a5fc6",
+    "name": "Vers Arc 1800",
+    "type": "easy"
+  },
+  {
+    "id": "8000cedf3f8fc32a5c32adaaf8e0386791e622d7",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "3dd3e5066fd4df23e205561f7c482c1fa0690c81",
+    "name": "Mont-Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "05608f2293daa016d213fafbd85ebf7b92ddaf7f",
+    "name": "Rhonaz",
+    "type": "easy"
+  },
+  {
+    "id": "bdfef43aa7c9d09e20b508227c18d4380ed115fa",
+    "name": "Lys, Aiguille Rouge",
+    "type": "intermediate"
+  },
+  {
+    "id": "acb4d355e58a5a4b4f33a75293b7e0c08c77a751",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "64c69ef41f79cb244a4281fb061a8c00dd5b1bdb",
+    "name": "Villaroger",
+    "type": "easy"
+  },
+  {
+    "id": "5fb9d42aec65e2601bf82fe10634187f70474b26",
+    "name": "Gollet",
+    "type": "easy"
+  },
+  {
+    "id": "fdb423fab6b60b23c33da22f8687254cb2404d37",
+    "name": "Gollet",
+    "type": "easy"
+  },
+  {
+    "id": "e3d7ac3a4e645af24b1aa0983938514f00ebb270",
+    "name": "Ski tranquille",
+    "type": "easy"
+  },
+  {
+    "id": "fc561928029cf4cbf93faeb62fbb312206c5482c",
+    "name": "Gollet",
+    "type": "easy"
+  },
+  {
+    "id": "08e4fac7ce0ec4b4c4e9f7267c4fc474d94fe10c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f2c2d46da2c2528cc15e17cb40fc00790f370e24",
+    "name": "Réservoir",
+    "type": "easy"
+  },
+  {
+    "id": "0e6673cf3d52bdc879c7c06fb9305d59c19ed3e9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c42699240c7c7b08389623be7d27164ae96c085a",
+    "name": "Allée du Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "7c904b4d0d048ebd41be01be9880d34d4e87f624",
+    "name": "Arc 1950",
+    "type": "easy"
+  },
+  {
+    "id": "d9cc3162f08922df09c119793917e486abc1b5db",
+    "name": "Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "a834ad7898ba4dcd54a1c6ef330d432415c3f727",
+    "name": "Vallée de l'Arc 3",
+    "type": "easy"
+  },
+  {
+    "id": "a118d23c8a30e94cfcd28b6617f2b1ec3a3e986e",
+    "name": "Vallée de l'Arc 3",
+    "type": "easy"
+  },
+  {
+    "id": "da00897174ba7b1a90dd1de7cfab2aa6594c2675",
+    "name": "Arandelières",
+    "type": "intermediate"
+  },
+  {
+    "id": "54d5881a03a0f14a37fab4e9ef62fb993f30c1f9",
+    "name": "Vallée de l'Arc 3",
+    "type": "easy"
+  },
+  {
+    "id": "6233807e38be3f5c7c2f1f730901375069a72c9c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "612362c3a46413d5434729a8bf15af174c529c72",
+    "name": "Ourson",
+    "type": "intermediate"
+  },
+  {
+    "id": "013d1f6b46852068352359c51878039951b376fc",
+    "name": "Retour Plan Peisey",
+    "type": "easy"
+  },
+  {
+    "id": "3c1013c11d6afdc7396faf44214c389283c1c32e",
+    "name": "Accès Transarc",
+    "type": "easy"
+  },
+  {
+    "id": "12465c0cde4617a963f90eacab14597102c4713b",
+    "name": "Fond Blanc",
+    "type": "advanced"
+  },
+  {
+    "id": "37124fb71cc9965efcd9bdc8f0f322ae909cf8cc",
+    "name": "Edmond Blanchoz",
+    "type": "easy"
+  },
+  {
+    "id": "b2ea6f423ee26b3cd1f0e2eabd08fb4696da892d",
+    "name": "Cornegidouille",
+    "type": "easy"
+  },
+  {
+    "id": "a8fdc1251ffe241c4a00c324f1e38ce05f0311ee",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b074a1fb14a05ca1ac237d478cff9697a53b2cc1",
+    "name": "Aiglon / Bergerie",
+    "type": "novice"
+  },
+  {
+    "id": "ef6430f064a4e8340b49a3855ea52a602ae0d5bd",
+    "name": "Stade de Slalom de Champagny",
+    "type": "intermediate"
+  },
+  {
+    "id": "bc399b5a62cddda5c9cfb38b3e7f6f8b134692b4",
+    "name": "Accès Stade de Slalom",
+    "type": "advanced"
+  },
+  {
+    "id": "88592e8d2f74f207908b2fd42fdc04dd47204b85",
+    "name": "Liaison Verdons",
+    "type": "easy"
+  },
+  {
+    "id": "9c5b927744aafad52fee486f09b02717dcd5e997",
+    "name": "La Route Bleue",
+    "type": "easy"
+  },
+  {
+    "id": "7b83d9010fbf9e681a194877445f36a2839dc7f0",
+    "name": "Liaison Verdons",
+    "type": "easy"
+  },
+  {
+    "id": "2d28cce4759922ee478d71ef5e6cd091c8900926",
+    "name": "Bouquetin",
+    "type": "easy"
+  },
+  {
+    "id": "a253dbccb606b52596056ba2622d8529096ffca1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "273c27ca9bcaa19ca3ac9408dd982f11367541da",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "020a5905fd5925bc23d2e9197021a9d04f1a3400",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8707e0d5fc72540e9a112dc0ad551fb8841e5b56",
+    "name": "Grand Renard",
+    "type": "intermediate"
+  },
+  {
+    "id": "f3476ad14ce3e6ec0e6c1131daaf2696d3dec0a8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0cf36191de19421aa1fe9e6092144ea8d69e1195",
+    "name": "Belvédère",
+    "type": "easy"
+  },
+  {
+    "id": "427747fd1e73433f99f84e210fa47d5cf49dc779",
+    "name": "Vallée de l'Arc 3",
+    "type": "easy"
+  },
+  {
+    "id": "fa67f316a614db743b4d1f20610428958f74065d",
+    "name": "Vallée de l'Arc 2",
+    "type": "easy"
+  },
+  {
+    "id": "acae0f76394b3fb99349e147246fea33cf3574b8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "be1c2ca520650219040682b2ab56c11bdcfce476",
+    "name": "Rêches",
+    "type": "intermediate"
+  },
+  {
+    "id": "60398d363bafd7e7f6ebd370d2e7453905630dd6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "eef9134752c9c85573fc7abfd9a95066a0904569",
+    "name": "Traversée 2",
+    "type": "easy"
+  },
+  {
+    "id": "1802d839345b9496a489054037fb28ed6725e36b",
+    "name": "Legend",
+    "type": "easy"
+  },
+  {
+    "id": "48e83f7e636dca48d2d661d620b27f9bbd48d6da",
+    "name": "Liaison Legend vers Arc 1800",
+    "type": "easy"
+  },
+  {
+    "id": "01610b520fd34db943938fb869df9d63b6360baf",
+    "name": "Accès Transarc",
+    "type": "easy"
+  },
+  {
+    "id": "d1fae4d17e8709f5d87c9c9c7b3f35c253aebb18",
+    "name": "Rêches",
+    "type": "intermediate"
+  },
+  {
+    "id": "dc37902ab685e5c07eb11556711281698b5f66b7",
+    "name": "Rêches",
+    "type": "intermediate"
+  },
+  {
+    "id": "e4f701d39426e019585cca739eb2112745a50c8c",
+    "name": "Accès Transarc",
+    "type": "easy"
+  },
+  {
+    "id": "604665afba03867fb58ca9d2a276e47e242a4afe",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "d4b667737f131ae8c652e9e0c4352fb80b803a0f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b2afbe038920c4522af0a65ca5d8e11dfcbb4d14",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c971593d8087eae0c6b1993f8aa14fb148a707d0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0807db43fd2279aaa8396d1abdb5580e4e7101e8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "33395fbf323f65ce52fd7b5d997c8a345abd0995",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "846314ffc8243bb0bf67350b84775051e20713c8",
+    "name": "Myrtilles",
+    "type": "easy"
+  },
+  {
+    "id": "b3cf0412469fba814cd6995b4d64d677e5eee963",
+    "name": "Golf",
+    "type": "easy"
+  },
+  {
+    "id": "90c91f9f6f46b0af05915ed2b53d7bbbdcc94ce7",
+    "name": "Palsembleu",
+    "type": "advanced"
+  },
+  {
+    "id": "bc250594b238f3d5322ff7139fab7d06d408af55",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f85c840a15f35f711164661f656387a567150ca7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "2ee99a209a2ddde5497ac4943b2b446e76b684a7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "c6285260ec106b51e31d31244a589ccd522ebb31",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f78ba5bc06816c122038a92e19bed5345f2a34ee",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "e03bb78fb10b0c399d322dc04e7159349d9e01fd",
+    "name": "Retour Plan Peisey",
+    "type": "easy"
+  },
+  {
+    "id": "0e2d0bfa11343a2b6acbe0c815bf8c196a759b2c",
+    "name": "Piste à Steph",
+    "type": "easy"
+  },
+  {
+    "id": "45a70fc7f29fa7f5753ed1e76bd8ae2b7f059658",
+    "name": "Génépi",
+    "type": "expert"
+  },
+  {
+    "id": "00da59e918f3afe59f7a4d6589cc22c746f75738",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "e8093d0bcd94b5bc1cfb230419961dea03f8254a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c31ffda708427a36f53d84006a226db9e42b363e",
+    "name": "Cornegidouille",
+    "type": "easy"
+  },
+  {
+    "id": "894277b1c99f034eed88dafcc97d14cd7340df67",
+    "name": "Le Gentil",
+    "type": "easy"
+  },
+  {
+    "id": "1029a1f7101bf92b7644e7c475be0eee67b8a256",
+    "name": "Chalets",
+    "type": "novice"
+  },
+  {
+    "id": "3007895362fb6a01f8237c35b7419156c0debf62",
+    "name": "Dents du Peigne",
+    "type": "easy"
+  },
+  {
+    "id": "54a5d397273710b6a26a88f0d808c474f029239f",
+    "name": "Grand Renard",
+    "type": "intermediate"
+  },
+  {
+    "id": "43bc829293223eba6e3874b6b6f7cb9a0fe5fc26",
+    "name": "Col de la Chal",
+    "type": "easy"
+  },
+  {
+    "id": "38bdab62d8bdf5f1465aba04a9da2e496a431d03",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "f193f55fd592fd0743493a0eb8d29cfbc11152a8",
+    "name": "La Forêt, Écureuils",
+    "type": "easy"
+  },
+  {
+    "id": "13a6c4be8a1155271c60a97ff8c1b6ba0e1a4ee7",
+    "name": "Arandelières",
+    "type": "intermediate"
+  },
+  {
+    "id": "ee8bd47737747b182081e03cf5df03e55b1e417a",
+    "name": "Arandelières",
+    "type": "intermediate"
+  },
+  {
+    "id": "d893e8bbe38eb7c7c42c6625ce8d806e671759df",
+    "name": "Grands Mélèzes",
+    "type": "easy"
+  },
+  {
+    "id": "5c20b035beef7e94c5118581b764753fd491efe6",
+    "name": "Maïtaz",
+    "type": "easy"
+  },
+  {
+    "id": "afa4138b93e3f30904b9d992c67a9cde963d7d2a",
+    "name": "Maïtaz",
+    "type": "easy"
+  },
+  {
+    "id": "85cac06cc02e2661373ce6364af9e569b2aef79c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5db7d0fa3e391e92bc1c4aa2e32bb2c6123ae6fc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "759ea1b3f302aa3b840305a33075b13fb87805a7",
+    "name": "Écureuils",
+    "type": "advanced"
+  },
+  {
+    "id": "9486fb747713c7818c94dcebe38dd203dcff5d1d",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "c560a25a854e86a4cd048008631ff88fa5644027",
+    "name": "Charmettoger",
+    "type": "easy"
+  },
+  {
+    "id": "54d0da72d2e8aa83ba52e18695ff803b19da6150",
+    "name": "Woodstock",
+    "type": "easy"
+  },
+  {
+    "id": "f95a12f69bbf3f7a8b092f4291d80d4336a21007",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "91410d9818a2027a6212a1b590bf0c36a9b89792",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "d74cf3b5eacd357a17a2b0956f3903b7b4fce2e2",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "2db4b853708d7c77213790eaa06579fa167b3e2c",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ba9e163aadef970bb915529979c93303b3923272",
+    "name": "Planay",
+    "type": "intermediate"
+  },
+  {
+    "id": "1ece7bd74467780472763c035c562d6d275bb85c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8964319f8ec08cf6691cf39e4eea6772178dee84",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "78db35779ab8bb8bbd56aed8185d9d2ff5bbd026",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d8ae0115775138f357a0bd0577f27d65e747a4f3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6f409f029b38adab950843548f42a726429b4424",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d0f31c029f2221d1ac0a0cae08fa752c58e2e02d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dfe9a38734849156fc67639dd389a61c317ae8bd",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a1ba895cf20f9b5c95b66c15a260c9b0994d832a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0c4f51ad188c5efced650098b83983797b95b1b8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "b7afeecb48295b4fb2f41566e04adbaabe28ab28",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d192d983185b89e5dcf1377cd388bedf3180d43e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "889bb5266d2933cca49599ee65146be4e752e1f7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "638250093fcadf6f4c7d6d6b05ccca5db7c84163",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "04fa20a4de159920c19c8591b365571b610d0620",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "1eebcadd59718f2d25eacf54531bba8f8d18ff7d",
+    "name": "Malatray",
+    "type": "advanced"
+  },
+  {
+    "id": "871c09c0eda0fe8ae498ca7a3698109abc9c8f98",
+    "name": "Murs",
+    "type": "advanced"
+  },
+  {
+    "id": "ed4a15aeb5968cd65bf45d4eec97700218cad7c2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fb7d808d629643c73cfc602ca64a04830125a790",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c529969516457c81c926d07ea26044863201bf25",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "52249a43872f24598e8621a00766921a906378ec",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f6e6e380837618beaa5f988901fd2cf7ad84fefa",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c0a8e7e4dce07d65e422f483fba93607dba3a40e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e051c6a36a791dd6a9d5d64696d7d63ac1420525",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8ff05cc40c2b8ef09e241318cf1ae78aaa29c755",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e2e9bdd11281f06e9a09716023219d8fca1e00e7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "731ea4711678c15aa88623df57377509a4110423",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "7f006eb24220157cbdbd201244ffcfb4e7b8a5f6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b113aef8340f65eead1c2eb45d6fe18416093f86",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2294603dd841789d5bf616a580469e26cbe5bef5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "276f6e17138cb38ec614aa7db71b452c5d3ad08e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "451e76e7e13a471c39bfe902d8bda0ac53b2ccbf",
+    "name": "Boardercross",
+    "type": "intermediate"
+  },
+  {
+    "id": "6a1a0f64d244d7cf615bb77f1fe2e57ef3f4ec89",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1ebd396c9d88638c4e5a383fd4c6350c8ab68784",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0160779f3cbf9ffc4bfe62891d7972e2cada9785",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9f85a7d6f9ef9136718d9246ac261cb5c819ef04",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "35e5fdda40ae6e08d3e90fe87a430c69075c2965",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "df6a060c828c92df1ce0959f7bf51702917e373c",
+    "name": "Grand Col",
+    "type": "intermediate"
+  },
+  {
+    "id": "83b0f4fa6cff3f437b844e31b04c0ed0b251425a",
+    "name": "Grand Col",
+    "type": "intermediate"
+  },
+  {
+    "id": "f9bdb12469e6c90abf5b86d96f134030fe64d465",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a881f207c1360ab5496189622bf2b271756a42c6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2c6b8ef88f63efc7be63c230f723fcca42125c21",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "60a322488d9662cdc7ca55ebbfd489c9712a8765",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c249b1e40cc59946b99dd6db6f2021a4824a2a37",
+    "name": "Route des Espagnols",
+    "type": "easy"
+  },
+  {
+    "id": "ece8ea4d926adac13281f340ee91b119bbc1592b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "58e17bd49d97c4be6c31940bdfa3bb61f20c1a22",
+    "name": "Liaison Legend vers Arc 1800",
+    "type": "easy"
+  },
+  {
+    "id": "9db919d49aa6f20378fa3f96ba62d1c702d81c66",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f09e41b5ac702d1a13665fb51927c3a2941a1292",
+    "name": "Liaison Legend vers Arc 1800",
+    "type": "easy"
+  },
+  {
+    "id": "5be8ac167f597e6a7d49263c21887fdb68db6d3a",
+    "name": "Chemin du Front de Neige",
+    "type": "easy"
+  },
+  {
+    "id": "474b7f072f2c1072984d72f0f164a31f57d08e8a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a11f46d5a4b0bee0439b784f8e00d3083a72ccee",
+    "name": "Barmont",
+    "type": "easy"
+  },
+  {
+    "id": "51965e2870768fe95f02773bcb4fbf045a740d98",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e0989cdaad3857425f3c5ca3d9c67636dbfe2ba4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5166cf5374e214667af2b3a78337c19315d7ae9e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ab97e49fd55fb3114dc702fe6d41600f22bdda75",
+    "name": "Bas KL",
+    "type": "novice"
+  },
+  {
+    "id": "77033eb54ebe7255791c051a7399ba8c142e5ec6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "44ece0d9b89388e0f14d73a156540b763e2e70c6",
+    "name": "Espace Cross Champagny",
+    "type": "easy"
+  },
+  {
+    "id": "932b413755dc0ba333daace7fe1f91883bcfc5bd",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ed41478574e12a9444c24a4166b9a432a57a15ea",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "2a6fb5e54c3dd63c2e61007d7a6c397035cbe667",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "462efb4fcc451859fa2663e7736a61198e54b370",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a499ff348f020844bd8e53d151a7a8995229cb19",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b3830575da7e7547d7a64fc66badd0fbab2c518f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a11f06e6731a03c6766eec625ea0573532b89f47",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f555059adfc11b4d8939775aa47ae199bb3a582b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f167ccd51a4e5169208d2394046416ace9e4bffc",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "76dcd8604c68a6aa2668881a2b88d0b1e962a810",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "601aca580e50a1e82afc7e27bb9775aba55a804b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e0ebb3bcd06d1feff8b77381b97b2753011c1b75",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8b7db9a4738f40bab8f8798cc603eeccfa7b6607",
+    "name": "Bellecôte",
+    "type": "expert"
+  },
+  {
+    "id": "4a75d65a6faac7a01ff48727011457eb1197bd1f",
+    "name": "La Mio",
+    "type": "advanced"
+  },
+  {
+    "id": "a1eabe29ecaf509cb604941fba51c10bcfefd6fd",
+    "name": "La Mio",
+    "type": "advanced"
+  },
+  {
+    "id": "f0a2a6465ef8ed4f2212d0042dcce81ca0fad824",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "d8c354479dc7c4cd51c8aeca5cb46cc73acb6a0f",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "df3245b7a3b15323a0af9d293773a9bc9fb15e05",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "19f8ba02bb525799e93a1e686560a1cb55d864a1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bed421773cdb4abb72d6fa3a88c52f047fbf2766",
+    "name": "Mont Blanc",
+    "type": "easy"
+  },
+  {
+    "id": "cec9a84cbcd9f32252f25ec6c516aef96b2b934e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e0dfc890897dc392147d9c5f20921da9b7dd9043",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "107211d44bbab57a08004ab7e8dda45b81f3cbc3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5584ae788cf9510634940427f86956f3293fdaaf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9654bdf6f8386544ea64ea8a58e72e17804d386b",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "7f18f14ddf40439352d87a13b17653cdd48b4396",
+    "name": "Verdons",
+    "type": "easy"
+  },
+  {
+    "id": "e34662f0c4f5f4ee735be9a940ed575285f9b9dd",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cb5fc5c5181824163091a8ce64a8f51054da9f5d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "fc1c5442077cf31e820cfd4b569770dd53e34751",
+    "name": "Ours",
+    "type": "intermediate"
+  },
+  {
+    "id": "3019e71a15afa85a920c9a943b94711f58e83851",
+    "name": "Ours",
+    "type": "easy"
+  },
+  {
+    "id": "901e26296e9c60e048a1f76c264ce5ce1c34df7d",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "40f3d43a8e8fcb7a620d774564e894197659b207",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "bf4a7588e5616cd2343c9f0409ae34a1d886ee42",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "709629d516c6a5f13874d23fa408f56814dbfbf4",
+    "name": "Bellecôte",
+    "type": "expert"
+  },
+  {
+    "id": "2a9ef728b93f22ba0e75a5ca368b51480f90d0e3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ea83cf1a2a1007f75e92dd6575aba1463661a862",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "314da94d5305a61c2f7085178f9a9990db75c333",
+    "name": "Villaroger",
+    "type": "easy"
+  },
+  {
+    "id": "30a95c93a4599de12ae3fc7ef306291f6a8b52a2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dea9b1d90d6b395d4a71cc64fde2b24c51377614",
+    "name": "Lac",
+    "type": "intermediate"
+  },
+  {
+    "id": "9ee54a59cadff6187d71a9ecbf0a5a5fb2d4a6b3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f96edd515cde30bf0a51f171f93c4349e350cc04",
+    "name": "Froide Fontaine",
+    "type": "intermediate"
+  },
+  {
+    "id": "5aff89d7fa20967469f2b510800a785dbc88343b",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c62891d1ad684cf1e24d10b9822d72bc6db14056",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f520eded395acdff377db8f52eb11aa535d1f922",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "23fe787bfcca469b683e317b37a86f97aabd73ac",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1156991111dac9b0f830fc9a5fb050c351e5d6f7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a4f5f99649b3ccb4801d8524e57178ee3cfe846e",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8defc386783e570425eedb813943daadcdf17107",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6330fea8d82cd255947f476240eaacc92dd16dbf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0e218806a184be3d02deae3a0b124188cb8950b9",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "868e99116f1f067ec76fefbad221dd6ee85ca73d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fcdfddb1c54451f8ef1face7e80951af79935f3b",
+    "name": "Aiguille Rouge",
+    "type": "advanced"
+  },
+  {
+    "id": "8a5da38276ecb312729bf8358ce9ebaa033301c7",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "62a89a40b3c4bd7c66ebd83771921616be119daf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "de60347fe76275538d6c649a382ded5aa1c22435",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "5af562b23b6e9d6e8e95764b671085c362370170",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "900024941189909062ec9ed52ddb944c16ed874f",
+    "name": "Chevrette",
+    "type": "easy"
+  },
+  {
+    "id": "b6e924180d925365c90d7d374d1ea3b2c363d84e",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "5bdc9ea445802cf53d5bc454c4a90c4828403ba4",
+    "name": "Bridge",
+    "type": "easy"
+  },
+  {
+    "id": "b59e1c7fdc31d83bc08139643a444bbc57e59a54",
+    "name": "Mira",
+    "type": "easy"
+  },
+  {
+    "id": "55f2c63cf69b36734154824c2096ad9f58a105a5",
+    "name": "Mira",
+    "type": "easy"
+  },
+  {
+    "id": "f31c0c81cf0d8c82f4a6b9e3cbae7ee58c6a6ec9",
+    "name": "Boardercross",
+    "type": "easy"
+  },
+  {
+    "id": "1b851c398f63b5b24625c30d0311065714d2d44c",
+    "name": "Rodéo Park",
+    "type": ""
+  },
+  {
+    "id": "1701dfd604d6e19525fb5650b959096abde4cfee",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fe09545a711687eb8a327128c12e61fc3d43b866",
+    "name": "",
+    "type": ""
+  }
+]

--- a/lumiplan-maps/data/tignes-valdisere-lifts.json
+++ b/lumiplan-maps/data/tignes-valdisere-lifts.json
@@ -1,0 +1,452 @@
+[
+  {
+    "id": "0514f4d0bc8bb166455e252ece6781c4eb2c8a33",
+    "name": "TCD10 des Boisses",
+    "type": "gondola"
+  },
+  {
+    "id": "6d9838b5e671e2ebc19a39e33a6a427e176d50d4",
+    "name": "Aiguille Percée",
+    "type": "chair_lift"
+  },
+  {
+    "id": "6f17f59d608dacf79731fee4102ad2ba3cc1c49f",
+    "name": "Daille",
+    "type": "gondola"
+  },
+  {
+    "id": "6ce8a200a93da3d77fe911a4c8ed8983a9d44707",
+    "name": "Funival",
+    "type": "funicular"
+  },
+  {
+    "id": "c8467b806d84f221af0ab322013925992b6ded2e",
+    "name": "Tommeuses",
+    "type": "chair_lift"
+  },
+  {
+    "id": "24b7b8d55b287251f7a2b2a769ea9b5d6568304b",
+    "name": "Mont Blanc",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2c2796f842b25c240d04024327432cc1d80155ef",
+    "name": "Tovière",
+    "type": "gondola"
+  },
+  {
+    "id": "35fa0ca97a2885cbc2b9a5d55f17d767e15ffc79",
+    "name": "TSD6 Bollin",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9ec50bd9d66ad6346338214e77dd8e72c2905eb7",
+    "name": "Tufs",
+    "type": "chair_lift"
+  },
+  {
+    "id": "eaa1fee0613bbc0018a27f592bb7033403dd3c9b",
+    "name": "TSD6 Tichot",
+    "type": "chair_lift"
+  },
+  {
+    "id": "04656135bc4fc896a4bf842c20b11e1d1811329e",
+    "name": "TSD6 Grattalu",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c98eb1d1141a7038612444403675182afc35e590",
+    "name": "Merles",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2569a66d66503f8b4ac8b772467f2b38fa6576ca",
+    "name": "Lavachet",
+    "type": "platter"
+  },
+  {
+    "id": "41b8cc9a7d02da9ae7edbbb4ab962e9b3d53acbf",
+    "name": "Palafour",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3bb5a534f21cd3b259c1a5a8e6656e102288c03c",
+    "name": "TSD6 Chaudannes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "58cdc3e8727e5b8c8d47423cf0713fef66800f50",
+    "name": "Grand Huit",
+    "type": "chair_lift"
+  },
+  {
+    "id": "d49237ddba241118f61a2c7569f27c28c1c08600",
+    "name": "Lanches",
+    "type": "chair_lift"
+  },
+  {
+    "id": "6c71c5ee8cf5a4fcdf1ff921904693da901fb6b3",
+    "name": "Grande Motte",
+    "type": "cable_car"
+  },
+  {
+    "id": "57d178ecaa1726799bc3b9613c1644e36cacb8c0",
+    "name": "Termignon 1",
+    "type": "t-bar"
+  },
+  {
+    "id": "ea4be6718f888d1b8024434030509373301760c1",
+    "name": "TS Fontaine",
+    "type": "chair_lift"
+  },
+  {
+    "id": "f1e8359b5bea176cd45908fe4b0b33e662ee82fc",
+    "name": "Fornet",
+    "type": "cable_car"
+  },
+  {
+    "id": "694f3db63148e4599593861b3b5b4e31179be8e9",
+    "name": "Vallon de l'Iseran",
+    "type": "gondola"
+  },
+  {
+    "id": "fa12dcdd20e744984afa097418fd8bfe11bb7049",
+    "name": "Col 2",
+    "type": "drag_lift"
+  },
+  {
+    "id": "799cd3f42587a6c97ebcf7c14e22a80f3fa67495",
+    "name": "Céma",
+    "type": "chair_lift"
+  },
+  {
+    "id": "854390f1cbb656306b7c71fb3adb04526f3febe3",
+    "name": "Cascade",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b2033ff5a1f4c03b4a4edb2b737f071db47b2201",
+    "name": "Montet",
+    "type": "drag_lift"
+  },
+  {
+    "id": "a4a11d4fc914f8727c00b4ce351c90900692ec5f",
+    "name": "Leissières",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9aa0c344ed4dee1ee0c05d9ca74b429c3602787b",
+    "name": "Signal 1",
+    "type": "drag_lift"
+  },
+  {
+    "id": "3bf18a979e519d587fcb25fd4ddbee8273ff0f1c",
+    "name": "Glacier",
+    "type": "chair_lift"
+  },
+  {
+    "id": "925c17e4bd178a7f20529d2e29ae427aab985923",
+    "name": "Datcha",
+    "type": "chair_lift"
+  },
+  {
+    "id": "55a50afa2de82c5bd8389de3c1f81c8cc5eb9bb5",
+    "name": "Laisinant",
+    "type": "chair_lift"
+  },
+  {
+    "id": "583199f4092506c0078cabda360ed55dedd6a1a7",
+    "name": "Cugnaï",
+    "type": "chair_lift"
+  },
+  {
+    "id": "26a6760d1650be3f85b1f851c050d2b6e18a784c",
+    "name": "Vanoise",
+    "type": "chair_lift"
+  },
+  {
+    "id": "0f523a9e7980e7be81c1eee7cc7b3d34db0d356c",
+    "name": "Grande Motte (Perce-Neige)",
+    "type": "funicular"
+  },
+  {
+    "id": "6336c6958f52035964f9d284d463ddef0bd54759",
+    "name": "Funival",
+    "type": "funicular"
+  },
+  {
+    "id": "f3875561dc7aa786411dd5bf7c4e3250a847bcc6",
+    "name": "Bellevarde Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "f780e0893eb09a16f9cc65596cd89791db6a614f",
+    "name": "Loyes Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "d86da6d57435c00656f68cdad66c1248bed180d9",
+    "name": "Madeleine Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "bce2d9736e67be3ddd89a274ec79b47c8c8733ff",
+    "name": "Manchet Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "5cb4ece979e54a453dfbd769e847ed764ffc8518",
+    "name": "Grand Pré",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c2d49e351801ed1437f1a71282074866f83847a0",
+    "name": "Centre",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "9d7007d686c17088f296734eabd70b3b69a2d20c",
+    "name": "Olympique",
+    "type": "cable_car"
+  },
+  {
+    "id": "6f35de51c0f7f608f16fd2b26dc0b2d599f14b5c",
+    "name": "3000",
+    "type": "platter"
+  },
+  {
+    "id": "ee4e0168c5b384298fd029a50b99cd71df59cb28",
+    "name": "Rosset",
+    "type": "chair_lift"
+  },
+  {
+    "id": "add6836a38dad706580896867395536799bfcd64",
+    "name": "TSF3 Col des Vés",
+    "type": "chair_lift"
+  },
+  {
+    "id": "930acf7318445e98619586c7a29992867ec22939",
+    "name": "Slalom",
+    "type": "t-bar"
+  },
+  {
+    "id": "e94893dadcf3a023f87f35d30e67c0eafd0aaf74",
+    "name": "Savonnette 1",
+    "type": "t-bar"
+  },
+  {
+    "id": "13f98464384d2e13785477cf9f163d77b57add96",
+    "name": "Village",
+    "type": "chair_lift"
+  },
+  {
+    "id": "ed369c24a1cc4613ea32442e6f29ece342761602",
+    "name": "Rogoney",
+    "type": "chair_lift"
+  },
+  {
+    "id": "d9d687ed7cea44efd6fe56e27a36302c5b83ee0b",
+    "name": "Pays Désert",
+    "type": "platter"
+  },
+  {
+    "id": "78117f1fba32cfe958fe985d52ed3deb14592607",
+    "name": "TKD1 Chardonnet",
+    "type": "platter"
+  },
+  {
+    "id": "ac3785d8c919605b182ca27564c04aca3773262b",
+    "name": "Combe Folle",
+    "type": "platter"
+  },
+  {
+    "id": "4fbe387cb2993590f663fea0741f0fa3c497c832",
+    "name": "TSD6 Aiguille Rouge",
+    "type": "chair_lift"
+  },
+  {
+    "id": "146c7fdf7ed3820e1de44aeb72956945724791c1",
+    "name": "Almes",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b68bbd2515e637ff441a22c0764c2fa7764ebc7b",
+    "name": "Panoramic",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b16010db5f0c629553c78a83bec0c61848c28235",
+    "name": "TKD1 Col du Palet",
+    "type": "platter"
+  },
+  {
+    "id": "4d75e8ddfcbd7d1a6f1c94bb831f6cd00e03bd17",
+    "name": "Pyramides",
+    "type": "chair_lift"
+  },
+  {
+    "id": "e201ce7e27ba182d2899307dc777dfe75835372c",
+    "name": "Paquis",
+    "type": "chair_lift"
+  },
+  {
+    "id": "7e170cc8b090a01bda41c7ac8d50364f5e8b4ffb",
+    "name": "Marmottes Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "b66a8afca4439d3d575680f079259752111a1075",
+    "name": "Legettaz",
+    "type": "platter"
+  },
+  {
+    "id": "b2053041fdc63a53b765ff252080f5be370ae144",
+    "name": "Borsat",
+    "type": "chair_lift"
+  },
+  {
+    "id": "27206de63b66f9c549fbb4226be4f645aac148d5",
+    "name": "Termignon 2",
+    "type": "t-bar"
+  },
+  {
+    "id": "893142d6595a3155c572e67ec70ff3a5bd08bca1",
+    "name": "Brévières",
+    "type": "funicular"
+  },
+  {
+    "id": "0911258dd2a2cc09ab68141a41a5bd9f23f296d6",
+    "name": "Corniche 1",
+    "type": "rope_tow"
+  },
+  {
+    "id": "d643a05321142cf26ce51c089c7da3d457cd22a5",
+    "name": "Corniche 2",
+    "type": "rope_tow"
+  },
+  {
+    "id": "729b3b4b3c2719c230e743362e0590aedbbd4f7f",
+    "name": "Tapis 1 Tignes 1800",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "47d92976686fc1e47d19ae7f74996b13075d0227",
+    "name": "Poum",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "653cb98f32edb313dbbdfc38f1329b3d1013d3f4",
+    "name": "Pim",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "c687fca50c6bd94e343d3427b1361fc37c838ed3",
+    "name": "Corniche 3",
+    "type": "rope_tow"
+  },
+  {
+    "id": "35a93d22940c857182a4fc739bc16abe82c7f7a2",
+    "name": "Solaise",
+    "type": "gondola"
+  },
+  {
+    "id": "0c4c1ae60139950e1bd1fb03a7a0374180f35405",
+    "name": "TCD8 des Brévières",
+    "type": "gondola"
+  },
+  {
+    "id": "1386974b0dd2d0abfd060bdf13a96baa138c3eee",
+    "name": "TKE Grande Parei",
+    "type": "drag_lift"
+  },
+  {
+    "id": "e3c537f8916173be2210085570d108aaf717e556",
+    "name": "Fresse",
+    "type": "chair_lift"
+  },
+  {
+    "id": "747258945d3d173ac2eab627d8d4550fee7113f1",
+    "name": "Club Méditerrannée",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "c0f8b2978f0175f0946dcdf967c2ab039eae5ef9",
+    "name": "Club PiouPiou",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "594d7c4c7d08e13663f4e99a487881a743c6d1ed",
+    "name": "Val Claret",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "6dcfbd46d175d5ee997a52990bfb936028631c67",
+    "name": "Tapis 2 Tignes 1800",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "09c422a29a0139ca23536ba3e271216669c3a873",
+    "name": "Snowtubing",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "a88bc2ffa30b2d192d853ace184be92291677134",
+    "name": "Grande Motte (Perce-Neige)",
+    "type": "funicular"
+  },
+  {
+    "id": "7abb77d277d58a383546be446097f3ed30e178e0",
+    "name": "Grande Motte (Perce-Neige)",
+    "type": "funicular"
+  },
+  {
+    "id": "25c0567af03bf3c09898aced43305a59b95f5510",
+    "name": "Snow Park",
+    "type": "t-bar"
+  },
+  {
+    "id": "c6448f520a637a33e79bbf9e376fcf5d4ed02852",
+    "name": "Carpe Diem",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "91c6f22001be679151a1b34abae1a3e1f97426b1",
+    "name": "Savonnette 2",
+    "type": "t-bar"
+  },
+  {
+    "id": "aa0b466eeb333a9b25ee316aed17792fb19506eb",
+    "name": "Lanche",
+    "type": "drag_lift"
+  },
+  {
+    "id": "5ec6c3691a8674a25e3abd0d6a9a42631e132d61",
+    "name": "Pam",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "f75e54f4efd05cfd7666d5362894c31916716b52",
+    "name": "Signal 2",
+    "type": "drag_lift"
+  },
+  {
+    "id": "6271aff8f2d6c0ae78a963eff5d004c780a03d82",
+    "name": "Col 1",
+    "type": "drag_lift"
+  },
+  {
+    "id": "6d45d916e175b8f3aad217ed00cefcb607411cbb",
+    "name": "Replat",
+    "type": "rope_tow"
+  },
+  {
+    "id": "0eb8ac50e650723dc639c15fa10784a8ad8c3fa3",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "4e6a9a06027f4a534148d8c8ba43a77d81890bad",
+    "name": "TSD6 Marais",
+    "type": "chair_lift"
+  }
+]

--- a/lumiplan-maps/data/tignes-valdisere-runs.json
+++ b/lumiplan-maps/data/tignes-valdisere-runs.json
@@ -1,0 +1,2122 @@
+[
+  {
+    "id": "05ecba7b0038732ca12fccf07d78541c671a6cc0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ba253c5cccb56e009ef8b5d03da8b34a70793313",
+    "name": "Grattalu",
+    "type": "easy"
+  },
+  {
+    "id": "1ba4643666a37464367c18784496373cf9e40ead",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5e1b0a0d96506a58eab540ca53172c26ba39d367",
+    "name": "Grattalu",
+    "type": "easy"
+  },
+  {
+    "id": "20f1a763137fc8ca1b60093af03047367917f55d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f719973b6ad5603d4371cac6e44ff51fd8fb2085",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "99276567ff50cd3c1359e5a343cda4025b8e8e46",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "24e908e1cce9c229819423e8d3860e85efa77ac4",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "a42402081b2485eec4b34a3d6da85e8d89634ddf",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "59c4bb0febb66abca80bde9803b79604bc14a924",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "f58e60dcf600f9b46d6cb5996a7af8c041fd4be6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8e60c11c953b147b0d83f6af906f7f7d99a3b71c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7614eda4a5ffd8422034e4de814c197df3ef6a30",
+    "name": "Henri",
+    "type": "easy"
+  },
+  {
+    "id": "63df2231bfac940bfc8cc0c27a297ed84390261a",
+    "name": "Lavachet",
+    "type": "novice"
+  },
+  {
+    "id": "0edd5c421173bf9656fd5e004f4b20d70cfcdb87",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "e5e51456b784cf2bf06d684bb5e7ec7812b4960c",
+    "name": "Digues",
+    "type": "novice"
+  },
+  {
+    "id": "4fb765e15c097cfb2b9927aa9eb0d8ab8d62d465",
+    "name": "Rosset",
+    "type": "easy"
+  },
+  {
+    "id": "971f9f3b86cb184f47a4707209e9ce261a12c036",
+    "name": "Prariond",
+    "type": "easy"
+  },
+  {
+    "id": "265d92e66f172e73f9a3c2e06040f4dcb8adc195",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e03427390bb923b74a1077f03b081418fd809c6d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "21c2d431c20bec3eff68f46c989c4284399815e5",
+    "name": "Trolles",
+    "type": "advanced"
+  },
+  {
+    "id": "740646ea2b316ad70338247652eee3c167412758",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "8390fb8d5c37dffc337ee14d40087cba6636cf53",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "6355e2e4bd70ea08e83f8377e666755bb689234e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "720097adaeb95e7a3a55ebd78028d52ab995f9db",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "60ea834fe32c0308e017b3ffeb9b9243807c4bbe",
+    "name": "Fresse",
+    "type": "novice"
+  },
+  {
+    "id": "0cdc01672cbca2bdba6d7c127619cc53f623ad1a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "efd673b5e3a16d259f8b49a49e94e27562ae084d",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8ae80da0d028d444627ef6cc979791c83277d7ee",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "72e5bf8089c3599e745bd97a2202f0bc6e86deb2",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "361a7ba5aafa04fd3fccacf4c89395a14adab6e1",
+    "name": "Genepy",
+    "type": "novice"
+  },
+  {
+    "id": "626d48f5ed7612003c258ed97a6c7ac93cf7bfd6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6418cbf9b8329baa277d7c551b0726a93fe47faa",
+    "name": "Fontaine Froide",
+    "type": "intermediate"
+  },
+  {
+    "id": "825f314f300c350b232fd0c3d180238b861a5d07",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "edea4068978ae6368c9e87e15ff5873cda3e3617",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fc42f0cdb3511017a548f022572a8d365c2aeb6a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "871d13368ed82f6d7c8f72f07fe35ee7e038fbc3",
+    "name": "Moraine",
+    "type": "intermediate"
+  },
+  {
+    "id": "e60eba4761d37c9badfb867e9c4b12f0cd577e11",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5aa7b136cdaa56a1281efafcb29eb94677e1d9c8",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "48e508e91b12c556a5df5756664ddd2cf222a58c",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fbdc4367ef27befe48f99d2a746a5e266e2c7647",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0dda0e8124cf45dac0c32195611edcd4f71e7fd9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "49f8276849edd48c57496b82b0b7cd6a18d70f5a",
+    "name": "Ancolie",
+    "type": "intermediate"
+  },
+  {
+    "id": "831fb18f22bff089ff4ebbfbedb30eff8c2afeed",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "eea20093b10036c572fdd960ddf780d99ab722e0",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "b39cf99ff07994bbd5880901cb233653895844fc",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5696560c194e6c7e501df3a9940af232075adf3a",
+    "name": "Bollin",
+    "type": "easy"
+  },
+  {
+    "id": "47d3030fc84641c9dc94596eb7d26186da691cc0",
+    "name": "Trolles",
+    "type": "advanced"
+  },
+  {
+    "id": "a8b5fad1adb61744404e1971398d5ee61db5e933",
+    "name": "Stade de slalom Palafour",
+    "type": ""
+  },
+  {
+    "id": "6f70491faeb4493c59c056bee7d48606e5bfa494",
+    "name": "Perce-Neige",
+    "type": "easy"
+  },
+  {
+    "id": "02b864f80a12f5bcb5378ca88a01ca3f2203a37d",
+    "name": "Crocus",
+    "type": "advanced"
+  },
+  {
+    "id": "33aff310584701ce630d280d2abd1a9db272daf5",
+    "name": "Combe Folle",
+    "type": "intermediate"
+  },
+  {
+    "id": "85544d6b7bec03695202b53987c4c340b18f21be",
+    "name": "Crocus",
+    "type": "intermediate"
+  },
+  {
+    "id": "ae7cc59a6ae2c7f540034ea42b5302de0a7919ec",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "84edc71b7862dca7d14ecab07f9992228bef1938",
+    "name": "Pitots",
+    "type": "easy"
+  },
+  {
+    "id": "75c981e5407b4eed0f09e9c3ff023a6da38d2e4a",
+    "name": "Pavot",
+    "type": "intermediate"
+  },
+  {
+    "id": "b73fc20b933cd95e1e55423dce25efdbce0fe275",
+    "name": "Creux",
+    "type": "easy"
+  },
+  {
+    "id": "3852dbacd8fca3649fb4b8c07515d7d98e474dd6",
+    "name": "Kadjar",
+    "type": "easy"
+  },
+  {
+    "id": "9f826c2040fa075b16575d06d0c62f49aa7036e8",
+    "name": "Half-Pipe Tignes Val Claret",
+    "type": "intermediate"
+  },
+  {
+    "id": "0c43d50d4478555577291c237c94869169886938",
+    "name": "Bleuets",
+    "type": "intermediate"
+  },
+  {
+    "id": "51a336d478c52cfd2a3db33887f8a8ac5e77ae8c",
+    "name": "Rhododendron",
+    "type": "easy"
+  },
+  {
+    "id": "926d904923321eba05cc2845c045cac775576952",
+    "name": "Santons",
+    "type": "intermediate"
+  },
+  {
+    "id": "06d2612aec5c8e0a0df5fa4c1023af102521911b",
+    "name": "Épaule du Charvet",
+    "type": "advanced"
+  },
+  {
+    "id": "e2f2db64e402d566382bd7bd51851b9bc857a0f5",
+    "name": "Stade Legettaz",
+    "type": "intermediate"
+  },
+  {
+    "id": "ab1ee0efb9cdc76f272335843d20719a522f2443",
+    "name": "Lac",
+    "type": "easy"
+  },
+  {
+    "id": "6ea2028049b8a57cd54bfa675330ee0db90878ae",
+    "name": "Stade de Lognan-Compétitions",
+    "type": "advanced"
+  },
+  {
+    "id": "937bcb620384b858655dfaf766a19cfd860e809e",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "79b131a4b4d2f77a040815a73562946028cf7809",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "0f90aa18fdfdc032f255793e9123209d8a441060",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "49242b5dd70743dd5dcf9acdfe0d2d35108a779e",
+    "name": "Chardons",
+    "type": "intermediate"
+  },
+  {
+    "id": "1e1a1cd84a799d9676e0b0c3293431167260327b",
+    "name": "Poney",
+    "type": "easy"
+  },
+  {
+    "id": "78fe43776c29a436bcdec803f96269a89ec017d5",
+    "name": "Sache",
+    "type": "advanced"
+  },
+  {
+    "id": "8c2efa61fc92041b58f39a4bb1459cb10a216e68",
+    "name": "Moutons",
+    "type": "easy"
+  },
+  {
+    "id": "820dc0b66f38b3617eb0d506f5f91352c0d4f66b",
+    "name": "Borsat",
+    "type": "novice"
+  },
+  {
+    "id": "d46ec14dd8494db1543db1eae7706c449b2d3646",
+    "name": "Carline",
+    "type": "easy"
+  },
+  {
+    "id": "739228e8467e77faa33f6aa35eccf7924c3e56c5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f56a9318296152ba201a453f0c0954136b50c22b",
+    "name": "Accès Merles",
+    "type": "easy"
+  },
+  {
+    "id": "ebddb633b872003ffb3630ea29339d1d4fd744c4",
+    "name": "Retour Lavachet",
+    "type": "novice"
+  },
+  {
+    "id": "c7d92b121e4b7d103741b76bd3a0ca3362a37dc8",
+    "name": "Saxifrage",
+    "type": "intermediate"
+  },
+  {
+    "id": "1656b00908ffa70099a17c6dfcacfaa552254b17",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "8a0ecab2458cef3105bfd8b6976e02c528ded928",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5a0a1d67556e94d621a134be88dc405e749d6bf5",
+    "name": "Génépy",
+    "type": "easy"
+  },
+  {
+    "id": "cbb1452caef779fedb13ead9e7c666dbda48682b",
+    "name": "Termignon",
+    "type": "intermediate"
+  },
+  {
+    "id": "6d73fef8c671410f24abb865adaa0952c81ab507",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "df350306cf433473b27aee5374e7a590ad2fcdec",
+    "name": "Glacier",
+    "type": "intermediate"
+  },
+  {
+    "id": "32d728c0c1c3b953ef772afd5d2e593d10c94027",
+    "name": "Pont Abatte",
+    "type": "easy"
+  },
+  {
+    "id": "a83af7e41be8d9e9d1ab0a0c7b0adeae1a824025",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3ce97ee5db384e32e809f340801b2a12a3bbfb41",
+    "name": "Montet",
+    "type": "easy"
+  },
+  {
+    "id": "802e576aa9428d763e788de2dd34803bac48cbac",
+    "name": "Col",
+    "type": "easy"
+  },
+  {
+    "id": "dc3eade1d7c45f1a0cf39dcc9b61651a98f9818c",
+    "name": "Col, Pont Abatte",
+    "type": "easy"
+  },
+  {
+    "id": "f0be5341ba7fd4a59cc6bb9395b4390fb3a3702d",
+    "name": "Col",
+    "type": "easy"
+  },
+  {
+    "id": "54982cae914f1e750ac729427afd478afc88f4b3",
+    "name": "Pré Chemin",
+    "type": "easy"
+  },
+  {
+    "id": "c4c4653f4b8aacc30fe64f878139e288f83731fc",
+    "name": "Moraine",
+    "type": "intermediate"
+  },
+  {
+    "id": "fa43f97987e6b84aa3093a65d808a6e885a1d4b0",
+    "name": "Montet",
+    "type": "easy"
+  },
+  {
+    "id": "eb0ca472ac53c4f435954b049b916442f3b634f6",
+    "name": "Mangard",
+    "type": "easy"
+  },
+  {
+    "id": "e8122434494ac74b1de40d6c5dc08e12d5c2012b",
+    "name": "Cognon",
+    "type": "intermediate"
+  },
+  {
+    "id": "e92f0d731355c188ba66d4ddea5ac02729592742",
+    "name": "Aiguille Pers",
+    "type": "easy"
+  },
+  {
+    "id": "e699ba2680abb20407636bfc8b0a88683a4467f6",
+    "name": "Variante Col",
+    "type": "easy"
+  },
+  {
+    "id": "367a11575cced6ec7ec8ed7679e2202cca00f94d",
+    "name": "Glacier",
+    "type": "easy"
+  },
+  {
+    "id": "11ea91541e16caf35af3d1fb9a574f12be16a401",
+    "name": "Glacier, Plan Milet",
+    "type": "easy"
+  },
+  {
+    "id": "a0c89ab37ef2e02e0200b7154c5158ebf0090937",
+    "name": "Glacier",
+    "type": "easy"
+  },
+  {
+    "id": "e1fc4d8bb31add1364f348768dfea71dd603b96e",
+    "name": "Plan Milet, Saint-Jacques",
+    "type": "easy"
+  },
+  {
+    "id": "f1545eccfedbdea65c8aca41b276b4803cf5f6fe",
+    "name": "Plan Milet",
+    "type": "easy"
+  },
+  {
+    "id": "d5ba648ac804d312f5ba165c1454fa266f8b2b02",
+    "name": "Leissières",
+    "type": "easy"
+  },
+  {
+    "id": "780f560532f81b31edbbfdcaabc16ce180372c12",
+    "name": "Cugnaï",
+    "type": "intermediate"
+  },
+  {
+    "id": "61500de3f57b08608e88f93b8ab939322587384d",
+    "name": "Cugnaï",
+    "type": "intermediate"
+  },
+  {
+    "id": "7343908c179be09ec3077ecb90ad62c594d1e2f4",
+    "name": "St.Jacques",
+    "type": "easy"
+  },
+  {
+    "id": "45d95617f5eeab287384b8de60aae2da47e97341",
+    "name": "Col de la Madeleine, Madeleine",
+    "type": "novice"
+  },
+  {
+    "id": "bc45f6551daea45f46fe535081144eef379161f2",
+    "name": "Col de la Madeleine",
+    "type": "easy"
+  },
+  {
+    "id": "cc03e327ee0e9b417ae818b8f3fa1a0fc566a9fa",
+    "name": "Cugnaï",
+    "type": "intermediate"
+  },
+  {
+    "id": "518923577f577c48c819f3166a886c0dadfff270",
+    "name": "Pavot",
+    "type": "intermediate"
+  },
+  {
+    "id": "b7fdf520859a5c405887de3576681e0c4b833940",
+    "name": "Bruyères",
+    "type": "easy"
+  },
+  {
+    "id": "8d1c37c8b76dc033d98aef288ad81c427192273d",
+    "name": "Dahu",
+    "type": "intermediate"
+  },
+  {
+    "id": "a9e20247e31eb16e122eb8bb824eb02906f87223",
+    "name": "Perce-Neige",
+    "type": "easy"
+  },
+  {
+    "id": "9a4c67dc1d65a4ee0fe312b7ca7dbc92c4f0d11d",
+    "name": "Les Tines",
+    "type": "easy"
+  },
+  {
+    "id": "c6ceb294535dcb25f3c0ee09875554da02dc7d67",
+    "name": "Les Tines, Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "927b533ae065fed87a6b5e380f6930a46c7b2f0e",
+    "name": "Les Tines",
+    "type": "easy"
+  },
+  {
+    "id": "34af39cb3f92bbb27aa97c29259abcb4ea3d993f",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "f5233a31773168103c8187891bea3012cbc5a569",
+    "name": "Coupe du Monde",
+    "type": "intermediate"
+  },
+  {
+    "id": "30ad080e4e44877fb632468fab8f38e4220fc63f",
+    "name": "Diebold",
+    "type": "easy"
+  },
+  {
+    "id": "522bd828f2daee9282547f69629b1ad22d40f2e6",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "62189c202d6469712df3a806a81527d01d14116e",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "75555e9a6070b9fde4a4c856498b5ed25509496c",
+    "name": "Face",
+    "type": "advanced"
+  },
+  {
+    "id": "ef5c6f43f75aa80fd964f454b2df66f8680b236a",
+    "name": "Face",
+    "type": "intermediate"
+  },
+  {
+    "id": "8ab8df85cc6a8b54651e480312d335affd589500",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b0288e56a8b65a22bb09a881674285bf28185881",
+    "name": "Piste M",
+    "type": "intermediate"
+  },
+  {
+    "id": "15603d52c5bc91c29151c2f045d8c605aebeb055",
+    "name": "Traversée du Laisinant",
+    "type": "easy"
+  },
+  {
+    "id": "b15832686f248977eeff33fd369cec0129d4562b",
+    "name": "Madeleine",
+    "type": "novice"
+  },
+  {
+    "id": "c846a7031d6729f79f66fe5d49b6a64bfc431cfa",
+    "name": "Madeleine",
+    "type": "novice"
+  },
+  {
+    "id": "0e66f25b746da40781578e21a4e6aeedb1937163",
+    "name": "Arcelle",
+    "type": "intermediate"
+  },
+  {
+    "id": "9ea24e19955c588fa72723243ae800f29575615d",
+    "name": "Arcelle, Marmottons",
+    "type": "intermediate"
+  },
+  {
+    "id": "b4c985803c3128473c6db1b146bb311a3f17ccb0",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "df0ef883ecdea521698ee2044dc92a6f9a7f058c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a528449828c892eb457590bb0650500bd258ce37",
+    "name": "Marais",
+    "type": "easy"
+  },
+  {
+    "id": "d81a2cb640f829d3c1fb36065a6b1ae0cb2093d8",
+    "name": "Lavachet",
+    "type": "novice"
+  },
+  {
+    "id": "491c819ce9f96717925ee70d5bd79ec67be509d4",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6b1d39d7afd3636cbc8146c59e2b1d956923ecef",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "02dbb1410fbd5c1478c4eccbc046817e850aafb2",
+    "name": "Raye",
+    "type": "intermediate"
+  },
+  {
+    "id": "b0cdcc3c3e4c1d7bd9cc32e743f8e2ac95d4a4de",
+    "name": "Épaule du Charvet",
+    "type": "advanced"
+  },
+  {
+    "id": "715e66b3069abc6839959248acb2ba6bfb682ff1",
+    "name": "Santons haut",
+    "type": "intermediate"
+  },
+  {
+    "id": "7e567b43f21bbc644c0526da6124519a52e27dcd",
+    "name": "Table d'Orientation",
+    "type": "intermediate"
+  },
+  {
+    "id": "1dad09a4386598025e3700da81c423121f6d7b81",
+    "name": "Combe Folle",
+    "type": "intermediate"
+  },
+  {
+    "id": "99ee526cc5f56d50869302ad4234c4a85a182c44",
+    "name": "Mélèzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "4104afa1eca130e79dce6c6f553fca72028953af",
+    "name": "Anemone",
+    "type": "easy"
+  },
+  {
+    "id": "4104f8737ab156211a2f5ac287c1295a8553cc75",
+    "name": "Combe",
+    "type": "easy"
+  },
+  {
+    "id": "7cd326a0b5161a7e4908a8fee2abdf9657240ce0",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "bfcc723a0153c555cb27619d39003955cde51fc2",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "955051b99d93c0583e6a7f18b86ec678334ba78b",
+    "name": "Almes",
+    "type": "easy"
+  },
+  {
+    "id": "1a8cfe546a2eadbad5ae9f8c8f104182c9229c7c",
+    "name": "OK",
+    "type": "intermediate"
+  },
+  {
+    "id": "2df63a7d7c646886da8eed690e70849ad1cfdcb3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a1374cc14d771ce77bce998b82094d5f9fc41982",
+    "name": "Face",
+    "type": "intermediate"
+  },
+  {
+    "id": "941bb2624e8f6435ebf805bfd25f1a7dafbcbc14",
+    "name": "Merles, Stade de Lognan-Compétitions",
+    "type": "easy"
+  },
+  {
+    "id": "4e3d349480e2c842a255804bcf802a45bc526545",
+    "name": "Merles",
+    "type": "intermediate"
+  },
+  {
+    "id": "7b2cc93bde9a76c658ccbc620b1eebb39f2af8c5",
+    "name": "Stade de Lognan-Compétitions",
+    "type": "easy"
+  },
+  {
+    "id": "07c627a3a96014e9caf1eb6d1aa4648c6f2066ce",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "017ef2108f30a722a25e42fc0a30a14165cd6b4c",
+    "name": "Ancolie",
+    "type": "intermediate"
+  },
+  {
+    "id": "5ad9377507af8609e3c9966bd77f6484f2821b1c",
+    "name": "Beau Plan",
+    "type": "easy"
+  },
+  {
+    "id": "baa23da207b3fb255684d7c513c6b9e21bb24bf1",
+    "name": "Rimaye",
+    "type": "easy"
+  },
+  {
+    "id": "7d06697d0e9a79582d7708447105696cf683cf49",
+    "name": "Double M",
+    "type": "intermediate"
+  },
+  {
+    "id": "5ac5e3d05b7b8450055e0976710df4c2d5789946",
+    "name": "Campanules",
+    "type": "advanced"
+  },
+  {
+    "id": "6f51ed85bc98ef10bcd1edf630773f10dd5efc03",
+    "name": "Joseray",
+    "type": "intermediate"
+  },
+  {
+    "id": "a8bbadf42819a1472be184e993fba22dd4b0d761",
+    "name": "Joseray",
+    "type": "intermediate"
+  },
+  {
+    "id": "7ce1ebd4e2956729d11765bc00c140dbf5b4a8cb",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f0b58e96cd95506afa5a3bbb0a0338bae1d81ac3",
+    "name": "Criterium",
+    "type": "easy"
+  },
+  {
+    "id": "baa4f2d30a36aab22be059d7558e1fa7315a28fc",
+    "name": "Airelles",
+    "type": "easy"
+  },
+  {
+    "id": "20f2b1bde9841253e7220e4eda508f52eefe9cc4",
+    "name": "Airelles, Rhododendron",
+    "type": "easy"
+  },
+  {
+    "id": "d52b654079dab0fd23f21aa431ed7f12b96566b6",
+    "name": "Airelles",
+    "type": "easy"
+  },
+  {
+    "id": "ff3efbd46782725c6db32da34950db49ec583d82",
+    "name": "Signal",
+    "type": "easy"
+  },
+  {
+    "id": "cb3b287576d58091748ba174fd1e1ed91970670f",
+    "name": "Savonnette",
+    "type": "novice"
+  },
+  {
+    "id": "af0fb1f9a30ee4f40dc48c6bd002db7b71c72e95",
+    "name": "Savonnette",
+    "type": "novice"
+  },
+  {
+    "id": "3e8f4b7cc13eeb18d8c806914ca71f7d25bd72d6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "adf220bbbe6f1d0d730d210ea90a0d027c3f8759",
+    "name": "Saint-Jacques",
+    "type": "easy"
+  },
+  {
+    "id": "8dd0d49042ecf7b46b44a3ffd7990b4c166122f1",
+    "name": "Plan Milet",
+    "type": "easy"
+  },
+  {
+    "id": "3b2496c3d02d7844f1f2b7a5580f5a8dee18d483",
+    "name": "Plan Milet",
+    "type": "easy"
+  },
+  {
+    "id": "b1bf138b2377af0e92600307626464244e770c4b",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ab6cdb0ccb90560c75b2c154499667e8c7d776fb",
+    "name": "Leissières",
+    "type": "easy"
+  },
+  {
+    "id": "2e7b97db026a733cc95aede74718022e9c6843f3",
+    "name": "Signal",
+    "type": "advanced"
+  },
+  {
+    "id": "be5da68e5835fab45cb339cc6d6c4aa073e7b1e1",
+    "name": "Pont Abatte",
+    "type": "easy"
+  },
+  {
+    "id": "e34ab960ece7f42121da4f0ad67e376193a30ccf",
+    "name": "Pont Abatte",
+    "type": "easy"
+  },
+  {
+    "id": "1a6d0ae8ea7817d23b0b3a818fa461894823146d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1e27228021097ef9982be9da55d1cca9c25bac89",
+    "name": "Marais",
+    "type": "easy"
+  },
+  {
+    "id": "e6159e36efa8547a49f26cbe8f0c8aed222e4c47",
+    "name": "Lac/Parc à Moutons",
+    "type": "easy"
+  },
+  {
+    "id": "d8a92bdc827bb985c41fd23369e3f66a345c518f",
+    "name": "Face",
+    "type": "advanced"
+  },
+  {
+    "id": "d1a9924c6a10a08a26072cef5367adee55553f4f",
+    "name": "Combe Martin",
+    "type": "advanced"
+  },
+  {
+    "id": "7f7f85be18294840c073841712735326c86f3cb9",
+    "name": "Pays Désert",
+    "type": "easy"
+  },
+  {
+    "id": "c62f6f7a0123cd670b9cf7e869943506fee9ef2f",
+    "name": "Traversée des Arses",
+    "type": "easy"
+  },
+  {
+    "id": "7a6da742906658dc17b21f0c3a1eb891c0aff302",
+    "name": "3J",
+    "type": "easy"
+  },
+  {
+    "id": "aec521ccf3689f4c974aee0bb01bd0e1fcb9a6e0",
+    "name": "Violettes",
+    "type": "easy"
+  },
+  {
+    "id": "866f036b6ce034d78bb1af96971226e244c25701",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "473dabcb2fd41b8bff7b663489a21bdbbed403ef",
+    "name": "Club des Sports",
+    "type": "easy"
+  },
+  {
+    "id": "6b969e712076b4fbe6def6ce3c35cd737fc3fe7d",
+    "name": "Fourche",
+    "type": "easy"
+  },
+  {
+    "id": "ead50144588d5817433f3ac5f5cef91699ee404e",
+    "name": "Petit Bois",
+    "type": "intermediate"
+  },
+  {
+    "id": "91d631acae0a285241147cfe04d477e902e75736",
+    "name": "Cascade",
+    "type": "intermediate"
+  },
+  {
+    "id": "13d00fa2d45c79d43fb14e039c6c925130abaded",
+    "name": "Rocs",
+    "type": "intermediate"
+  },
+  {
+    "id": "193132c8efd632f287ad9a3c5851549400d73971",
+    "name": "Stade de Slalom",
+    "type": "intermediate"
+  },
+  {
+    "id": "98c8d28068405ca6b82ab6a87e6eebbe92197531",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5633aa6610af6d6021dd93983ac5df30423e95ac",
+    "name": "Snow Park",
+    "type": "easy"
+  },
+  {
+    "id": "724fc0f93ab1fcf0571e08e48ad52aa541a45c75",
+    "name": "G",
+    "type": "intermediate"
+  },
+  {
+    "id": "09e5c9414c24fad02728728a545a3dcc6536682e",
+    "name": "Pissaillas",
+    "type": "easy"
+  },
+  {
+    "id": "11a3a5f0fd929c97054f1cbebeab50b0b7e9dee3",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "93665666b10ed7bf39f0918b0f78650050569415",
+    "name": "Joubarbe",
+    "type": "easy"
+  },
+  {
+    "id": "e5410b68401140ba794c0dd3b683d190e9a1b303",
+    "name": "Grand Pré",
+    "type": "novice"
+  },
+  {
+    "id": "4276643042a4df0b11dac3e3eac3e46eb148865a",
+    "name": "Cairn",
+    "type": "easy"
+  },
+  {
+    "id": "5ee02cce6ed0a294895e1fd7f19826ff63fcfed1",
+    "name": "Roches",
+    "type": "intermediate"
+  },
+  {
+    "id": "3d8d53129d7f480345326ca549ea8c9758bcabcc",
+    "name": "Mur",
+    "type": "intermediate"
+  },
+  {
+    "id": "40514b9888e23772837eb4845e70f82cf38f366c",
+    "name": "Diebold",
+    "type": "easy"
+  },
+  {
+    "id": "464fb0e93c6d73079257c90e1725f1e4dca4ff6f",
+    "name": "Semanmille",
+    "type": "intermediate"
+  },
+  {
+    "id": "93f840b59279ee7780432757fd978a8286577058",
+    "name": "Fontaine Froide",
+    "type": "intermediate"
+  },
+  {
+    "id": "aac4723a87d43f1f28211c3eb86da84feeb59861",
+    "name": "Cyclamen",
+    "type": "intermediate"
+  },
+  {
+    "id": "f3c967e05e65fcfb7748430d17651df3c3d6381c",
+    "name": "Grattalu",
+    "type": "easy"
+  },
+  {
+    "id": "93a18ce7367013b845cee34a240253d57c0a32d3",
+    "name": "Henri",
+    "type": "easy"
+  },
+  {
+    "id": "bb351440b1327670429c1f251a5ed2a861decbdd",
+    "name": "Descente",
+    "type": "advanced"
+  },
+  {
+    "id": "b61e0b0824918907211bcc95a6b9d26f541b13b7",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "d0308f49510c6552543501080d3b53e2f86b83ac",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "af55db89a46a41f9be02ee4e3a3c3f6bba53580e",
+    "name": "Chemin vers le Lavachet (piste non répertoriée)",
+    "type": ""
+  },
+  {
+    "id": "5479347f552419ecd1a4bc9108627108e8d2cd79",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a8a9338799987f2977d74eb33e9b0ea69479bd8a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fbc6e4d466d67fd1e41cf0a39851a03d47c7ffac",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c35087289084cb6840dd05184041c338fa21d109",
+    "name": "Grand Stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "d8ea17cf00aa2ea759f6b8566782e1c7628d76e7",
+    "name": "Digues",
+    "type": "novice"
+  },
+  {
+    "id": "2039b5d92f58d861f4e4cacb9e8d5dc43f1cbb30",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "9c2c254c059df588e9fa663821711f1752627857",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "546b9cb2413d53f156604ff6437d2fc360d7286b",
+    "name": "Diebold",
+    "type": "easy"
+  },
+  {
+    "id": "36b7d8ff583c2ac70778e38b02b5ecaf0a0930ad",
+    "name": "Fresse",
+    "type": "novice"
+  },
+  {
+    "id": "858363704000f8b8d097554a1883647eac2fcc76",
+    "name": "Prémou",
+    "type": "easy"
+  },
+  {
+    "id": "c9c6f77f8210b79b192df5932bd710c5198f31b2",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8d34f39a3b74887602348fb781c3be12f3816082",
+    "name": "Double M",
+    "type": "intermediate"
+  },
+  {
+    "id": "9849c658ca0e7be968631cca604ebf351de3181d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "45bdda506b5cc2f7950cd6d4f24717d9f396885f",
+    "name": "Marmottons",
+    "type": "advanced"
+  },
+  {
+    "id": "b0c38518345656709d014c9478da77f59be7bc09",
+    "name": "Diebold",
+    "type": "easy"
+  },
+  {
+    "id": "68916be4c2912666b50be07ec9ff58aa381a3ab0",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e83887c08f8d36c4c1b471711dca3b0990d55360",
+    "name": "Orange",
+    "type": "intermediate"
+  },
+  {
+    "id": "1ec5754e33e2ad81a936b7251402dc3f41477e9f",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "2edcf54036cff0efb6273ca9d73b48466566bd16",
+    "name": "Colchique",
+    "type": "easy"
+  },
+  {
+    "id": "fa1b36d0f20ce8516450a598d3c3b6618c134c7f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d70659ddaeb4bfe10a934f41972ae86161625110",
+    "name": "Isérane",
+    "type": "easy"
+  },
+  {
+    "id": "970765127cd285bfaf3b4e7f888bcd80b5d519b4",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c32783a73b33978542365ea1aa18ebf84337a342",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "205c70da0f58e32ec4c9c30fa573f703750cee21",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "294a745ccbe2c415163a76bc76ae2831b1474d32",
+    "name": "Route de l'Eau Rousse",
+    "type": ""
+  },
+  {
+    "id": "ef88dca7913ce9ab5befdfbf702c869c9c967a28",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "111f3bccc2a986bfef1f748dc084e40478a6babb",
+    "name": "Santons",
+    "type": "intermediate"
+  },
+  {
+    "id": "c9df521fe5b37c4e3ba4d6ee1f79d71f9dfc1843",
+    "name": "Traversée du Rogoney",
+    "type": "intermediate"
+  },
+  {
+    "id": "94e13f28e6f6b827bcb7c8486aaf98f52e182606",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f8f9403131d8785545ada26b88ab14b41cb82ed4",
+    "name": "Route de l'Eau Rousse",
+    "type": ""
+  },
+  {
+    "id": "7d0e3ac8bf279819a0aeb4d113536622a87401f4",
+    "name": "Route de l'Eau Rousse",
+    "type": ""
+  },
+  {
+    "id": "73f5acdee8a04fc87e7217129eac80f663fddccb",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "822323540d64d1b2bef5071f49a1ee267bd93f6d",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "5acae2ab8025de2e25041b68d7312d0944e95221",
+    "name": "Glacier",
+    "type": "easy"
+  },
+  {
+    "id": "0ba8c2ca4df30891280aa4217784d1ce0dac5c94",
+    "name": "Crêtes",
+    "type": "advanced"
+  },
+  {
+    "id": "d0807a0fb7a1351696f0e530915319e68bfd87ab",
+    "name": "Creux",
+    "type": "easy"
+  },
+  {
+    "id": "3b529371b0d03bb8a547f9321d4e35f9c7897e99",
+    "name": "Carline",
+    "type": "easy"
+  },
+  {
+    "id": "c31a16874c5d85953d34f233de00957a714dbbdf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "09858558ad8711c9427c52c12411bf112871150a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "09c9aa4ac01891fb46c9194ff5ff33d22616eb7f",
+    "name": "Fontaine Froide",
+    "type": "intermediate"
+  },
+  {
+    "id": "7786214729ddacbb4f9053cbffeca934c6e39ece",
+    "name": "Boarder X des Experts",
+    "type": "easy"
+  },
+  {
+    "id": "fa49b3575ab1c9da2f63886ca6014e89fbd8ef78",
+    "name": "Myosotis",
+    "type": "intermediate"
+  },
+  {
+    "id": "c1d9c515a76de2f24dd79f5cd89982fcb388f805",
+    "name": "Rosset",
+    "type": "easy"
+  },
+  {
+    "id": "38d34af019409adc49c4435367cbdfc36ab963d6",
+    "name": "Trolles",
+    "type": "advanced"
+  },
+  {
+    "id": "2ba57e562df05d800e7a296f63d0e4fc1be6510c",
+    "name": "Les Tines",
+    "type": "easy"
+  },
+  {
+    "id": "d6459c035b59e04079e67affacaee624adbee460",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6beda5531c57863cbfb9670640f8b908b4d90e39",
+    "name": "Diebold",
+    "type": "easy"
+  },
+  {
+    "id": "c51fc132adb7c176519081c200e21f90706721de",
+    "name": "Coupe du Monde",
+    "type": "intermediate"
+  },
+  {
+    "id": "6bff32fa364d87f2f54ff8157605c1fb26d568bc",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "cfc4af10e0c810d24fc1a85446739ae753ce0eb3",
+    "name": "Diebold",
+    "type": "novice"
+  },
+  {
+    "id": "19f33cdd8a96009fd572291eabe4727e8dc4fb0f",
+    "name": "Bollin",
+    "type": "easy"
+  },
+  {
+    "id": "6c1fb7f9bed2d567299f7a65d31686bb0b2d2790",
+    "name": "Lac",
+    "type": "easy"
+  },
+  {
+    "id": "edcc0c8c787c1e7f132378f9acb33d154bafffab",
+    "name": "Lac",
+    "type": "easy"
+  },
+  {
+    "id": "93406ed9d3460ea21c08f43947caa1dd1d938815",
+    "name": "Piste S",
+    "type": "expert"
+  },
+  {
+    "id": "8637c0402fefbb75b01c7c8e7e8cce0f41cfe08f",
+    "name": "Crocus",
+    "type": "advanced"
+  },
+  {
+    "id": "8dd6945fc0e687f519401e80a46c8cf9ea773d1f",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "6d24991468008c408a9154a3be70d1c64359bbdf",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "a1adbb03848fa708413247ebf2fb80203ad40f44",
+    "name": "Face de Bellevarde",
+    "type": "expert"
+  },
+  {
+    "id": "db00174d705f6db0b3700a536b998e37e0b0d4cf",
+    "name": "Rimaye",
+    "type": "intermediate"
+  },
+  {
+    "id": "6320ab8bf6f6c56abff5f92057c6c425db538777",
+    "name": "Rabotch",
+    "type": "easy"
+  },
+  {
+    "id": "2060cd17b31a728ce7d5a2f45a4e863a2af0d4d3",
+    "name": "Liaison Myrtilles Pitots",
+    "type": "easy"
+  },
+  {
+    "id": "2b1d7400161ad6de03dff024e5bd70b807c20665",
+    "name": "Pitots",
+    "type": "easy"
+  },
+  {
+    "id": "5f043c204b1e539c6d05453b5ed620a45915f26a",
+    "name": "Pitots",
+    "type": "easy"
+  },
+  {
+    "id": "f7e8bf10343f7d13d2aee1e18bcaf3e4b3025170",
+    "name": "Trolles",
+    "type": "advanced"
+  },
+  {
+    "id": "6c4c1404e39c20d7a95e12fb32e78838abe09e10",
+    "name": "Johan Clarey",
+    "type": "advanced"
+  },
+  {
+    "id": "21748cb60855fa6f82f05153b2a5617fe764c1df",
+    "name": "Anémone",
+    "type": "easy"
+  },
+  {
+    "id": "1e8e571aca40c8258295b6b4b42d013e2cf8e76d",
+    "name": "Gentiane",
+    "type": "easy"
+  },
+  {
+    "id": "4559495433c7c373b21620dd9144163953500b37",
+    "name": "Stade de Lognan-Compétitions",
+    "type": "advanced"
+  },
+  {
+    "id": "ca1398dbdb80eac6a6fe1b9021eb62d1d24004a7",
+    "name": "Cafo",
+    "type": "novice"
+  },
+  {
+    "id": "db3116ec995fe3a0623302bab296db3462d2d160",
+    "name": "Grattalu",
+    "type": "easy"
+  },
+  {
+    "id": "71103bfba6b62e7a79cfd09aeee37cc3edd10666",
+    "name": "Cirse",
+    "type": "intermediate"
+  },
+  {
+    "id": "4948904e7a5160dfba3d638ec5a71732ba651907",
+    "name": "Carline",
+    "type": "easy"
+  },
+  {
+    "id": "ecb1fcc346fe2bfb87cc75db9a9bc3a1310158ba",
+    "name": "Pramecou",
+    "type": "advanced"
+  },
+  {
+    "id": "146cf4b149aa84169a24801a54f5c8d6624d61ff",
+    "name": "Bleuets",
+    "type": "intermediate"
+  },
+  {
+    "id": "44d06c19ffb2b9aca6390b30d400e2fb9ccd82f5",
+    "name": "Rhododendron",
+    "type": "easy"
+  },
+  {
+    "id": "3c7bdc6ccd9b2df3f1f828faf02b582b7f6da2c5",
+    "name": "Aiglon, Arollay",
+    "type": "easy"
+  },
+  {
+    "id": "d2fdcbf0aae5ba6d83f05ba8d2841607032577e0",
+    "name": "Aiglon",
+    "type": "intermediate"
+  },
+  {
+    "id": "f53a09c4066173634738ec836f9cf9f8fe2aac33",
+    "name": "Mélèzes",
+    "type": "easy"
+  },
+  {
+    "id": "6e966935f73235a7bc901430650adf65762a9432",
+    "name": "Signal Bas",
+    "type": "advanced"
+  },
+  {
+    "id": "4ab1e391cd0651e9a4ad838beddf9f4a7ca2a221",
+    "name": "Centre",
+    "type": "novice"
+  },
+  {
+    "id": "c435d90eef4ed7315f25a917578855bd570482f5",
+    "name": "Face",
+    "type": "intermediate"
+  },
+  {
+    "id": "c2961f0fbcf478a8ae55a9003d7a1d395f8b3af4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "866fabc342781b07c2d6f5bb1bcb8c23ebc08c8b",
+    "name": "Easy Border",
+    "type": "easy"
+  },
+  {
+    "id": "1e3cbe60645f53f1bbd07d72c06b0d4f61b1e18e",
+    "name": "Boarder Cross",
+    "type": "intermediate"
+  },
+  {
+    "id": "c211bb7ab8b8833e0f6df9b5730b571da3a2a36d",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1150bff7a96d9e7b30772f0859e847e72e173ced",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f5a748eb8546d14326e31675afc0c29dcb022797",
+    "name": "Génépy",
+    "type": "novice"
+  },
+  {
+    "id": "a1581baa490d82b3763e5c7ca8f9096ec876b0a7",
+    "name": "Fresse",
+    "type": "novice"
+  },
+  {
+    "id": "6fbeb4eb87e3e29f1df66b15c3c1e1671bc4f718",
+    "name": "Verte, Mont Blanc",
+    "type": "novice"
+  },
+  {
+    "id": "ddb712f45d4b1b8d4ea2cc3be576201fececcd86",
+    "name": "Chemin des Côves",
+    "type": "novice"
+  },
+  {
+    "id": "88021c77c035dc2cf5e8f3a061da2c12e38a0011",
+    "name": "Borsat",
+    "type": "novice"
+  },
+  {
+    "id": "7da7f16cde497fdb05dcc4b98ef57b0c385c837a",
+    "name": "Collet",
+    "type": "easy"
+  },
+  {
+    "id": "422b6677347b2d9693a9e12b5d5401fd4605db63",
+    "name": "Mont Blanc",
+    "type": "novice"
+  },
+  {
+    "id": "22a4cc1ce5ccb3479964097ac779c95a73c63e83",
+    "name": "Myrtilles",
+    "type": "easy"
+  },
+  {
+    "id": "19c00d0b9c8d0edc3d914052c44c029c22f9e0fd",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "fe6110a81dc0afe9ed8404c781f831b5581cf12d",
+    "name": "Isolée",
+    "type": "easy"
+  },
+  {
+    "id": "000a4e7ebcfca5a5b44c5565e04a39968e415796",
+    "name": "Prariond",
+    "type": "easy"
+  },
+  {
+    "id": "246fc50cb9cc3500fae4109dd4ce497d62138b70",
+    "name": "Boïu",
+    "type": "novice"
+  },
+  {
+    "id": "7c54a900616c902d6c5c70ba1b4dfbe019f9e1cc",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "e62628b5f02d71c9123788858d3f719092d4ea6f",
+    "name": "Poney",
+    "type": "easy"
+  },
+  {
+    "id": "26a76c7287b2c17de7be6f460e42d29049bb6004",
+    "name": "Face de Bellevarde",
+    "type": "advanced"
+  },
+  {
+    "id": "5d293b717f3f866c7f2592833b78f6a028ada13b",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "255bbf367a8cb9162cfd87586aa58f2ed596d7a8",
+    "name": "Pyramides",
+    "type": "easy"
+  },
+  {
+    "id": "7ebbfaf1b1f5aed9f4048f7c87b14e70856f6e2c",
+    "name": "Vallon",
+    "type": "easy"
+  },
+  {
+    "id": "d3b8fb15f30fb8f774f035775e101ac5006655a3",
+    "name": "Piste L",
+    "type": "intermediate"
+  },
+  {
+    "id": "5301a844d909913346fb3c4bb23a13d57c285b6c",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "08e533588e1e33cee9af70fb3d229f061e4d1ff9",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "099845549133a20cb49aff91e0d1d4d404fb9a4d",
+    "name": "Primevères",
+    "type": "advanced"
+  },
+  {
+    "id": "d4e5f88f45d2fb0fe4bfa4c0cba2f22470583d09",
+    "name": "BMW xDrive Cup Ski Movie",
+    "type": "advanced"
+  },
+  {
+    "id": "ee33e14edbd733e23114b23c28f5851deafa1c92",
+    "name": "Rhône-Alpes",
+    "type": "advanced"
+  },
+  {
+    "id": "195664a7d50482a16c036deb50301060ede7fedb",
+    "name": "Traversée du Rogoney",
+    "type": "easy"
+  },
+  {
+    "id": "8d51739842cb0fba1dd254d7badba120195b526b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7c5c3bfb9377b918ec4a134f680439d79c63ba10",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "52ee54683af591763efc3d7d742482bd2420ca4d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "482b34ac57343f4185186097fbd8a03e5b46c3cd",
+    "name": "Chemin vers le Lavachet (piste non répertoriée)",
+    "type": ""
+  },
+  {
+    "id": "3c1da3ce806523731243233063d63f575692e6da",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "5130b016198e07c5888aabb08fdf1a551d0e82c1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a035754b6c28f84090799cb0009af7db27f6190d",
+    "name": "Arcosses",
+    "type": "intermediate"
+  },
+  {
+    "id": "f0b1208545624f167e286f5e5c2e6c48389727d0",
+    "name": "Mélèzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "712549c739e8ead8b9eed65c798eae4b69d7bc9e",
+    "name": "Chardons",
+    "type": "intermediate"
+  },
+  {
+    "id": "75c3638dbe404f67ee92cbe7f0d1dc1e6087f393",
+    "name": "Mélèzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "b9a84f467dc6a831810dbe27fac104ab25e631ec",
+    "name": "Mélèzes",
+    "type": "intermediate"
+  },
+  {
+    "id": "848658357341fa61cebdc81bf4f7f900ae94dc88",
+    "name": "Arcosses",
+    "type": "intermediate"
+  },
+  {
+    "id": "3818fa899957b2225d7f214ca673e7114b3d4baf",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "97ff7d722acc842fa10c4c2a84119ed5d5a696be",
+    "name": "Pont Abatte",
+    "type": "easy"
+  },
+  {
+    "id": "cf739010d3d0668d0a807a270a747983ea69a595",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ba76a719d7817000a1a1342ee3ba41c16b31e97f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "da193f157cad529910ab0ef0f4fe5d082d02200a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "11510a1880abc7a08b806dc337c2577507e5d4f4",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "3bca271965b8823adbbed2cb11ebb08c1ba247a5",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "ee5f22b2086b50eda799a1c3553fc5f9aea50909",
+    "name": "Pyramides",
+    "type": "easy"
+  },
+  {
+    "id": "4d617469b4d6a2a1d43f5ee1896bb258b74be714",
+    "name": "Lac Céma",
+    "type": "novice"
+  },
+  {
+    "id": "d02a68a69188f1e9ef8563ef80e94fd6732414d2",
+    "name": "Pays Désert",
+    "type": "novice"
+  },
+  {
+    "id": "70afaa27e7d60388774b80e7c50c3358663b24b1",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "e1bb664971c07e2392c04d1c7cc025f02e00031d",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "70be1a8df26921fdd4756e37c66047806d35d75d",
+    "name": "Triffollet",
+    "type": "intermediate"
+  },
+  {
+    "id": "b2e2224c71401b88ab94308f13a8dedb91985c04",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "ac2df9e48c1e51223b19f4769a1bcce574fc320e",
+    "name": "Parking Ski d'été",
+    "type": "easy"
+  },
+  {
+    "id": "cbb8cecda79e2d54172aad1505ef84b9e8879916",
+    "name": "Traversée du Rogoney",
+    "type": "easy"
+  },
+  {
+    "id": "ad21e29f7fbfc3f78ee8bd230637d99a9ebeac58",
+    "name": "Mangard",
+    "type": "easy"
+  },
+  {
+    "id": "d6aa8ce8367cd0cf67761392965ed9a5f380cfeb",
+    "name": "Henri",
+    "type": "easy"
+  },
+  {
+    "id": "7ad456a060c17edce8d96aba52433b557958a407",
+    "name": "Henri",
+    "type": "easy"
+  },
+  {
+    "id": "105b862f3648a59dd9b5ea57f9448ee2f19bc325",
+    "name": "Joubarbe",
+    "type": "easy"
+  },
+  {
+    "id": "bb785bdef207929f29fb94fe3550d24c591ad668",
+    "name": "Joubarbe",
+    "type": "easy"
+  },
+  {
+    "id": "754710a96481b1ad706749fa62170a83eecf2498",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "44ab8036577848c62635ba8773ba6c7f9df9eec4",
+    "name": "Verte",
+    "type": "novice"
+  },
+  {
+    "id": "7d492e1f1e7852ded0bd37ebddc8f05328668ac5",
+    "name": "Le Plan",
+    "type": "intermediate"
+  },
+  {
+    "id": "c2f4f583f50ebc1162d2eb6ab900df75ba85e399",
+    "name": "Traversée du Rogoney",
+    "type": "easy"
+  },
+  {
+    "id": "c1a5fe06622d126c10a0b0423a54efc793ab4530",
+    "name": "Village-I, Village-II",
+    "type": "novice"
+  },
+  {
+    "id": "30dcf6d9ddff23613a7724960de4de9a8c1bf9fa",
+    "name": "Village-I",
+    "type": "novice"
+  },
+  {
+    "id": "f22791aac4ba02231751826a16a4ab0a22a74def",
+    "name": "Village-II",
+    "type": "novice"
+  },
+  {
+    "id": "850a28c01fba1ee6cc3a7f8fe5fa3730c4ce2a8b",
+    "name": "Santons haut",
+    "type": "intermediate"
+  },
+  {
+    "id": "1697ef50382244969dc7927fd8f2770736ad8039",
+    "name": "Corniche",
+    "type": "easy"
+  },
+  {
+    "id": "3596e7b0d342da1df89e810a601ab2ce8077dc57",
+    "name": "P'tit Cross",
+    "type": "novice"
+  },
+  {
+    "id": "8c882ee589138de6e04d20de8ed0fac854eb065c",
+    "name": "Germain Mattis",
+    "type": "intermediate"
+  },
+  {
+    "id": "0f98bb7426aadcf504de99c624aa129b1bf9c1b5",
+    "name": "Route du Col",
+    "type": "intermediate"
+  },
+  {
+    "id": "cbfcef3bb8b4ba02027f7e27d83ae646233ccd21",
+    "name": "Mangard",
+    "type": "easy"
+  },
+  {
+    "id": "c7f2f506adbb513c198673c299baef5971368c87",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b83b87f106bddb92c7fc3d2561b272674071aee3",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8f5bf502ddcd26cc0fdc160fbcc983e4a45c96aa",
+    "name": "Digues",
+    "type": "novice"
+  },
+  {
+    "id": "639aa11e3c9c8619b2fbb5093d9e58f26f8448e6",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "01b8ac17892d9d69763dba3fd71b9e37a3cb8464",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "c25986719f6dfd64ef30b66a8bef548f9086d779",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "42669e1ace6c81343e1bf8ddfff6eb437e5baef1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "16f38d727a28ac1c00551fd40f012a779efadc85",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "95076fd7dba9bc3d52c6151cfcecbdfdd808cf54",
+    "name": "Lanche",
+    "type": "novice"
+  },
+  {
+    "id": "db662a24a235d4472ba815b67c3e4515203f3eaa",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f536d1cf52c310421b2e2139674681de3902b3db",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7d2257ac9c83d2c7c89ee1b81b279f3e044daf16",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "8a2ed509ad4b4f7b9def0aa4270860bd3ef98734",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "356cb46cdd610884efd1565952163b3d37d1330a",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "7fa012708f8d5ce064d7667da817d75a2ccee2fc",
+    "name": "Bec Rouge",
+    "type": "easy"
+  },
+  {
+    "id": "f358b8dbe380f31ec15d30b662541df638a26526",
+    "name": "Combe",
+    "type": "easy"
+  },
+  {
+    "id": "9edb6f5b76e59c9541f69dbb878ee07c86acc76f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "1fda8fd7161edb7e66b8177021b68f419388f67f",
+    "name": "Joubarbe",
+    "type": "easy"
+  },
+  {
+    "id": "84aba9a226f109ddf17a3af0534bb0b4ee104c9f",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "34881adf7a9e08d3372e7a21e7dfa26b9f3f42ca",
+    "name": "Petit Col",
+    "type": "easy"
+  },
+  {
+    "id": "ded3ca5991565f63950d3797217506ac56133127",
+    "name": "Digues",
+    "type": "novice"
+  },
+  {
+    "id": "30b9ec01482dfcff5cf9336f715ca2ac9609e272",
+    "name": "Retour Lavachet, Lavachet",
+    "type": "novice"
+  },
+  {
+    "id": "11bb7ddad6e9d00780d40ec8ff29720031af6a7d",
+    "name": "Lavachet, Digues",
+    "type": "novice"
+  },
+  {
+    "id": "5635f4b1c1632f22b059ddb20634c7b5bfdf5229",
+    "name": "Lavachet",
+    "type": "novice"
+  },
+  {
+    "id": "eb3fcacf9efcc33893fabf1942ecebc26c7caac1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6a41cb3336bb17f31dd345aaf50daacc3a5f19b3",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "93ace88ac78642a11a157ecf4874ce4a23a5c029",
+    "name": "Crocus",
+    "type": "intermediate"
+  },
+  {
+    "id": "37f2792d2f01c1f175d5acd0f843dbe93f1b6a0d",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "03256e87d5cc849605a1813c24b3abeb22a6bfb5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "df6328460a54524d21e9e887aea4bdf7b61801e3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4d24d1e368aef70dced9d2c538d2e2972a7e2469",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "01963dea5c2fc76e30cc6b39711667dca903410c",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "972218f06b3ea2ccf08b3cad52b514c60871a756",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "341febbdbf5787021601369d4fdb103014f0b207",
+    "name": "Couloir de petite balme",
+    "type": "freeride"
+  },
+  {
+    "id": "39fe3ef7d0832ab4171b794f5e557e47cd7310cf",
+    "name": "couloir de grande balme",
+    "type": "freeride"
+  },
+  {
+    "id": "7d937bf0ef4549b1309f82c723048c0490c93c1e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "514ac36e599948691fb0c14edd6da097de8f7432",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "20a8e47419a70fda7d60790d3dd7b0baf1c2b9c5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "3d324d580e5b23a3d297bd0f9d631166af108399",
+    "name": "Dahu",
+    "type": "intermediate"
+  },
+  {
+    "id": "23e685291b248096d140edbeb914d19e270fc230",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "effade16b18cc98405b33a1e58245a642a9602c1",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "0e890a66e3a9ca11c7dac1ed441904f15f0df861",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c6a1b735497c08f8850775f971f3337d7e4daae9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "11bd5c102ed3d9781b500f4952a398010cc11d00",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8e7354563d5e0987f18e430930313193327ae32e",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "b8e9d0c5d5ab5bdef11b4821229a3561e9e210ed",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "5c97cfeaf0eef38ab2689c63c04e848992eea4bd",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "64dafd4d8f536e552c6dbc6812f0abf09ae4725a",
+    "name": "Leisse",
+    "type": "intermediate"
+  },
+  {
+    "id": "8cb39e84d96733ec44bafa9d93382282c08992d6",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "38a4084a408e15c050390c6054fe9a7b164d73f0",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "05d201bcc2121f0ae56b7629bf00c63052f1b834",
+    "name": "Chardons",
+    "type": "intermediate"
+  },
+  {
+    "id": "412186ea5053a1cbace85b8b459ec3d0146b45da",
+    "name": "Arollay",
+    "type": "easy"
+  }
+]

--- a/lumiplan-maps/data/vaujany-lifts.json
+++ b/lumiplan-maps/data/vaujany-lifts.json
@@ -1,0 +1,417 @@
+[
+  {
+    "id": "d4f28c26e3b4f9d6b6acb318157cb3bea7c7803c",
+    "name": "Le Villarais",
+    "type": "chair_lift"
+  },
+  {
+    "id": "20bc247107547d522598ef67f1caa73a7547963c",
+    "name": "Romains",
+    "type": "chair_lift"
+  },
+  {
+    "id": "3dfbaca5b7f76139e21efe73575ee9e47e5a98bd",
+    "name": "Marmottes 1",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "f69c7c7679c0d66dcabc9fb1982ce32644ec8ec4",
+    "name": "Pic Blanc 2",
+    "type": "gondola"
+  },
+  {
+    "id": "240e7e4d44e20d9c251c9726002c15bcf23dfcf0",
+    "name": "Pic Blanc 3",
+    "type": "cable_car"
+  },
+  {
+    "id": "64f5c2e0133ce2c05288a987d722949115708c88",
+    "name": "TC Alpette",
+    "type": "gondola"
+  },
+  {
+    "id": "2362a4a756456fb28c55b958f49c0ebb19d151cb",
+    "name": "Poutran 1",
+    "type": "gondola"
+  },
+  {
+    "id": "311c96115d3639be8b1d1602268aa39dfea0cf50",
+    "name": "Marmottes 2",
+    "type": "gondola"
+  },
+  {
+    "id": "13d7bde831add84546e663e9aa20f2ecb70c53dc",
+    "name": "Marmottes 3",
+    "type": "cable_car"
+  },
+  {
+    "id": "08e4af9eca2111eb886352b428ef76ca62a5e64f",
+    "name": "Lièvre Blanc",
+    "type": "chair_lift"
+  },
+  {
+    "id": "29b5919a6d108c8d733acf033c5fde045fae6240",
+    "name": "Alpette-Rousses",
+    "type": "cable_car"
+  },
+  {
+    "id": "c4d44d1b25af44228967c72646edaa3560ea7e46",
+    "name": "TK Alpette",
+    "type": "platter"
+  },
+  {
+    "id": "309b323031916416c4203c90e9099df32cc7331a",
+    "name": "Olmet",
+    "type": "platter"
+  },
+  {
+    "id": "7150aa1ac6539ae6361249058c7c6c9585662cd3",
+    "name": "Champ Clotury",
+    "type": "platter"
+  },
+  {
+    "id": "48b7afd64d48c3420efc64733b31e0f7fe557e9f",
+    "name": "Herpie",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2cb4f141c0682655857aca086db7a659bfd54b19",
+    "name": "Télécentre",
+    "type": "gondola"
+  },
+  {
+    "id": "2b255fe0277b5b25a65d19e040577e6ea0e39ffb",
+    "name": "Lac Blanc",
+    "type": "chair_lift"
+  },
+  {
+    "id": "c695f56ee5ef968a87b0b1f2ed94a3db35ce63ec",
+    "name": "Lama",
+    "type": "platter"
+  },
+  {
+    "id": "2b3a74ed8d586307a2421aff3f1ce75af6850ef7",
+    "name": "Petit Prince",
+    "type": "platter"
+  },
+  {
+    "id": "560e364ccd110ed37b50fa0e3087c11e0eaab10d",
+    "name": "Alpauris",
+    "type": "chair_lift"
+  },
+  {
+    "id": "664075557f8202804fda09e9213c2f5544b699f2",
+    "name": "Louvets",
+    "type": "chair_lift"
+  },
+  {
+    "id": "be9645292b5d594cb5c4c40ca2f378167d1e61b1",
+    "name": "Auris Express",
+    "type": "chair_lift"
+  },
+  {
+    "id": "9eff14dbd889e0ae9fe1d9708dfe542ce1b16920",
+    "name": "Fontfroide",
+    "type": "chair_lift"
+  },
+  {
+    "id": "03a7dbef58123c43729079661940b5ddd82550dd",
+    "name": "Enversin",
+    "type": "gondola"
+  },
+  {
+    "id": "82755fe98b70a754a586a9e1c5184a10caf07c42",
+    "name": "Vaujany-Villette",
+    "type": "gondola"
+  },
+  {
+    "id": "8dfb1909725e2637a38a5d139581e0b17c587b39",
+    "name": "Villette-Montfrais",
+    "type": "gondola"
+  },
+  {
+    "id": "9c2f06720b3ee15222531ecbf31eedbc3380a3ab",
+    "name": "Montfrais",
+    "type": "chair_lift"
+  },
+  {
+    "id": "e8a26cd437ece7cadf025ad6896041f0fbb44c6b",
+    "name": "Vallonet",
+    "type": "chair_lift"
+  },
+  {
+    "id": "02fe7fa5f0b5f8fa16ef0f4486bd773176fe199e",
+    "name": "Tapis Olmet",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "d48bee4b9af3ccada64980dfd231fec84e9189ed",
+    "name": "Clos du Pré",
+    "type": "platter"
+  },
+  {
+    "id": "52f37ad219892c144345aab4bd930f9d7dfe2f30",
+    "name": "Maronne",
+    "type": "chair_lift"
+  },
+  {
+    "id": "16496e3832d2df49456f9a4de57f7ed71aae0525",
+    "name": "Babars",
+    "type": "platter"
+  },
+  {
+    "id": "83314e487785a1b3dd12f9da2c4e8306dd88b20a",
+    "name": "Grande Sure",
+    "type": "chair_lift"
+  },
+  {
+    "id": "e01171aac79954856bfb3e3d62b38674bd2bc71b",
+    "name": "Lombards",
+    "type": "chair_lift"
+  },
+  {
+    "id": "4fbd93dae67e95d54980f7ae38d06d1b4a6af65d",
+    "name": "Vaujany-Alpette",
+    "type": "cable_car"
+  },
+  {
+    "id": "04b7dcea1c7d4e3e28b6fd615bef9b2785c25cff",
+    "name": "Pic Blanc 1",
+    "type": "gondola"
+  },
+  {
+    "id": "4c0a255d7e4108013adf6d90306a659849bc260d",
+    "name": "Cloudit",
+    "type": "platter"
+  },
+  {
+    "id": "55aebc9c4d1305ea1469d2a79573f833f2d7c5e7",
+    "name": "Langaret",
+    "type": "platter"
+  },
+  {
+    "id": "65b69a9afae90fbc889a965b0e7b4adbdc0203a9",
+    "name": "Rif Nel 1",
+    "type": "gondola"
+  },
+  {
+    "id": "2cf43e89411c5d3fccaa7163d6343908615a6c7f",
+    "name": "Tortue",
+    "type": "platter"
+  },
+  {
+    "id": "7ed109ffa4232b3839e5ad907fe27c47d6868833",
+    "name": "Huez Express",
+    "type": "gondola"
+  },
+  {
+    "id": "4c39cea89028e3cd3872f6321218ca8e97b8c816",
+    "name": "Stade",
+    "type": "platter"
+  },
+  {
+    "id": "337eef38d3ef159c714f8ca53f5f547f2da014aa",
+    "name": "Ascenseur Villard",
+    "type": "funicular"
+  },
+  {
+    "id": "78d92ffbbab21e721dd6f7d15bc7d19ce84b2056",
+    "name": "École 1",
+    "type": "platter"
+  },
+  {
+    "id": "bbef622fb65b5ec3d875ee50dc03d6802bf8c199",
+    "name": "École 2",
+    "type": "platter"
+  },
+  {
+    "id": "846709a093cbc2a16aefa96b8a6bd034c1a9db86",
+    "name": "Tapis Montfrais",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "91032816cad8f8723ec777e409ba323970c30d0e",
+    "name": "Clos Giraud",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "8f029bee2fe09818ce85ddd686dfb07c7850fcb2",
+    "name": "Jeux",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "5f1c3f73c6577a1d9969c7b224a8c85e948a5fd0",
+    "name": "Bauchets",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "a7f92fa729ddec6bf67209e08cb9917bd4e1dcc6",
+    "name": "Grenouilles",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "cb27ef0b5a679d0af5080f4832f354c433a91bff",
+    "name": "Sagnes",
+    "type": "platter"
+  },
+  {
+    "id": "4601b0c2b966009021406097fff3a4ea436f926e",
+    "name": "Poutran",
+    "type": "platter"
+  },
+  {
+    "id": "1a0ff3b65b3755b9d4af4dcdec9cb21aacae1bf6",
+    "name": "Tapis Bambin",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "2ee9d4c727d6543fa2cf6d36e95d89f47763c671",
+    "name": "Piégut",
+    "type": "platter"
+  },
+  {
+    "id": "dd282f0ac67df56d39ccb89f2912ae416d9c81be",
+    "name": "Forêt",
+    "type": "platter"
+  },
+  {
+    "id": "1c1256ee731ba42af22bad747d20a7a4fd249706",
+    "name": "Signal",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "895a93679e42f618d4435a992df7435db9e11861",
+    "name": "Alpe Express",
+    "type": "gondola"
+  },
+  {
+    "id": "7c3fc119056985da4edd5a6f8b228cdda78631a9",
+    "name": "Tapis Escargot",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "f196a8eaabb9d9b1abae65265288ac084ac454c7",
+    "name": "Eau d'Olle Express",
+    "type": "gondola"
+  },
+  {
+    "id": "7ae26a018b9a9273fbe612544fa798d4a68e82be",
+    "name": "Rousses",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "2219f81846e4372c2ff75a90d7b22ff3a7ef8648",
+    "name": "Poutran 2",
+    "type": "gondola"
+  },
+  {
+    "id": "dfc0934b6f52ed5e22ba54c7166f545e8ca742be",
+    "name": "Montfrais 1",
+    "type": "drag_lift"
+  },
+  {
+    "id": "25fea42b8feb261399185e7b92b2b50a614e2695",
+    "name": "Chalvet",
+    "type": "chair_lift"
+  },
+  {
+    "id": "2068d1712bcc0a189b34ec18ad7d9eb8dc6437bc",
+    "name": "Tapis Bergers",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "57f2d15618ceacd171d9acf4d4bdf1eaa1bed8e2",
+    "name": "Tapis Moutons",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "3b5e95fcd8d5351426283a4237590c88e8178cee",
+    "name": "Fil Neige",
+    "type": "rope_tow"
+  },
+  {
+    "id": "c02e6c65924444bb91dd7618aa88dbfe5c688ce5",
+    "name": "Écureuils",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "4b343019a5d2b84b6178f16b26ad0501e2d646e7",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "0e278e952d30054b27d18128db3ac7b5853e39cd",
+    "name": "Sures",
+    "type": "mixed_lift"
+  },
+  {
+    "id": "46e9f815f60366b6a16fb9d10c446861d533fa10",
+    "name": "Tapis Rif Nel 1",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "350df9106545179176df8c3bc40051fe1c5686bc",
+    "name": "Tapis Rif Nel 2",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "85286c837783313a201fb8b17aaa3d92202c6e47",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "4cd4f30d0c7c712f3824919997b15f4a098b3ee4",
+    "name": "",
+    "type": "magic_carpet"
+  },
+  {
+    "id": "1efba5ce2b3c05a50db4678b3bdf7a8773998a7b",
+    "name": "Rif Nel",
+    "type": "gondola"
+  },
+  {
+    "id": "d61cde77154ad834761bb339f13873a169295da7",
+    "name": "Rif Nel 2",
+    "type": "gondola"
+  },
+  {
+    "id": "a2507b7f20a0d9277067920c31d1ca0f9615e75d",
+    "name": "Pic Blanc",
+    "type": "gondola"
+  },
+  {
+    "id": "e3f4eda46d4828453da5f8fb71ebe91a712748d4",
+    "name": "Poutran",
+    "type": "gondola"
+  },
+  {
+    "id": "35e6e18e7c4e39c576db71855daf9e438719f026",
+    "name": "Huez Express",
+    "type": "gondola"
+  },
+  {
+    "id": "1c09d07e1c834f922d8d1585dcf949d3b3a1d8d9",
+    "name": "Huez Express",
+    "type": "gondola"
+  },
+  {
+    "id": "b62be2f4a94553f15fc7be2e4913e8df956837c6",
+    "name": "Alpauris",
+    "type": "chair_lift"
+  },
+  {
+    "id": "f3334c30c055c710584e571f5942deefc4e7d3d4",
+    "name": "Alpauris",
+    "type": "chair_lift"
+  },
+  {
+    "id": "695d7e94ee071b9e331b3ab91649d113b1004195",
+    "name": "Alpe Express",
+    "type": "gondola"
+  },
+  {
+    "id": "9f4d4fbb4da534fc0ced0e5ab897023f24cf2591",
+    "name": "Alpe Express",
+    "type": "gondola"
+  }
+]

--- a/lumiplan-maps/data/vaujany-runs.json
+++ b/lumiplan-maps/data/vaujany-runs.json
@@ -1,0 +1,1807 @@
+[
+  {
+    "id": "566d9dff4cdc9f50031eabafe0beffa059ef7569",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "7a8cd47713171b77876c5dbb3cb603559e86c8ed",
+    "name": "Crocus",
+    "type": "novice"
+  },
+  {
+    "id": "f8a273271330c6bc74392e31abb1ec301e810733",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "95de658dca5f3452d1c31b318bf8884d22cbb272",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "41aabc1686edaec8ccc08ef5b91a0d54a0bb89c5",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "5a1970f720aa193063e2c4cd461a7e26f93f80b7",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "a5c44369b443d3c3cfea74c63a7843ca3ebfc1e9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "22c6f3acdd69af3465863fe6350a157d86dfcdfe",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "dda237a674fe61d6faf1b696c85e09c5434e2199",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f41e382a6f3147c6f2ef6570d42b5113eeff14f3",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "ae14a1cca0f7c426bb32c12340f4ff4f19b93d75",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "6d37705f590796a97fad4e1c555a3db24f7c6159",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a43a7e3a1b79b8aa3e934bccdeb1f91df9e08511",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a9b96d38041115ae61ebc0fe43149097235d3b69",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "a3a04d2cd4e2a5036b5383f7eb33f24a8538b64a",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "26ee19d23aa35688263a47bf8e6fb9a5135f17e9",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "65f7d99bac0c931a31e3053622adf400be9eb773",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "d5abf9848087f41bff2135ce298e75bc589ee25c",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "43b3ed2657be8d49500b40dff99a93cde54ac7e5",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "8321046cbe889bc01802f61daaf898f3f832385c",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "10548247ff8d369a9bf74dc765d0c19fb460e5d2",
+    "name": "Balcons",
+    "type": "advanced"
+  },
+  {
+    "id": "bc00469ec73d9826efa2c37058629fa7e0e39af9",
+    "name": "Promontoire",
+    "type": "intermediate"
+  },
+  {
+    "id": "c211d93ade18c4bbda6dc6c178e5649eb420cfa0",
+    "name": "Promontoire",
+    "type": "intermediate"
+  },
+  {
+    "id": "aaa1c48e5fa8c47ecdf021f23da2e0ddf2f8e5fc",
+    "name": "Alpette, Les Lacs",
+    "type": ""
+  },
+  {
+    "id": "ee67236626dcde871195cb6b36c498ece263151d",
+    "name": "Alpette, Boucle des lacs",
+    "type": ""
+  },
+  {
+    "id": "9198e29721f7fbf9cb8b7e15a835d02d5c5d31bd",
+    "name": "Alpette, Boucle des lacs",
+    "type": ""
+  },
+  {
+    "id": "073eb4930fa0d5b8fcab2f6268ef52f5ffb4eaa8",
+    "name": "Lac Besson, Boucle des Lacs",
+    "type": ""
+  },
+  {
+    "id": "9517e75223cb23fce96f9f9ad9064f414fdd2d71",
+    "name": "Poutran",
+    "type": ""
+  },
+  {
+    "id": "9438aa068bdddf6a849c69d35c63338429022c78",
+    "name": "Poutran, Boucle de Poutran",
+    "type": "easy"
+  },
+  {
+    "id": "087eae384358ee447d2dfd3f5ebb1d7807e035df",
+    "name": "Poutran, Chardons, Boucle de Poutran",
+    "type": "novice"
+  },
+  {
+    "id": "9f7af547cdc36b9e2613e61d2979b92139b3be8e",
+    "name": "Poutran, Boucle de Poutran",
+    "type": "easy"
+  },
+  {
+    "id": "4bd56da2e39e27921a26d96278edb67acfa73270",
+    "name": "Poutran",
+    "type": ""
+  },
+  {
+    "id": "e12e6408a389dfe679cc9bab91b1c2d738c93dd1",
+    "name": "Gorges de Sarenne",
+    "type": ""
+  },
+  {
+    "id": "90264b6abef997a7c3ddd8abd80104282f99ddc6",
+    "name": "Couloir",
+    "type": "easy"
+  },
+  {
+    "id": "e5edc8d4781745f6bd332140c0fe1db0cbd50e07",
+    "name": "Chamois",
+    "type": "intermediate"
+  },
+  {
+    "id": "d5ff0ab4a78aaf37133870c805c3fe0aa8966e85",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7ce43f3586260d3a45cc489f27bef0910deea626",
+    "name": "Jeux",
+    "type": "novice"
+  },
+  {
+    "id": "37de42a67173e4f9a499bccb79fd3f33f3574880",
+    "name": "Boardercross Family",
+    "type": "novice"
+  },
+  {
+    "id": "00ad11177a5d45472bb62e73f883f29ecf37f846",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "e3fc12ae1f25d159bcccef8a590af2085ba97a68",
+    "name": "Le Belvédère",
+    "type": "intermediate"
+  },
+  {
+    "id": "bca0640c93fe6e5f58fe738d9ce30ec447b8f6e4",
+    "name": "Rousses",
+    "type": "intermediate"
+  },
+  {
+    "id": "7f5c4c83123dd98fe5167ce2dccd1ccba72a8850",
+    "name": "Bartavelles",
+    "type": "intermediate"
+  },
+  {
+    "id": "261d07dad886420ec4d1e4d19b0f645a9b57f7cb",
+    "name": "L'Alpette",
+    "type": "intermediate"
+  },
+  {
+    "id": "42579d0e2095f7997d2661a4fc1600e6daaa5fa1",
+    "name": "Champ Clotury",
+    "type": "easy"
+  },
+  {
+    "id": "7665dcaee112f43af020a329b37f27019d89bec3",
+    "name": "L'Olmet",
+    "type": "intermediate"
+  },
+  {
+    "id": "649807c474d90119b4d6e499edacb746a4c1a762",
+    "name": "Canetons",
+    "type": "novice"
+  },
+  {
+    "id": "86a8699c294e21e2fa04cc28205d946085f25f68",
+    "name": "Le Gua",
+    "type": "easy"
+  },
+  {
+    "id": "843f09e23955186c5114c0f5c5e8f90e01900c69",
+    "name": "Clocher de Mâcle",
+    "type": "advanced"
+  },
+  {
+    "id": "c196f92106046d2ea8238eada825ae9669ea6d92",
+    "name": "Déversoir",
+    "type": "intermediate"
+  },
+  {
+    "id": "80d9a2f75e6fef8f053e90c5c0225ee7d956f4dc",
+    "name": "Campanules",
+    "type": "intermediate"
+  },
+  {
+    "id": "586843f9cd5d9d5acdb206eda4d8e8348185ee1b",
+    "name": "La Balme",
+    "type": "advanced"
+  },
+  {
+    "id": "1ea37b96d1e873a03a7f4e4ef4bb551b8d25283f",
+    "name": "Les Bergers",
+    "type": "easy"
+  },
+  {
+    "id": "723533d90f6f174ec8131ef1e297eef21484a702",
+    "name": "Dahut",
+    "type": "intermediate"
+  },
+  {
+    "id": "8c68190d9f6769e63f78c39bcb8a72770be02746",
+    "name": "Stade du Taburle",
+    "type": "novice"
+  },
+  {
+    "id": "cdd96becd80cf59e95cf489933998bfe839fa13b",
+    "name": "Le Rifnel",
+    "type": "novice"
+  },
+  {
+    "id": "bc42c9ad0f69d6c69898383cde6f2dda2efd1b77",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "470e098e41f53e2433fe1e4a782e536e7f4699e3",
+    "name": "Signal Bis",
+    "type": "intermediate"
+  },
+  {
+    "id": "16846dc5db4a42069cb9e437f6520b44b35d5556",
+    "name": "Signal",
+    "type": "intermediate"
+  },
+  {
+    "id": "0ceb7f943e38f7ec4fa710b6cd97eb654826fa3c",
+    "name": "Petite Sure",
+    "type": "intermediate"
+  },
+  {
+    "id": "21d40cdc678a9b805e52718973319b0d187eea17",
+    "name": "Léopold",
+    "type": "novice"
+  },
+  {
+    "id": "0bb52eada56e2882b56f734ceee457d3c38a186d",
+    "name": "Villard",
+    "type": "novice"
+  },
+  {
+    "id": "b5030ac1890ea245deb2c18f7e874046412c42b3",
+    "name": "Les Vallons",
+    "type": "easy"
+  },
+  {
+    "id": "d30dfae518a309848f55857d83652262bf9a8d9a",
+    "name": "Lama",
+    "type": "novice"
+  },
+  {
+    "id": "4fe4ef0c07ba61b86bf84d5072bc7ee564c28b05",
+    "name": "Carrelet",
+    "type": "novice"
+  },
+  {
+    "id": "a2e778d3571e28bcc08bc59a9ca280482a3fee6e",
+    "name": "Lutins",
+    "type": "novice"
+  },
+  {
+    "id": "a2366e4c78360338d2d4377e6a29fc9cbd61070d",
+    "name": "Boulevard des Lutins",
+    "type": "easy"
+  },
+  {
+    "id": "6716e7a60cbcc59ba1d5f0d00eb3f0da6cb82a34",
+    "name": "Poutran",
+    "type": "intermediate"
+  },
+  {
+    "id": "b932f8e414d335034589435ef050c2bac99e43eb",
+    "name": "Villard",
+    "type": "easy"
+  },
+  {
+    "id": "450becbc244b45b54b090fddaaadb9929980703a",
+    "name": "Olympique",
+    "type": "intermediate"
+  },
+  {
+    "id": "ba29ca2fb78d52f919ec2b18c98a2ea346459f9f",
+    "name": "Col",
+    "type": "easy"
+  },
+  {
+    "id": "c01425b9e349220aea53c90110e05e02c4f242d9",
+    "name": "Éterlous",
+    "type": "easy"
+  },
+  {
+    "id": "6d15dbae24ebb86f346e36915d98967d967398fd",
+    "name": "Fontfroide",
+    "type": "intermediate"
+  },
+  {
+    "id": "3644f0a69bf50758ed0c47fd178f434fe02a4fb5",
+    "name": "Chalets",
+    "type": "easy"
+  },
+  {
+    "id": "8576be9ee74a9640de63c913b257d72fc4b63e01",
+    "name": "La Fare",
+    "type": "advanced"
+  },
+  {
+    "id": "680f884d5857c4c2fe99e671812183c80d12c667",
+    "name": "Cascade",
+    "type": "easy"
+  },
+  {
+    "id": "a042da5b696deb5fda34a92acdf071fea8637135",
+    "name": "Étourneaux",
+    "type": "easy"
+  },
+  {
+    "id": "69c3a70a8cfc497fab0da71d594a7f28c23619af",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "c71797a2430d27eb0aff2451f08f852b47eb884a",
+    "name": "Les Travers",
+    "type": "easy"
+  },
+  {
+    "id": "3817c07cd2ed3376e785de0b0b3ecf15f7081dff",
+    "name": "Cascade",
+    "type": "easy"
+  },
+  {
+    "id": "0d0e345fd09b7db7e7540f1fa15711f89bd17871",
+    "name": "Myrtilles",
+    "type": "easy"
+  },
+  {
+    "id": "e527a38425ee37c78a87c88923da692e528b2f88",
+    "name": "Canetons",
+    "type": "novice"
+  },
+  {
+    "id": "23dcd8ba3a060363238a6c71c25e27f4a576f93d",
+    "name": "Boucle des Lacs",
+    "type": ""
+  },
+  {
+    "id": "b254f0faabea57a81c4112e276034b96e646f2a5",
+    "name": "Boucle de Poutran",
+    "type": "easy"
+  },
+  {
+    "id": "b71da4bba2ea5168f970e58041b73daa3c2df66b",
+    "name": "Col de Cluy",
+    "type": "advanced"
+  },
+  {
+    "id": "86110673e273c133b0c89850af4e241e417738ee",
+    "name": "Boulevard des Marmottes",
+    "type": "easy"
+  },
+  {
+    "id": "8cd2ad7033d12fb3b095f46b5aa05de81978304a",
+    "name": "Les Bûcherons",
+    "type": "novice"
+  },
+  {
+    "id": "6eb5b0dd2dc388938a9d6d7a2ba7caf0ba8c6bd1",
+    "name": "Col",
+    "type": "easy"
+  },
+  {
+    "id": "68ad17222f1da8b1a4c4280fb5a2641f2108401e",
+    "name": "Les Rhodos",
+    "type": "intermediate"
+  },
+  {
+    "id": "899dfd8788f716ac61c287a77fb409f731f1715f",
+    "name": "Marmottes",
+    "type": "novice"
+  },
+  {
+    "id": "6e3ab51080d025f621377641142e163032449e71",
+    "name": "Crocus",
+    "type": "novice"
+  },
+  {
+    "id": "9bd5eae5efa8a440258d30614be826e2108d9fa1",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "3feedfbe810d969de0105a6782c6bc26dc78d347",
+    "name": "Farcis",
+    "type": "easy"
+  },
+  {
+    "id": "ec4858dc8438028a8c1116d1f7867744cf5fe6e0",
+    "name": "Le Rosai",
+    "type": "intermediate"
+  },
+  {
+    "id": "1fc7d23c8583b30957d7fef833544febd55d5e64",
+    "name": "Gentianes",
+    "type": "easy"
+  },
+  {
+    "id": "198fd9e1a99de019f714531c474b87c9b00a9c26",
+    "name": "Les Gentianes",
+    "type": "easy"
+  },
+  {
+    "id": "f6498c01d482d72093b8d7da31f4fbcf682fee12",
+    "name": "Éterlous",
+    "type": "easy"
+  },
+  {
+    "id": "500b45be24ba5756b1262977c5cd904fc782dd35",
+    "name": "Demoiselles",
+    "type": "easy"
+  },
+  {
+    "id": "add89828da01d34ae8c7477a04481ab6aafcb7d7",
+    "name": "Bergeries",
+    "type": "advanced"
+  },
+  {
+    "id": "3fad5e7369bc1a6d7c6dff2f08d206e265c2146f",
+    "name": "Chez Roger",
+    "type": "novice"
+  },
+  {
+    "id": "cb80827d29ebffddc05e83e3fa594b88bacfbf8a",
+    "name": "Agneaux",
+    "type": "novice"
+  },
+  {
+    "id": "328e2aa0ed22c9be8ba9e7ec78ab1a62558a53a0",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "63c8e12b9019f772c531666bc41df51cc6d2ef53",
+    "name": "Boucle des Lacs",
+    "type": ""
+  },
+  {
+    "id": "fccd0664c07b04d85ff93d1e82342cfb02f6533a",
+    "name": "Léopold",
+    "type": "novice"
+  },
+  {
+    "id": "62d92557b2f80e0aa3fff1600318941350abf18e",
+    "name": "Le Gua",
+    "type": "easy"
+  },
+  {
+    "id": "91330fe5ac3763155f74ebe6b209273597e99437",
+    "name": "Mélèzes",
+    "type": "novice"
+  },
+  {
+    "id": "df0ae0abd64e785b77648d6e10a9966d7cc8e950",
+    "name": "Club Med",
+    "type": "novice"
+  },
+  {
+    "id": "97655c49299638ed4ef8b7f7c154bc4db69a4d46",
+    "name": "Chevreuils",
+    "type": "easy"
+  },
+  {
+    "id": "316f1ab4ef15c9b36854ef216480dbe0889d49e4",
+    "name": "Cristaux",
+    "type": "advanced"
+  },
+  {
+    "id": "605ceee21aef3a1a1bedba125e27963456eb1572",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "167992061ecb3e8f1c6ea82ae2e451df507ef75c",
+    "name": "Combe Charbonnière",
+    "type": "advanced"
+  },
+  {
+    "id": "70080863757307a6d19082c2dfa6952c45c88c24",
+    "name": "Chez Roger",
+    "type": "novice"
+  },
+  {
+    "id": "3f7469846577875caf37f35356ba1579a0a51dee",
+    "name": "Chardons",
+    "type": "novice"
+  },
+  {
+    "id": "fcd3eea2f984b9526faa9025f3b99ee00e9df985",
+    "name": "Chardons",
+    "type": "novice"
+  },
+  {
+    "id": "a4e264d2eea136e14a92e7b40c1b20cc25c6cea0",
+    "name": "Club Med",
+    "type": "novice"
+  },
+  {
+    "id": "1baabafdada083f9b295124960db27f023ff9644",
+    "name": "Mélèzes",
+    "type": "novice"
+  },
+  {
+    "id": "6e631a6cea951329debb27ad8b635da90b02bf2b",
+    "name": "Piste de Bob",
+    "type": "novice"
+  },
+  {
+    "id": "c52b8c6f0c00840ce20c122452d3dc92a0be3eed",
+    "name": "Huez",
+    "type": "intermediate"
+  },
+  {
+    "id": "95c64e0ab21a61845a2748bd9bb5f2c5d38718f9",
+    "name": "Huez",
+    "type": "intermediate"
+  },
+  {
+    "id": "ce2ddc6dc677030d1b8d0ba3f08ac477ec4c8233",
+    "name": "Village",
+    "type": "easy"
+  },
+  {
+    "id": "aa79602e67c75ccad88b22c446a43f0a9aa77ca7",
+    "name": "Mur",
+    "type": "intermediate"
+  },
+  {
+    "id": "cc407d50800d916fda53aeef6be202ed96518a0b",
+    "name": "Altiport",
+    "type": "novice"
+  },
+  {
+    "id": "62ae3ccae11cd2a47a2525ab5cb9f9b4d73ffc2f",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "13e8d531ddbd298f661f0449cacac77fbc94e675",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "5397e2848c955a95c8752a676ab2bcbb3d692d9d",
+    "name": "Skicross",
+    "type": "intermediate"
+  },
+  {
+    "id": "37bfdd8a5d18bd77a4075f173a3624a56b5c047b",
+    "name": "Piégut",
+    "type": ""
+  },
+  {
+    "id": "39c0b171f9503173899ea977f2a8111ebbcc0f87",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ea4ba5667822aa20aa1806be5cf0583e7943cf57",
+    "name": "Chez Roger",
+    "type": "novice"
+  },
+  {
+    "id": "bfd64c9c9a6c8c32036f51ef68fb441c250dfbcf",
+    "name": "Les Clarines",
+    "type": "novice"
+  },
+  {
+    "id": "3547950df30f83b4246b70686cb5ec57d3ac8959",
+    "name": "Les Clarines",
+    "type": "novice"
+  },
+  {
+    "id": "c39adf6c644211aca5ea9096293099b6618c934e",
+    "name": "Cassini",
+    "type": "advanced"
+  },
+  {
+    "id": "9d2c95bc7dd1bf3133abb8acf40aa373d447491c",
+    "name": "Herpie",
+    "type": "easy"
+  },
+  {
+    "id": "a56bf6138c01a7c28af847f8788d18c734dee79e",
+    "name": "Sarenne",
+    "type": "advanced"
+  },
+  {
+    "id": "95013e97645f25283d76085d8e0f387e94d24e11",
+    "name": "Cristalliere",
+    "type": "easy"
+  },
+  {
+    "id": "45da2d5ed94bb97efc9cff75f2f9bc2a25ecadff",
+    "name": "Corniche Variante",
+    "type": "easy"
+  },
+  {
+    "id": "9693d8a20402683a7eb3e469e643ea392fbae015",
+    "name": "Loup Blanc",
+    "type": "novice"
+  },
+  {
+    "id": "c6ef93dab218e242f947ef5514ff125e43450093",
+    "name": "Bergers",
+    "type": "easy"
+  },
+  {
+    "id": "84314d055813d225690f1d59f293c8789b6f7c24",
+    "name": "Retour 1800",
+    "type": "novice"
+  },
+  {
+    "id": "387c6840711f623e42dfcf5d11a83b993f5fbd49",
+    "name": "Les Bergers",
+    "type": "easy"
+  },
+  {
+    "id": "fb77262fd0f19792734374833880629a4cea529b",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "99813de81ae49f0bfbab74f75d1c79050b810f55",
+    "name": "Ancolie",
+    "type": "easy"
+  },
+  {
+    "id": "1e747f28e9dc6bf4815fe4afa6bf85f922b1d90a",
+    "name": "Violettes",
+    "type": "novice"
+  },
+  {
+    "id": "48112d36975c18ee5bbab1c0717780a7f10b3ab5",
+    "name": "Village",
+    "type": "easy"
+  },
+  {
+    "id": "36b70c5cb821cf4de2f187f0be7958ff78621a16",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e628ac5860b64a9a95c8783a477a1d89e74db60e",
+    "name": "Ancolies",
+    "type": "easy"
+  },
+  {
+    "id": "7bb986e064a97146ee8a71f2572af4e6bb82c99a",
+    "name": "Poutat",
+    "type": "intermediate"
+  },
+  {
+    "id": "f306f50dd32311efbff4d2a895a73c2611d090df",
+    "name": "Erables",
+    "type": "novice"
+  },
+  {
+    "id": "02bcec3025e79142d46746ae196acaddf7196092",
+    "name": "La Forêt",
+    "type": "advanced"
+  },
+  {
+    "id": "9d35002aa2b3cc67c0e7db706b0fb0d11a549465",
+    "name": "Cloudit",
+    "type": "novice"
+  },
+  {
+    "id": "a1d1dee547613886847509ca25675f22e9a8eecd",
+    "name": "Brebis",
+    "type": "easy"
+  },
+  {
+    "id": "24314acbac2703931947ff7fb78fa92182be9c0b",
+    "name": "Chevreaux",
+    "type": "novice"
+  },
+  {
+    "id": "b40598c07a24d41fa75751241e63a43f754ba115",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9321d19fcbd3ed56fc7fe983a3134a31f958dc5d",
+    "name": "Cloudit",
+    "type": "novice"
+  },
+  {
+    "id": "e6c71b94d7aa8df6cc2abfe5f1be64df22796075",
+    "name": "Petit Prince",
+    "type": "easy"
+  },
+  {
+    "id": "1bdb29d4a964000455f14a071d58877ddc4eedd8",
+    "name": "Sarenne",
+    "type": "advanced"
+  },
+  {
+    "id": "b1c9c7878352fcfa7e77d249c940227b5ee037db",
+    "name": "Déversoir",
+    "type": "intermediate"
+  },
+  {
+    "id": "759a6f9b6bfad065c3f5907df2198b4960607248",
+    "name": "Lièvre Blanc",
+    "type": "intermediate"
+  },
+  {
+    "id": "c1223ed1e5ff12b87ed0cfb5e517085bb508f4e5",
+    "name": "Boulevard des Lacs",
+    "type": "easy"
+  },
+  {
+    "id": "05b86d34ee26a3107278949f75a560cc7b948551",
+    "name": "Chavannus",
+    "type": "intermediate"
+  },
+  {
+    "id": "e30c7c3da86a08084ed926b1b27ea1132b9e22f1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "63aede8699459ec29b6afde43b9970e775fac215",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ae7423aeb18873abdf4f25d13bce0243a976ed3d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ec48020772ac62d1cd7bbe288fb226cf1c6b7ce8",
+    "name": "Boulevard des Marmottes",
+    "type": "easy"
+  },
+  {
+    "id": "157fbacf98111834f2656c8afaa1cf5f76b0a20f",
+    "name": "Olympique",
+    "type": "intermediate"
+  },
+  {
+    "id": "b883c0e1c167e8fe8f6c8b17bb146d0f0a368fb8",
+    "name": "Olympique",
+    "type": "intermediate"
+  },
+  {
+    "id": "e147e8a3edf807e0b4245b6553083acf85b8a7f6",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f4e691b7fe7105bcc86f3f046399eabac029d2f9",
+    "name": "Babars",
+    "type": "novice"
+  },
+  {
+    "id": "409f5e2e9e09882a58c74c3e2eba84e20e849744",
+    "name": "Chardons",
+    "type": "novice"
+  },
+  {
+    "id": "e19c9113c7ed4a463e1eb07f7fcc21d967e8f9b1",
+    "name": "Snowpark des Sagnes",
+    "type": "novice"
+  },
+  {
+    "id": "f95e17e2dc12b3d67eaa86ad53a268a8bf40fe1f",
+    "name": "Grenouilles",
+    "type": "novice"
+  },
+  {
+    "id": "ba1bbe9c7d125327d96ee06367448d3b21bca3ce",
+    "name": "Stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "589bf44a27d63872c917d94af78a9d12701e329d",
+    "name": "L'Estacade",
+    "type": "novice"
+  },
+  {
+    "id": "a9f91d878cd2dae1a755b0e2b6cd02722527c319",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e371385f7f9050e93f788126a608af5b63980f75",
+    "name": "Lys",
+    "type": "easy"
+  },
+  {
+    "id": "029a8ffcfc7ec7b77a05c3eb49002a6a73bcf2c3",
+    "name": "Pré-rond",
+    "type": "easy"
+  },
+  {
+    "id": "c417f3ffe2339d1ff3c9bc40d5da5212abd3df91",
+    "name": "Sarenne",
+    "type": "advanced"
+  },
+  {
+    "id": "d8ddae50d8817ea6c0e23a4a0f08d71cac59feca",
+    "name": "Sarenne",
+    "type": "advanced"
+  },
+  {
+    "id": "ef894af3d37c697d03ecff11aa9558558324450c",
+    "name": "Le Lac Blanc",
+    "type": "novice"
+  },
+  {
+    "id": "b291b4b04ef7627d10c1a68849cce7b4bb6d5f58",
+    "name": "Retour 1800",
+    "type": "novice"
+  },
+  {
+    "id": "2d86f23084257846481d05f5604b9fab3989470c",
+    "name": "Chamois",
+    "type": "intermediate"
+  },
+  {
+    "id": "54c0e5bb5ed5048ca557f5434207eb36f6547a77",
+    "name": "Chamois",
+    "type": "intermediate"
+  },
+  {
+    "id": "e79bbfdbb94f9999b513af759b4057249f3cf66e",
+    "name": "Glacier",
+    "type": "advanced"
+  },
+  {
+    "id": "cca296b62d70347fb2d1c58eab8e4af14867c2f0",
+    "name": "Herpie",
+    "type": "easy"
+  },
+  {
+    "id": "bffbce07cabcd09100e1f67f62424b802a6f4afb",
+    "name": "Herpie",
+    "type": "easy"
+  },
+  {
+    "id": "cbed772deb4bd671a33c87d40a7154f9f8fc79c1",
+    "name": "Les Bergers",
+    "type": "novice"
+  },
+  {
+    "id": "ea922b1c0eef6792a444cedc90ccf08565677837",
+    "name": "Les Clarines",
+    "type": "novice"
+  },
+  {
+    "id": "b5545d51db4b87eca333133fdbc4175e38077d69",
+    "name": "Olympique",
+    "type": "intermediate"
+  },
+  {
+    "id": "b25ec19d1bb460746335b922231c7de46362ccb4",
+    "name": "Farcis",
+    "type": "easy"
+  },
+  {
+    "id": "12ef8d58c2aa3d7acdcb45ab1bc1b8097d301ef7",
+    "name": "Les Rhodos",
+    "type": "intermediate"
+  },
+  {
+    "id": "2f3906e2cc5ab36f4e4a7c767e09de98710c17aa",
+    "name": "Les Rhodos",
+    "type": "intermediate"
+  },
+  {
+    "id": "7c84e977d64390ad62da6576859bf8b721ed4fc0",
+    "name": "Les Rhodos",
+    "type": "intermediate"
+  },
+  {
+    "id": "aff1cc2a00da5010192c26ba14670b0910658135",
+    "name": "Les Rhodos",
+    "type": "intermediate"
+  },
+  {
+    "id": "b408ad1e9586ae62b560478add6d1204089180d8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "4a74aed462b193bc82d48260a686ca3743e78b20",
+    "name": "École",
+    "type": "novice"
+  },
+  {
+    "id": "e3142faf6c52f331243ead8a97b1af06d5cd04f1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e1c15e684ae4608d39e0ec98a9c3ddd61020cc5f",
+    "name": "Clos du Pré",
+    "type": "novice"
+  },
+  {
+    "id": "fb072ed05aef3a44f1b6bf96c57466161c3fc014",
+    "name": "Couloir",
+    "type": "easy"
+  },
+  {
+    "id": "92eaedefc78f51249a75fdbb07c62b149c66984f",
+    "name": "Agneaux",
+    "type": "novice"
+  },
+  {
+    "id": "76f5b81b81e6a031e1f35470c3c4547235315ab2",
+    "name": "Cristaux",
+    "type": "advanced"
+  },
+  {
+    "id": "c50547e23014c171299d964d8638c8ad560b0f25",
+    "name": "Tunnel",
+    "type": "advanced"
+  },
+  {
+    "id": "322c11a8fb26aff19e2d258280c0d98baeb31d79",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d11859d558b58a3a592afe43c20f42b9d23c9f03",
+    "name": "Herpie",
+    "type": "easy"
+  },
+  {
+    "id": "efa53b96e359f4f309060e528cea2096dca21c81",
+    "name": "Le Gua",
+    "type": "easy"
+  },
+  {
+    "id": "0b21af20ca4a18117cb2cc390115577466dea831",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "6f851fb76da480fa60b41cb19be3f4c370853dfc",
+    "name": "Canetons",
+    "type": "novice"
+  },
+  {
+    "id": "91557b25cadf8efdbc7dca4fd7c745d03957f8eb",
+    "name": "Canetons, L'Olmet",
+    "type": "novice"
+  },
+  {
+    "id": "04cf886256f0ed3578b741da00b0cd151bc46c52",
+    "name": "Canetons",
+    "type": "novice"
+  },
+  {
+    "id": "301bff9570b1586fc0593f2f869d6f1f3c771fa9",
+    "name": "Cannetons",
+    "type": "novice"
+  },
+  {
+    "id": "cfd16d5137f5a4bb3a02de6a7e733f433a077f32",
+    "name": "Érables",
+    "type": "novice"
+  },
+  {
+    "id": "ade67e2a20cb646cd1baebc237807d644d8ffeb1",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "b252ce58ecd1efe65643aa31d74a06d30c2f0a25",
+    "name": "Marcel’s Farm",
+    "type": "novice"
+  },
+  {
+    "id": "92aa606d5323d8d68e8607cb5fe6efc84e2025c0",
+    "name": "Boucle des lacs",
+    "type": ""
+  },
+  {
+    "id": "c1a9dc90f80e14add540a930749c5caf3e6bc379",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "2d0c2edba80f995f9e0db6c24993ecfe8eac560b",
+    "name": "Huez",
+    "type": "intermediate"
+  },
+  {
+    "id": "7f7a147f8c992de47bb30d082fe04ad6c6149b8c",
+    "name": "Éclose",
+    "type": "novice"
+  },
+  {
+    "id": "1d50d418dbeeeb9f71c20336473f16c78c141b00",
+    "name": "Vaujaniate",
+    "type": "intermediate"
+  },
+  {
+    "id": "12f630b4016ddd813772d89f9ce0dc667db1518d",
+    "name": "Roche Noire",
+    "type": "advanced"
+  },
+  {
+    "id": "608eb8309e3379c20f4cbadc356796b70ba006c3",
+    "name": "Herpie",
+    "type": "easy"
+  },
+  {
+    "id": "311f99ffb9e6be277b984b565b24a7898ae9f360",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "bd5295e0cc20c51ab681c1a1cae61eac080a21d2",
+    "name": "Le Dôme",
+    "type": "intermediate"
+  },
+  {
+    "id": "c572965c400c499a6099a4f9799cab43af12c737",
+    "name": "Edelweiss",
+    "type": "easy"
+  },
+  {
+    "id": "a358594f4e5124346a8e45a3e0c35af2cbff026e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "72895ab7a8dd8f5531f6cd2ca4b30aa70b6babd9",
+    "name": "Villard",
+    "type": "easy"
+  },
+  {
+    "id": "3b27de7fe235b9b9f8c5cd32dfc7fad35809ab0d",
+    "name": "Les Demoiselles",
+    "type": "novice"
+  },
+  {
+    "id": "fa9a9887055fd654197df148d3815528faeb34e8",
+    "name": "Escapade",
+    "type": "intermediate"
+  },
+  {
+    "id": "db58da96fcf739a349b25a3f6982934fd930e7ca",
+    "name": "Chemin des Demoiselles",
+    "type": "novice"
+  },
+  {
+    "id": "8414cf86c1bec3a179b4cf377f3a8f5d034c33f5",
+    "name": "Les Demoiselles",
+    "type": "novice"
+  },
+  {
+    "id": "db1a24e2d94a7ce31be0b2c3bf1f6c0d53cc7806",
+    "name": "Tunnel",
+    "type": "advanced"
+  },
+  {
+    "id": "731322dcf9b4f29f54846ef69ce0f27ec7acfb36",
+    "name": "Le Gua",
+    "type": "easy"
+  },
+  {
+    "id": "aa30a41b1e3fcbffa660b1bbcf94dd2504361771",
+    "name": "Le Gua",
+    "type": "easy"
+  },
+  {
+    "id": "e5753e71cd4b3663dae4f77d08171e6798d327e3",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "2838e80c90b49bdf57d94bef6723e66996f3500a",
+    "name": "Route des Lacs",
+    "type": ""
+  },
+  {
+    "id": "d9835e4ef1a4475efc98d86ad636b23469ea6012",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "eaaca911c6b20736b36358c581e5cc8265ade828",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "357f94e7cad5d3ccb777937db204ddde4d7890bc",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "d1c1e05528f8aa0dd582bff90b6bfea9b2e7b9f6",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "87377d89b407f75e083cbba777c6c7b996af7534",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "a172f16294bca75eb05086db546bd4dfe0d59465",
+    "name": "Boucle des lacs",
+    "type": ""
+  },
+  {
+    "id": "1f2a16710acf335b4a8ed8e19e42f70d14025351",
+    "name": "Route des Lacs",
+    "type": ""
+  },
+  {
+    "id": "237a006cdbaafdbae87b80a87eb09180a0990594",
+    "name": "Boucle des lacs",
+    "type": ""
+  },
+  {
+    "id": "a05f85a90bf672a90d8724e93b4ecd3650f9f6e6",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "2d7e8200a7da5e63ce35e7e6a05e576fe464d20a",
+    "name": "Les Lacs",
+    "type": ""
+  },
+  {
+    "id": "eaaf98f700a4e944ef4f8354ccadf84a614825b2",
+    "name": "Boucle rochette",
+    "type": ""
+  },
+  {
+    "id": "c9980f44bd8e7c9c17c3885872f5a3974c8748f7",
+    "name": "La Fare",
+    "type": "advanced"
+  },
+  {
+    "id": "eb2c5bfff68bc79b84be9ad987f9cbdd976ac744",
+    "name": "Crocus",
+    "type": "novice"
+  },
+  {
+    "id": "b346d252430de8e473c83eea016c5bddac9eab95",
+    "name": "Vaujaniate",
+    "type": "intermediate"
+  },
+  {
+    "id": "8543a83f6b142e5ed1461b19112237f1580017e9",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "92309be80c8a120624f9fe671f619968d8ed98e9",
+    "name": "Stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "03e0a36fd3b929293240dbe164fcb5aa8c5f39d5",
+    "name": "Tunnel",
+    "type": "advanced"
+  },
+  {
+    "id": "963ed3e06f2ee9ef87e264dc4a615c7734848808",
+    "name": "Tunnel",
+    "type": "advanced"
+  },
+  {
+    "id": "217e1763d8d659ff4f3a690a47cb087cf6666ad3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "cc88a3c80ea03fc897d885adc6cb7370164f493e",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "d3605addcf93ad901c3a3035639308b9974f1285",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8fa599cee01b61765029bae0e73bbf020bd4821c",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "cc5dee7ac20777eb1e2958826e8c0bf7503cec16",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "e6be1c31d918ef3cabcd6bdfce52bc830d927f1d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1c49fc598805a102bd1dc636276e8a03bc7fa7c9",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "2dcba7e6b364533955a348fabce3b249a453d382",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "aecb82d00e8a2b78bbc6de4dbe3797d72d84a718",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ebbe8dacfa6c0d1afdb202f3d88ff1ad5f6e3238",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7dd92e46ce866f9deed1525598e5e0ad4e523e0a",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f9529091bfbbc7567cc69d6e6c0370f26e2fa9c1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "f4413a29ec6a3744d7e139a79a864142bf5a0ec4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "9a9681e50f645490c7b80761170f10938b9e6586",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "0bc663f8b8d92edcf4cd1fad798af5b8693ac7c1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "92d80d767cfe9d42f065360b43db57f769dcaba4",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "fd2968ddc3787747948858493bdff03b736a834d",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "458599cace4ae5290418a3fcfe3e62aa557c05eb",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "81217213f9fd17ace53827e151b50eb263f39a1f",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ace3cf608a291118ad6752cd6b9e8c6dd88727c9",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "2e09c9a0989d2ef1a0644cc4a52600c9a54bf775",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "6435d3fbc0e280d186046d991a142605009244d7",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "04fe9ea8e22b419170c0e9d30e32deca2e4add4d",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "ba2a35e001cd6e32bd3f75e86b5dc05cfcd8e6fb",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "37cf7e34311243780e7b74f3d996b54411a8041a",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "b6697c059a8b24e74928b1fd42c07f107e887788",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e56e56acf46ae953cedb89834ded8033f328e3a2",
+    "name": "Chemin de l'Orgière",
+    "type": "easy"
+  },
+  {
+    "id": "27771eb5df4bb9c17ee080dedbda73248c4d78ff",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "ef79350d58ecf81260f1f8b16c6ff0a1db1d014d",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "b02d7918bf883c10074ffc2ecbe758b1b57e5798",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "0d792d93493354cc61f2d6abb76b6cd5827a3014",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "c4f2f43848dd9275450e78bbb7b9032f4bbc1dc3",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "e07385f3010e1f78ea40f28651254676cb9b4fbf",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9e880207c2fff8ab9f958d88ebdf0296c2a235d2",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "f2763b8075cb70a4858dcfe89d65c4b656858e47",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "e027f4980711556a1af7d2eabe7fa264818e4a1b",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "b81e84e6f6d507663b0a584a63553f3db9726b73",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "fb3e9c932f9f8f5ba19e0bcccdaaf02342c89e43",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "efeaa9bfce4855bdbeeb19cdb866298a4d397599",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "4d20db3c175e5f20f350e86dab49adc892ab33f8",
+    "name": "Tunnel",
+    "type": "advanced"
+  },
+  {
+    "id": "d46823bdd2cf30f114f37d1cd4e1e8cc832d0aed",
+    "name": "Retour residence Ecrins d'Auris",
+    "type": ""
+  },
+  {
+    "id": "e21beebd962a0e7227fd6eb4bb52fc0450bb27f5",
+    "name": "Stade Désiré Lacroix",
+    "type": "intermediate"
+  },
+  {
+    "id": "8084d9b3b5230310b77b65de75fc9a8ac3a0cd11",
+    "name": "Stade Désiré Lacroix",
+    "type": "intermediate"
+  },
+  {
+    "id": "4aec2a8ff9f8dcbb33af1a341998e52ac21e9940",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "1ee6de90b9a2dbbcce8e4dbfa469a29e9597f5ab",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "925311d8bc8f356350eb5f64b74500ad4bb406c3",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "b4711ae02fe714b089ac56421320a6c38e127a76",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "09e4853a776429b80d171adead862e0d4c881c25",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "1edb7e601b9ae9cae2b9ac298114f8b9fa19f580",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "83fd5b26ac149ec2c47eadcfa158c1c506a21ce4",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "e40e85b56136839cccde1ceb2d99df1073096fef",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "26b4c4e38d33d68164b30b5cac99555820077dad",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "33af4b958a63e6101f7c749ba7b83d375fe21e92",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "98509d6fcbe58e7a3f51a54059694fd2d8a53d8b",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7c1cf440ca958edfc5a277eaeae37966295040cd",
+    "name": "Escargot",
+    "type": "novice"
+  },
+  {
+    "id": "fbb46a421d0ba759746f5300b7694df539f061ed",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "a0db4f3044fe1dbe1fa1c853d60a689cceb18857",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "8b7245919022dcf8e181236eaadce701c3bfbbc4",
+    "name": "Pré-rond",
+    "type": "easy"
+  },
+  {
+    "id": "5f7b06e4734c54874413303b455b45dfc3570bcb",
+    "name": "Couloir",
+    "type": "easy"
+  },
+  {
+    "id": "2da6d51fb7677f5203851ba57603c4d87c3e5b95",
+    "name": "Boarder Cross",
+    "type": "easy"
+  },
+  {
+    "id": "866a0ad2e200186e30510123e2610d4d6363d4e1",
+    "name": "Boarder Cross",
+    "type": "easy"
+  },
+  {
+    "id": "3bc255d030736679c54d9e742919619ecf75bd75",
+    "name": "Eteaux",
+    "type": "easy"
+  },
+  {
+    "id": "711f2b2c4c9f9f54b21585e4153d36967ac90944",
+    "name": "Les Dolines",
+    "type": "novice"
+  },
+  {
+    "id": "b40ce2c7408ce48ba8703237a685d8126211cc79",
+    "name": "Ecureuils",
+    "type": "easy"
+  },
+  {
+    "id": "74814c055f48fadebfa98d2b8487c4c0325c690d",
+    "name": "Stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "188aa6e0f28b64ba15b8f2c22d418e5b4f5ab377",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "c5ebf87303a2353f422a8f18bb34eeaee7b38f71",
+    "name": "stade",
+    "type": "intermediate"
+  },
+  {
+    "id": "d7891cdff57ce61824e552b675822db5de0bcb69",
+    "name": "Snowpark Montfrais",
+    "type": ""
+  },
+  {
+    "id": "00d139980e126e12fefc4796e076051ebabb7967",
+    "name": "Snowpark Montfrais",
+    "type": ""
+  },
+  {
+    "id": "2a44d527a0d80dadd377427b3fa324f2b95c3cb6",
+    "name": "Retour TC Alpette",
+    "type": "easy"
+  },
+  {
+    "id": "a8081ab333dd2601ccd89f8bc1b46ecef3996ccf",
+    "name": "Variante Poutran",
+    "type": "easy"
+  },
+  {
+    "id": "8597b551ae01bcc2692ffab3ace03f3bfad231c5",
+    "name": "Chamois",
+    "type": "intermediate"
+  },
+  {
+    "id": "21fef21cb3c4b993a424919d925d20195c577cc9",
+    "name": "Agneaux",
+    "type": "easy"
+  },
+  {
+    "id": "647080c35100bcc8b9265b3d46539173845baca1",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "13a950b5955c5662c53caa336e005de51dfa4bd1",
+    "name": "Moutons",
+    "type": "novice"
+  },
+  {
+    "id": "ca6122f85437b7f30d2cca04da300d0c82c15b46",
+    "name": "Altiport",
+    "type": "intermediate"
+  },
+  {
+    "id": "75db7ae37db2a8424ee797a3cb53a34c97fc1c86",
+    "name": "Retour Club Med",
+    "type": "novice"
+  },
+  {
+    "id": "0ee59a51125a507a8ec7947ac4edae3cb4fab0ce",
+    "name": "Chez Roger",
+    "type": "novice"
+  },
+  {
+    "id": "7806bbf6b785c6424ad5c019c0c3fe62594dfe7e",
+    "name": "Babars",
+    "type": "novice"
+  },
+  {
+    "id": "2332b02fa28af74273167477ccd1f24e1339309d",
+    "name": "Alouette",
+    "type": "novice"
+  },
+  {
+    "id": "761b80077c9fba9f1eea16a9802dd218c0a6913a",
+    "name": "Petite Sure",
+    "type": "intermediate"
+  },
+  {
+    "id": "083dc2595256b83364bae3ee6265b21860f266e2",
+    "name": "La Forêt",
+    "type": "advanced"
+  },
+  {
+    "id": "5c0eb3db078099edbe88e5c96ffa8cc566e96a70",
+    "name": "Les Sagnes",
+    "type": "novice"
+  },
+  {
+    "id": "d50fed063f513886d4ac33db549995e8d20a0b52",
+    "name": "La Mine",
+    "type": "intermediate"
+  },
+  {
+    "id": "5a22c4f8d8e1afe79ab719ab8d6cea136064539d",
+    "name": "Halfpipe de Marcel",
+    "type": "novice"
+  },
+  {
+    "id": "b790b092097471bd8c1ce360743cfa529f56ba54",
+    "name": "Tunnel de Marcel",
+    "type": "novice"
+  },
+  {
+    "id": "0402eb7fe94fd069b710677ba8b5b8542e6528d9",
+    "name": "Tunnel de Marcel",
+    "type": "novice"
+  },
+  {
+    "id": "c3fb3297e4ff87b883a9e57e81dd04f3151a6f02",
+    "name": "Snowpark de Marcel",
+    "type": "novice"
+  },
+  {
+    "id": "a3c54a50c2f68a9f74699fabb3401ff0b1417f63",
+    "name": "Erables",
+    "type": "novice"
+  },
+  {
+    "id": "65070218e5ca51c85ab2117e7cf1399e2446a5a4",
+    "name": "Cloudit",
+    "type": "novice"
+  },
+  {
+    "id": "4cfd148a8191e4be136baa8c8466e7b9c01c33f7",
+    "name": "Mur",
+    "type": "intermediate"
+  },
+  {
+    "id": "ee1f940ff228f72c6d40f3d57cad7320a5340816",
+    "name": "Villard",
+    "type": "easy"
+  },
+  {
+    "id": "d8a78e6b7dcda0c928b05fb7ce7def77ddf40422",
+    "name": "Les Bûcherons",
+    "type": "novice"
+  },
+  {
+    "id": "baeb7f91ecee152a205edeb8dd157c6848a8c7ce",
+    "name": "Le Rosai",
+    "type": "intermediate"
+  },
+  {
+    "id": "09c7fb04175863a98f590cf13d0e9529142fa8c5",
+    "name": "Anémones",
+    "type": "intermediate"
+  },
+  {
+    "id": "ae2b49e9abe04e8a17cabe142def96f2c32c01a1",
+    "name": "Anémones",
+    "type": "intermediate"
+  },
+  {
+    "id": "fafa5b216c9da1a54b8bee9d96ff3522bc1ad6e8",
+    "name": "La Fare",
+    "type": "advanced"
+  },
+  {
+    "id": "144b8cfc9497a196a41dcfff3cbecd7f6850a869",
+    "name": "Le Gua",
+    "type": "easy"
+  },
+  {
+    "id": "a8ebd0797dd65019c3eea14d42bdd77509583a83",
+    "name": "Chez Roger",
+    "type": "novice"
+  },
+  {
+    "id": "874f524c6524b368e4f665de5eb2e67a1aae99f6",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "fee76e0472e0935d99a3a8044450aa999d9a56b4",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "e36601867ede96074946f7b880bc484c18117abb",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "d100825ec459b8382b08adc691ea3f6b0f2670f1",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "a0a47a4cf8018ae66b55b5d6518e35195b5eeec8",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "7e6a1476410c22220925288257a90a4216bc22b3",
+    "name": "",
+    "type": "novice"
+  },
+  {
+    "id": "048895a7bc2df59fb5cb32263d56b7d59dff965c",
+    "name": "Le Dôme",
+    "type": "intermediate"
+  },
+  {
+    "id": "4373b86f8990ddfca5102a7ed37344671092b4ea",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "65a3e144fdf98e0549d451c6867fea421af0f313",
+    "name": "",
+    "type": "advanced"
+  },
+  {
+    "id": "97e6928e93c9c902f00b0386dde292b668f62916",
+    "name": "",
+    "type": ""
+  },
+  {
+    "id": "f9749304600d0b7bbe69d623436c2644ae11b867",
+    "name": "",
+    "type": "intermediate"
+  },
+  {
+    "id": "dafb4f271301d46850219f800baa92d271788606",
+    "name": "",
+    "type": "easy"
+  },
+  {
+    "id": "9a4bcc344b33626cdf5aa68d6e3f1a7780672775",
+    "name": "",
+    "type": "novice"
+  }
+]

--- a/lumiplan-maps/package-lock.json
+++ b/lumiplan-maps/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "lumiplan-ski-data",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lumiplan-ski-data",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "fuse.js": "^7.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/lumiplan-maps/package.json
+++ b/lumiplan-maps/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "lumiplan-ski-data",
+  "version": "1.0.0",
+  "description": "Fetch ski resort lift and run data from Lumiplan interactive maps",
+  "main": "src/index.js",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "test": "node src/test.js",
+    "fetch": "node src/cli.js",
+    "generate-data": "node src/generate-osm-data.js"
+  },
+  "keywords": [
+    "ski",
+    "resort",
+    "lumiplan",
+    "lifts",
+    "runs",
+    "pistes"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "fuse.js": "^7.0.0"
+  }
+}

--- a/lumiplan-maps/src/cli.js
+++ b/lumiplan-maps/src/cli.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * CLI tool for fetching Lumiplan ski data
+ *
+ * Usage:
+ *   node src/cli.js <map-id> [options]
+ *
+ * Examples:
+ *   node src/cli.js tignes-valdisere
+ *   node src/cli.js paradiski --lifts-only
+ *   node src/cli.js les-3-vallees --summary
+ */
+
+import { getSkiAreaData, getLiftStatus, getRunStatus, getAvailableMaps, LUMIPLAN_MAPS } from './index.js';
+
+const args = process.argv.slice(2);
+
+// Show help
+if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+  console.log(`
+Lumiplan Ski Data CLI
+
+Usage:
+  node src/cli.js <map-id> [options]
+
+Available Maps:
+${Object.entries(LUMIPLAN_MAPS).map(([id, config]) => `  ${id.padEnd(20)} ${config.displayName}`).join('\n')}
+
+Options:
+  --summary       Show summary only (lift/run counts)
+  --lifts-only    Show only lift data
+  --runs-only     Show only run data
+  --json          Output as JSON
+  --help, -h      Show this help
+
+Examples:
+  node src/cli.js tignes-valdisere
+  node src/cli.js paradiski --summary
+  node src/cli.js les-3-vallees --json
+`);
+  process.exit(0);
+}
+
+const mapId = args[0];
+const showSummary = args.includes('--summary');
+const liftsOnly = args.includes('--lifts-only');
+const runsOnly = args.includes('--runs-only');
+const jsonOutput = args.includes('--json');
+
+async function main() {
+  try {
+    if (!LUMIPLAN_MAPS[mapId]) {
+      console.error(`Error: Unknown map ID '${mapId}'`);
+      console.error('Available maps:', Object.keys(LUMIPLAN_MAPS).join(', '));
+      process.exit(1);
+    }
+
+    console.error(`Fetching data for ${LUMIPLAN_MAPS[mapId].displayName}...`);
+
+    if (showSummary) {
+      const [liftStatus, runStatus] = await Promise.all([
+        getLiftStatus(mapId),
+        getRunStatus(mapId)
+      ]);
+
+      if (jsonOutput) {
+        console.log(JSON.stringify({ lifts: liftStatus, runs: runStatus }, null, 2));
+      } else {
+        console.log('\n=== Lift Status ===');
+        console.log(`Total: ${liftStatus.total}`);
+        console.log(`Open: ${liftStatus.open} (${liftStatus.openPercentage}%)`);
+        console.log(`Closed: ${liftStatus.closed}`);
+        console.log(`Scheduled: ${liftStatus.scheduled}`);
+
+        console.log('\n=== Run Status ===');
+        console.log(`Total: ${runStatus.total}`);
+        console.log(`Open: ${runStatus.open} (${runStatus.openPercentage}%)`);
+        console.log('\nBy Difficulty:');
+        for (const [diff, counts] of Object.entries(runStatus.byDifficulty)) {
+          const pct = counts.total > 0 ? Math.round((counts.open / counts.total) * 100) : 0;
+          console.log(`  ${diff}: ${counts.open}/${counts.total} (${pct}%)`);
+        }
+      }
+    } else {
+      const data = await getSkiAreaData(mapId, { matchOsm: true });
+
+      if (jsonOutput) {
+        if (liftsOnly) {
+          console.log(JSON.stringify(data.lifts, null, 2));
+        } else if (runsOnly) {
+          console.log(JSON.stringify(data.runs, null, 2));
+        } else {
+          console.log(JSON.stringify(data, null, 2));
+        }
+      } else {
+        if (!runsOnly) {
+          console.log('\n=== Lifts ===');
+          console.log(`Total: ${data.lifts.length}`);
+          console.log('');
+          for (const lift of data.lifts.slice(0, 20)) {
+            const osmInfo = lift.osmMatch ? ` [OSM: ${lift.osmMatch.osmId.slice(0, 8)}...]` : '';
+            console.log(`  [${(lift.status || 'unknown').padEnd(10)}] ${lift.name}${osmInfo}`);
+          }
+          if (data.lifts.length > 20) {
+            console.log(`  ... and ${data.lifts.length - 20} more`);
+          }
+        }
+
+        if (!liftsOnly) {
+          console.log('\n=== Runs ===');
+          console.log(`Total: ${data.runs.length}`);
+          console.log('');
+          for (const run of data.runs.slice(0, 20)) {
+            const osmInfo = run.osmMatch ? ` [OSM: ${run.osmMatch.osmId.slice(0, 8)}...]` : '';
+            const diff = run.difficulty ? `(${run.difficulty})` : '';
+            console.log(`  [${(run.status || 'unknown').padEnd(10)}] ${run.name} ${diff}${osmInfo}`);
+          }
+          if (data.runs.length > 20) {
+            console.log(`  ... and ${data.runs.length - 20} more`);
+          }
+        }
+
+        console.log('\n=== Metadata ===');
+        console.log(`Fetched at: ${data.metadata.fetchedAt}`);
+        console.log(`Language: ${data.metadata.language}`);
+      }
+    }
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/lumiplan-maps/src/config.js
+++ b/lumiplan-maps/src/config.js
@@ -1,0 +1,117 @@
+/**
+ * Lumiplan Interactive Map Configuration
+ * Maps Lumiplan map names to their UUIDs and OpenSkiMap resort IDs
+ */
+
+export const LUMIPLAN_MAPS = {
+  'tignes-valdisere': {
+    mapName: 'Tignes_ValdIsere',
+    uuid: '84a526a4-c935-455e-a9c5-037061d75ba4',
+    displayName: 'Tignes - Val d\'Isère (Espace Killy)',
+    // OpenSkiMap ski area IDs for resorts within this domain
+    openSkiMapIds: ['6ed5f25f0eb3e366ee2e0e667d998c0bf551225f'],
+    // Lumiplan internal resort IDs mapped to names
+    lumiplanResorts: {
+      '653': 'Tignes',
+      '664': 'Val d\'Isère'
+    }
+  },
+
+  'paradiski': {
+    mapName: 'Paradiski',
+    uuid: 'e6302a83-ce5b-4717-bab8-4f282b1083d7',
+    displayName: 'Paradiski (Les Arcs, La Plagne, Peisey-Vallandry)',
+    openSkiMapIds: [
+      'dec537b602584db89d89ab114a619f1ae356398e', // Les Arcs
+      'f47f7e05cc676b25b6a00f77f0b86a897f03018c'  // La Plagne
+    ],
+    lumiplanResorts: {
+      '520': 'Les Arcs',
+      '497': 'La Plagne',
+      '515': 'Peisey-Vallandry'
+    }
+  },
+
+  'les-3-vallees': {
+    mapName: 'les-3-vallees',
+    uuid: 'bd632c91-6957-494d-95a8-6a72eb87e341',
+    displayName: 'Les 3 Vallées',
+    openSkiMapIds: [
+      '3ab7375c4734163405f0f77a7c5a6afdfd600b73', // Val Thorens - Orelle
+      '68b126bc3175516c9263aed7635d14e37ff360dc'  // Les Trois Vallées
+    ],
+    lumiplanResorts: {
+      '815': 'Méribel-Mottaret',
+      '833': 'Courchevel',
+      '848': 'Val Thorens',
+      '859': 'Orelle',
+      '863': 'Méribel-Alpina',
+      '874': 'Les Menuires'
+    }
+  },
+
+  'aussois': {
+    mapName: 'Aussois',
+    uuid: 'e68b5cdd-02c4-43f9-b75f-2c679445b626',
+    displayName: 'Aussois',
+    openSkiMapIds: ['a0ffbaaaf9807c58da7fecab4df2617502f1d584'],
+    lumiplanResorts: {
+      '274': 'Aussois'
+    }
+  },
+
+  'orcieres': {
+    mapName: 'Orcieres',
+    uuid: '6789b50e-22ec-4f68-b3ad-73f047c3cfdd',
+    displayName: 'Orcières Merlette 1850',
+    openSkiMapIds: ['824c7b22068010ed9590671f95a41f7eaf5f3819'],
+    lumiplanResorts: {
+      '335': 'Orcières 1850'
+    }
+  },
+
+  'vaujany': {
+    mapName: 'Vaujany',
+    uuid: 'c3a3e312-e191-436b-aefb-abf54eaa0b04',
+    displayName: 'Alpe d\'Huez Grand Domaine (Vaujany, Oz)',
+    openSkiMapIds: ['721dd142d0af653027c7569e1bd0799586bdefa1'],
+    lumiplanResorts: {
+      '601': 'Oz-Vaujany',
+      '610': 'Alpe d\'Huez'
+    }
+  }
+};
+
+// Base URL for Lumiplan API
+export const LUMIPLAN_API_BASE = 'https://lumiplay.link/interactive-map-services/public/map';
+
+// Lift type mappings from Lumiplan to standardized types
+export const LIFT_TYPE_MAP = {
+  'SURFACE_LIFT': 'drag_lift',
+  'CHAIRLIFT': 'chair_lift',
+  'DETACHABLE_CHAIRLIFT': 'chair_lift',
+  'GONDOLA': 'gondola',
+  'CABLE_CAR': 'cable_car',
+  'FUNICULAR': 'funicular',
+  'MAGIC_CARPET': 'magic_carpet',
+  'PLATTER': 'platter',
+  'T_BAR': 't-bar',
+  'ROPE_TOW': 'rope_tow'
+};
+
+// Trail difficulty mappings from Lumiplan to standardized
+export const TRAIL_DIFFICULTY_MAP = {
+  'GREEN': 'novice',
+  'BLUE': 'easy',
+  'RED': 'intermediate',
+  'BLACK': 'advanced',
+  'DOUBLE_BLACK': 'expert'
+};
+
+// Opening status mappings
+export const OPENING_STATUS_MAP = {
+  'OPEN': 'open',
+  'CLOSED': 'closed',
+  'FORECAST': 'scheduled',
+  'UNKNOWN': 'unknown'
+};

--- a/lumiplan-maps/src/fetcher.js
+++ b/lumiplan-maps/src/fetcher.js
@@ -1,0 +1,192 @@
+/**
+ * Lumiplan Data Fetcher
+ * Fetches and merges static and dynamic POI data from Lumiplan API
+ */
+
+import { LUMIPLAN_API_BASE, LIFT_TYPE_MAP, TRAIL_DIFFICULTY_MAP, OPENING_STATUS_MAP } from './config.js';
+
+/**
+ * Fetch static POI data for a map
+ * @param {string} uuid - Lumiplan map UUID
+ * @param {string} lang - Language code (default: 'en')
+ * @returns {Promise<Object>} Static POI data
+ */
+export async function fetchStaticData(uuid, lang = 'en') {
+  const url = `${LUMIPLAN_API_BASE}/${uuid}/staticPoiData?lang=${lang}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch static data: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch dynamic POI data for a map
+ * @param {string} uuid - Lumiplan map UUID
+ * @param {string} lang - Language code (default: 'en')
+ * @returns {Promise<Object>} Dynamic POI data
+ */
+export async function fetchDynamicData(uuid, lang = 'en') {
+  const url = `${LUMIPLAN_API_BASE}/${uuid}/dynamicPoiData?lang=${lang}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch dynamic data: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch map metadata
+ * @param {string} mapName - Lumiplan map name
+ * @returns {Promise<Object>} Map metadata
+ */
+export async function fetchMapMetadata(mapName) {
+  const url = `${LUMIPLAN_API_BASE}/name/${mapName}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch map metadata: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Extract lifts from static data
+ * @param {Object} staticData - Raw static POI data
+ * @returns {Map<number, Object>} Map of lift ID to lift data
+ */
+export function extractLifts(staticData) {
+  const lifts = new Map();
+
+  for (const item of staticData.items || []) {
+    if (item.data?.type === 'LIFT') {
+      const lift = {
+        id: item.data.id,
+        name: item.data.name,
+        type: LIFT_TYPE_MAP[item.data.liftType] || item.data.liftType?.toLowerCase(),
+        liftType: item.data.liftType,
+        capacity: item.data.capacity,
+        duration: item.data.duration,
+        length: item.data.length,
+        uphillCapacity: item.data.uphillCapacity,
+        arrivalAltitude: item.data.arrivalAltitude,
+        departureAltitude: item.data.departureAltitude,
+        openingTimes: item.data.openingTimesTheoretic,
+        coordinates: { x: item.x, y: item.y }
+      };
+      lifts.set(item.data.id, lift);
+    }
+  }
+
+  return lifts;
+}
+
+/**
+ * Extract runs/trails from static data
+ * @param {Object} staticData - Raw static POI data
+ * @returns {Map<number, Object>} Map of trail ID to trail data
+ */
+export function extractRuns(staticData) {
+  const runs = new Map();
+
+  for (const item of staticData.items || []) {
+    if (item.data?.type === 'TRAIL') {
+      const run = {
+        id: item.data.id,
+        name: item.data.name,
+        type: item.data.trailType?.toLowerCase(),
+        difficulty: TRAIL_DIFFICULTY_MAP[item.data.trailLevel] || item.data.trailLevel?.toLowerCase(),
+        trailLevel: item.data.trailLevel,
+        length: item.data.length,
+        surface: item.data.surface,
+        arrivalAltitude: item.data.arrivalAltitude,
+        departureAltitude: item.data.departureAltitude,
+        guaranteedSnow: item.data.guaranteedSnow,
+        openingTimes: item.data.openingTimesTheoretic,
+        coordinates: { x: item.x, y: item.y }
+      };
+      runs.set(item.data.id, run);
+    }
+  }
+
+  return runs;
+}
+
+/**
+ * Merge dynamic status data into items
+ * @param {Map<number, Object>} items - Static items (lifts or runs)
+ * @param {Array<Object>} dynamicItems - Dynamic status items
+ * @returns {Map<number, Object>} Items with status merged
+ */
+export function mergeDynamicData(items, dynamicItems) {
+  const statusMap = new Map();
+
+  for (const dynItem of dynamicItems) {
+    statusMap.set(dynItem.id, dynItem);
+  }
+
+  for (const [id, item] of items) {
+    const status = statusMap.get(id);
+    if (status) {
+      item.status = OPENING_STATUS_MAP[status.openingStatus] || status.openingStatus?.toLowerCase();
+      item.openingStatus = status.openingStatus;
+      item.operating = status.operating;
+      item.message = status.message?.content;
+
+      // Run-specific status fields
+      if (status.groomingStatus) {
+        item.groomingStatus = status.groomingStatus;
+      }
+      if (status.snowQuality) {
+        item.snowQuality = status.snowQuality;
+      }
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Fetch and merge all data for a Lumiplan map
+ * @param {string} uuid - Lumiplan map UUID
+ * @param {string} lang - Language code
+ * @returns {Promise<Object>} Complete ski area data with lifts and runs
+ */
+export async function fetchAndMergeData(uuid, lang = 'en') {
+  // Fetch both datasets in parallel
+  const [staticData, dynamicData] = await Promise.all([
+    fetchStaticData(uuid, lang),
+    fetchDynamicData(uuid, lang)
+  ]);
+
+  // Extract items
+  const lifts = extractLifts(staticData);
+  const runs = extractRuns(staticData);
+
+  // Merge dynamic status
+  const dynamicItems = dynamicData.items || [];
+  mergeDynamicData(lifts, dynamicItems);
+  mergeDynamicData(runs, dynamicItems);
+
+  // Get totals from dynamic data
+  const totals = dynamicData.totals || [];
+
+  // Get resort info
+  const resorts = staticData.resorts || [];
+
+  return {
+    lifts: Array.from(lifts.values()),
+    runs: Array.from(runs.values()),
+    resorts,
+    totals,
+    metadata: {
+      fetchedAt: new Date().toISOString(),
+      language: lang
+    }
+  };
+}

--- a/lumiplan-maps/src/generate-osm-data.js
+++ b/lumiplan-maps/src/generate-osm-data.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Generate precomputed OpenSkiMap data files for each Lumiplan map
+ *
+ * This script reads the main ski-lift-status CSV files and extracts
+ * the relevant lifts and runs for each configured Lumiplan map.
+ *
+ * Run this once to generate the data files, then they can be used
+ * for offline matching.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { LUMIPLAN_MAPS } from './config.js';
+import { parseOpenSkiMapCSV } from './matcher.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const skiLiftStatusRoot = join(projectRoot, '..');
+
+const LIFTS_CSV = join(skiLiftStatusRoot, 'data', 'lifts.csv');
+const RUNS_CSV = join(skiLiftStatusRoot, 'data', 'runs.csv');
+const DATA_DIR = join(projectRoot, 'data');
+
+function loadCSV(path) {
+  if (!existsSync(path)) {
+    console.warn(`Warning: ${path} not found`);
+    return '';
+  }
+  return readFileSync(path, 'utf-8');
+}
+
+function generateOsmData() {
+  console.log('Generating OpenSkiMap data files...\n');
+
+  // Load CSV data
+  console.log('Loading CSV files...');
+  const liftsCSV = loadCSV(LIFTS_CSV);
+  const runsCSV = loadCSV(RUNS_CSV);
+
+  if (!liftsCSV && !runsCSV) {
+    console.error('No CSV data found. Make sure the ski-lift-status data files exist.');
+    process.exit(1);
+  }
+
+  // Process each map
+  for (const [mapId, config] of Object.entries(LUMIPLAN_MAPS)) {
+    console.log(`\nProcessing ${mapId}...`);
+    console.log(`  OpenSkiMap IDs: ${config.openSkiMapIds.join(', ')}`);
+
+    // Extract lifts
+    const lifts = parseOpenSkiMapCSV(liftsCSV, config.openSkiMapIds);
+    console.log(`  Found ${lifts.length} lifts`);
+
+    // Extract runs
+    const runs = parseOpenSkiMapCSV(runsCSV, config.openSkiMapIds);
+    console.log(`  Found ${runs.length} runs`);
+
+    // Write data files
+    const liftsPath = join(DATA_DIR, `${mapId}-lifts.json`);
+    const runsPath = join(DATA_DIR, `${mapId}-runs.json`);
+
+    writeFileSync(liftsPath, JSON.stringify(lifts, null, 2));
+    writeFileSync(runsPath, JSON.stringify(runs, null, 2));
+
+    console.log(`  Wrote ${liftsPath}`);
+    console.log(`  Wrote ${runsPath}`);
+  }
+
+  console.log('\nDone!');
+}
+
+generateOsmData();

--- a/lumiplan-maps/src/index.js
+++ b/lumiplan-maps/src/index.js
@@ -1,0 +1,190 @@
+/**
+ * Lumiplan Ski Data
+ *
+ * A module for fetching real-time ski resort lift and run data from
+ * Lumiplan interactive maps, with fuzzy matching to OpenSkiMap IDs.
+ *
+ * @example
+ * import { getSkiAreaData, LUMIPLAN_MAPS } from 'lumiplan-ski-data';
+ *
+ * // Get data for Tignes - Val d'Isère
+ * const data = await getSkiAreaData('tignes-valdisere');
+ * console.log(data.lifts); // Array of lifts with status
+ * console.log(data.runs);  // Array of runs with status
+ */
+
+import { LUMIPLAN_MAPS, LUMIPLAN_API_BASE } from './config.js';
+import { fetchAndMergeData, fetchStaticData, fetchDynamicData } from './fetcher.js';
+import { matchAllItems, parseOpenSkiMapCSV, normalizeName } from './matcher.js';
+import { readFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// Re-export configuration
+export { LUMIPLAN_MAPS, LUMIPLAN_API_BASE };
+export { normalizeName } from './matcher.js';
+
+// Get the directory of this module
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Load precomputed OpenSkiMap data for a Lumiplan map
+ * @param {string} mapId - Lumiplan map ID (e.g., 'tignes-valdisere')
+ * @returns {Object} Object with lifts and runs arrays
+ */
+function loadOsmData(mapId) {
+  const dataDir = join(__dirname, '..', 'data');
+  const liftsPath = join(dataDir, `${mapId}-lifts.json`);
+  const runsPath = join(dataDir, `${mapId}-runs.json`);
+
+  let lifts = [];
+  let runs = [];
+
+  if (existsSync(liftsPath)) {
+    lifts = JSON.parse(readFileSync(liftsPath, 'utf-8'));
+  }
+
+  if (existsSync(runsPath)) {
+    runs = JSON.parse(readFileSync(runsPath, 'utf-8'));
+  }
+
+  return { lifts, runs };
+}
+
+/**
+ * Get ski area data with real-time status
+ *
+ * @param {string} mapId - Lumiplan map ID (e.g., 'tignes-valdisere', 'paradiski')
+ * @param {Object} options - Options
+ * @param {string} options.lang - Language code (default: 'en')
+ * @param {boolean} options.matchOsm - Whether to match with OpenSkiMap data (default: true)
+ * @returns {Promise<Object>} Ski area data with lifts, runs, and metadata
+ *
+ * @example
+ * const data = await getSkiAreaData('tignes-valdisere');
+ *
+ * // Each lift has:
+ * // - id, name, type, status, openingStatus, operating
+ * // - capacity, duration, length, arrivalAltitude, departureAltitude
+ * // - osmMatch (if matchOsm is true): { osmId, osmName, score, confidence }
+ *
+ * // Each run has:
+ * // - id, name, type, difficulty, status, openingStatus
+ * // - length, surface, groomingStatus, snowQuality
+ * // - osmMatch (if matchOsm is true): { osmId, osmName, score, confidence }
+ */
+export async function getSkiAreaData(mapId, options = {}) {
+  const { lang = 'en', matchOsm = true } = options;
+
+  const mapConfig = LUMIPLAN_MAPS[mapId];
+  if (!mapConfig) {
+    const availableMaps = Object.keys(LUMIPLAN_MAPS).join(', ');
+    throw new Error(`Unknown map ID: ${mapId}. Available maps: ${availableMaps}`);
+  }
+
+  // Fetch and merge Lumiplan data
+  const data = await fetchAndMergeData(mapConfig.uuid, lang);
+
+  // Match with OpenSkiMap data if requested and available
+  if (matchOsm) {
+    const osmData = loadOsmData(mapId);
+
+    if (osmData.lifts.length > 0) {
+      data.lifts = matchAllItems(data.lifts, osmData.lifts);
+    }
+
+    if (osmData.runs.length > 0) {
+      data.runs = matchAllItems(data.runs, osmData.runs);
+    }
+  }
+
+  // Add map configuration to metadata
+  data.metadata.mapId = mapId;
+  data.metadata.mapName = mapConfig.mapName;
+  data.metadata.displayName = mapConfig.displayName;
+  data.metadata.uuid = mapConfig.uuid;
+  data.metadata.openSkiMapIds = mapConfig.openSkiMapIds;
+
+  return data;
+}
+
+/**
+ * Get list of available Lumiplan maps
+ * @returns {Array<Object>} Array of map info objects
+ */
+export function getAvailableMaps() {
+  return Object.entries(LUMIPLAN_MAPS).map(([id, config]) => ({
+    id,
+    name: config.mapName,
+    displayName: config.displayName,
+    openSkiMapIds: config.openSkiMapIds
+  }));
+}
+
+/**
+ * Get lift status summary for a ski area
+ * @param {string} mapId - Lumiplan map ID
+ * @returns {Promise<Object>} Summary with counts and percentages
+ */
+export async function getLiftStatus(mapId) {
+  const data = await getSkiAreaData(mapId, { matchOsm: false });
+
+  const total = data.lifts.length;
+  const open = data.lifts.filter(l => l.status === 'open').length;
+  const closed = data.lifts.filter(l => l.status === 'closed').length;
+  const scheduled = data.lifts.filter(l => l.status === 'scheduled').length;
+
+  return {
+    total,
+    open,
+    closed,
+    scheduled,
+    openPercentage: total > 0 ? Math.round((open / total) * 100) : 0,
+    lifts: data.lifts.map(l => ({
+      name: l.name,
+      type: l.type,
+      status: l.status
+    }))
+  };
+}
+
+/**
+ * Get run status summary for a ski area
+ * @param {string} mapId - Lumiplan map ID
+ * @returns {Promise<Object>} Summary with counts by difficulty
+ */
+export async function getRunStatus(mapId) {
+  const data = await getSkiAreaData(mapId, { matchOsm: false });
+
+  const byDifficulty = {};
+  for (const run of data.runs) {
+    const diff = run.difficulty || 'unknown';
+    if (!byDifficulty[diff]) {
+      byDifficulty[diff] = { total: 0, open: 0 };
+    }
+    byDifficulty[diff].total++;
+    if (run.status === 'open') {
+      byDifficulty[diff].open++;
+    }
+  }
+
+  const total = data.runs.length;
+  const open = data.runs.filter(r => r.status === 'open').length;
+
+  return {
+    total,
+    open,
+    openPercentage: total > 0 ? Math.round((open / total) * 100) : 0,
+    byDifficulty,
+    runs: data.runs.map(r => ({
+      name: r.name,
+      difficulty: r.difficulty,
+      status: r.status,
+      groomingStatus: r.groomingStatus
+    }))
+  };
+}
+
+// Export fetcher functions for advanced usage
+export { fetchStaticData, fetchDynamicData, fetchAndMergeData } from './fetcher.js';
+export { matchAllItems, parseOpenSkiMapCSV, createMatcher } from './matcher.js';

--- a/lumiplan-maps/src/matcher.js
+++ b/lumiplan-maps/src/matcher.js
@@ -1,0 +1,173 @@
+/**
+ * Fuzzy Matcher for OpenSkiMap IDs
+ * Matches Lumiplan lift/run names to OpenSkiMap data using fuzzy matching
+ */
+
+import Fuse from 'fuse.js';
+
+/**
+ * Normalize a name for better matching
+ * @param {string} name - Original name
+ * @returns {string} Normalized name
+ */
+export function normalizeName(name) {
+  if (!name) return '';
+
+  return name
+    .toLowerCase()
+    // Remove common prefixes
+    .replace(/^(ts|tsd|tc|tcd|tk|tm|tf|tp|cab|fun|tel)\s+/i, '')
+    .replace(/^(télésiège|téléski|télécabine|téléphérique|funiculaire)\s+/i, '')
+    .replace(/^(chairlift|gondola|cable car|funicular|drag lift|t-bar|platter)\s+/i, '')
+    // Normalize accents
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    // Remove special characters
+    .replace(/['-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Create a Fuse.js instance for matching
+ * @param {Array<Object>} items - Items to search (must have 'name' and 'id' fields)
+ * @returns {Fuse} Fuse.js instance
+ */
+export function createMatcher(items) {
+  // Pre-process items with normalized names
+  const processedItems = items.map(item => ({
+    ...item,
+    normalizedName: normalizeName(item.name)
+  }));
+
+  return new Fuse(processedItems, {
+    keys: ['name', 'normalizedName'],
+    threshold: 0.4,
+    distance: 100,
+    includeScore: true,
+    ignoreLocation: true
+  });
+}
+
+/**
+ * Find the best match for a Lumiplan item
+ * @param {Fuse} matcher - Fuse.js instance
+ * @param {string} name - Name to match
+ * @returns {Object|null} Best match with score, or null if no good match
+ */
+export function findBestMatch(matcher, name) {
+  if (!name) return null;
+
+  const normalizedQuery = normalizeName(name);
+  const results = matcher.search(normalizedQuery);
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  const best = results[0];
+
+  // Only accept matches with a reasonable score
+  if (best.score > 0.5) {
+    return null;
+  }
+
+  return {
+    osmId: best.item.id,
+    osmName: best.item.name,
+    score: best.score,
+    confidence: best.score < 0.1 ? 'high' : best.score < 0.3 ? 'medium' : 'low'
+  };
+}
+
+/**
+ * Match all Lumiplan items to OpenSkiMap data
+ * @param {Array<Object>} lumiplanItems - Lumiplan lifts or runs
+ * @param {Array<Object>} osmItems - OpenSkiMap items
+ * @returns {Array<Object>} Items with osmMatch field added
+ */
+export function matchAllItems(lumiplanItems, osmItems) {
+  if (!osmItems || osmItems.length === 0) {
+    return lumiplanItems;
+  }
+
+  const matcher = createMatcher(osmItems);
+
+  return lumiplanItems.map(item => {
+    const match = findBestMatch(matcher, item.name);
+    return {
+      ...item,
+      osmMatch: match
+    };
+  });
+}
+
+/**
+ * Load OpenSkiMap data from CSV
+ * This is a simple parser for the ski-lift-status CSV format
+ * @param {string} csvContent - CSV file content
+ * @param {Array<string>} skiAreaIds - OpenSkiMap ski area IDs to filter by
+ * @returns {Array<Object>} Parsed items
+ */
+export function parseOpenSkiMapCSV(csvContent, skiAreaIds = []) {
+  const lines = csvContent.split('\n');
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split(',');
+  const items = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    // Simple CSV parsing (doesn't handle escaped quotes properly for complex cases)
+    const values = parseCSVLine(line);
+    if (values.length !== headers.length) continue;
+
+    const item = {};
+    headers.forEach((header, idx) => {
+      item[header.trim()] = values[idx];
+    });
+
+    // Filter by ski area IDs if provided
+    if (skiAreaIds.length > 0) {
+      const itemAreaIds = (item.ski_area_ids || '').split(';');
+      const hasMatch = itemAreaIds.some(id => skiAreaIds.includes(id));
+      if (!hasMatch) continue;
+    }
+
+    items.push({
+      id: item.id,
+      name: item.name,
+      type: item.lift_type || item.run_type || item.difficulty
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Parse a CSV line handling quoted values
+ * @param {string} line - CSV line
+ * @returns {Array<string>} Parsed values
+ */
+function parseCSVLine(line) {
+  const values = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === ',' && !inQuotes) {
+      values.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  values.push(current);
+
+  return values;
+}

--- a/lumiplan-maps/src/test.js
+++ b/lumiplan-maps/src/test.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for Lumiplan Ski Data
+ * Runs basic tests to verify the module is working correctly
+ */
+
+import { getSkiAreaData, getLiftStatus, getRunStatus, getAvailableMaps, LUMIPLAN_MAPS } from './index.js';
+import { normalizeName } from './matcher.js';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`✗ ${name}`);
+    console.log(`  Error: ${error.message}`);
+    failed++;
+  }
+}
+
+async function testAsync(name, fn) {
+  try {
+    await fn();
+    console.log(`✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`✗ ${name}`);
+    console.log(`  Error: ${error.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}
+
+async function runTests() {
+  console.log('Running Lumiplan Ski Data Tests\n');
+  console.log('=================================\n');
+
+  // Test configuration
+  console.log('Configuration Tests:');
+  test('LUMIPLAN_MAPS should have entries', () => {
+    assert(Object.keys(LUMIPLAN_MAPS).length > 0, 'No maps configured');
+  });
+
+  test('getAvailableMaps should return array', () => {
+    const maps = getAvailableMaps();
+    assert(Array.isArray(maps), 'Should return array');
+    assert(maps.length > 0, 'Should have maps');
+    assert(maps[0].id, 'Maps should have id');
+    assert(maps[0].displayName, 'Maps should have displayName');
+  });
+
+  // Test name normalization
+  console.log('\nName Normalization Tests:');
+  test('normalizeName removes prefixes', () => {
+    assert(normalizeName('TS des Almes') === 'des almes' || normalizeName('TS des Almes') === 'almes', 'Should remove TS prefix');
+    assert(normalizeName('TSD MADELEINE') === 'madeleine', 'Should remove TSD prefix');
+  });
+
+  test('normalizeName handles accents', () => {
+    assert(normalizeName('Méribel') === 'meribel', 'Should normalize accents');
+  });
+
+  // Test API fetching
+  console.log('\nAPI Tests (Tignes-ValdIsere):');
+  await testAsync('getSkiAreaData should fetch data', async () => {
+    const data = await getSkiAreaData('tignes-valdisere', { matchOsm: false });
+    assert(data, 'Should return data');
+    assert(Array.isArray(data.lifts), 'Should have lifts array');
+    assert(Array.isArray(data.runs), 'Should have runs array');
+    assert(data.lifts.length > 0, 'Should have some lifts');
+    assert(data.runs.length > 0, 'Should have some runs');
+    console.log(`    Found ${data.lifts.length} lifts and ${data.runs.length} runs`);
+  });
+
+  await testAsync('Lifts should have required fields', async () => {
+    const data = await getSkiAreaData('tignes-valdisere', { matchOsm: false });
+    const lift = data.lifts[0];
+    assert(lift.id, 'Lift should have id');
+    assert(lift.name, 'Lift should have name');
+    assert(lift.type || lift.liftType, 'Lift should have type');
+    assert('status' in lift || 'openingStatus' in lift, 'Lift should have status');
+  });
+
+  await testAsync('Runs should have required fields', async () => {
+    const data = await getSkiAreaData('tignes-valdisere', { matchOsm: false });
+    const run = data.runs[0];
+    assert(run.id, 'Run should have id');
+    assert(run.name, 'Run should have name');
+    assert(run.difficulty || run.trailLevel, 'Run should have difficulty');
+  });
+
+  await testAsync('getLiftStatus should return summary', async () => {
+    const status = await getLiftStatus('tignes-valdisere');
+    assert(typeof status.total === 'number', 'Should have total');
+    assert(typeof status.open === 'number', 'Should have open count');
+    assert(typeof status.openPercentage === 'number', 'Should have percentage');
+    console.log(`    Lifts: ${status.open}/${status.total} open (${status.openPercentage}%)`);
+  });
+
+  await testAsync('getRunStatus should return summary', async () => {
+    const status = await getRunStatus('tignes-valdisere');
+    assert(typeof status.total === 'number', 'Should have total');
+    assert(typeof status.open === 'number', 'Should have open count');
+    assert(status.byDifficulty, 'Should have byDifficulty');
+    console.log(`    Runs: ${status.open}/${status.total} open (${status.openPercentage}%)`);
+  });
+
+  // Test other maps
+  console.log('\nOther Maps Tests:');
+  const otherMaps = ['paradiski', 'les-3-vallees', 'aussois'];
+  for (const mapId of otherMaps) {
+    await testAsync(`${mapId} should fetch data`, async () => {
+      const data = await getSkiAreaData(mapId, { matchOsm: false });
+      assert(data.lifts.length > 0, 'Should have lifts');
+      assert(data.runs.length > 0, 'Should have runs');
+      console.log(`    Found ${data.lifts.length} lifts and ${data.runs.length} runs`);
+    });
+  }
+
+  // Summary
+  console.log('\n=================================');
+  console.log(`Tests: ${passed} passed, ${failed} failed`);
+  console.log('=================================\n');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+runTests().catch(error => {
+  console.error('Test runner failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
This isolated module fetches lift and run data from Lumiplan interactive maps and matches them to OpenSkiMap IDs using fuzzy name matching.

Features:
- Support for 6 resorts: Tignes-ValdIsere, Paradiski, Les 3 Vallées, Aussois, Orcières, and Vaujany (Alpe d'Huez)
- Static and dynamic POI data fetching from Lumiplan API
- Fuzzy matching of lift/run names to OpenSkiMap data using Fuse.js
- Pre-generated OpenSkiMap reference data for all resorts
- CLI tool for command-line usage
- Designed for npm module publishing